### PR TITLE
Add issue source to squad team context

### DIFF
--- a/.squad/team.md
+++ b/.squad/team.md
@@ -39,3 +39,10 @@
 - **Owner:** shane
 - **Universe:** Seinfeld
 - **Created:** 2026-04-04
+
+## Issue Source
+
+- **Provider:** GitHub
+- **Repository:** `sfalik/Precept`
+- **Connected:** 2026-04-05T19:00:10Z
+- **Filters:** Open issues and open pull requests


### PR DESCRIPTION
Adds the GitHub issue-source metadata to .squad/team.md so the squad roster carries the connected repository context alongside the team definition.