### PR TITLE
Backlog grooming: keyword-symbol framework, #22 data-only precepts research, wave milestones

### DIFF
--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -46,6 +46,8 @@ These principles have driven every syntax and semantics decision:
 
 12. **AI is a first-class consumer.** The DSL is readable by humans and writable by hand, but its properties are chosen to make AI authoring reliable. Deterministic semantics (no hidden state, no side effects) mean an AI can reason about outcomes. Keyword-anchored flat statements mean an AI can parse and generate without tracking indentation context. Structured tool APIs (MCP) return typed JSON that an AI can validate, audit, and iterate against without human feedback. The language reference itself is queryable as data (`precept_language`), so the AI never relies on training-data recall for syntax. The intended workflow: a domain expert describes intent, the AI authors the precept, and the toolchain closes the correctness loop.
 
+13. **Keywords for domain, symbols for math.** Precept uses English keywords for domain concepts, structural anchors, actions, and logical operators (`and`, `or`, `not`). Symbols are reserved for universal mathematical notation (`+`, `-`, `==`, `!=`) and the one structural exception `->`. This line is drawn deliberately — see the [Keyword vs Symbol Design Framework](#keyword-vs-symbol-design-framework-locked).
+
 ## Non-Goals
 
 - Perfect parity with the current DSL syntax.
@@ -87,6 +89,68 @@ in Open, InProgress, Blocked assert Assignee != null because "Must have an assig
 # any — expands to all declared states
 from any assert AuditLog.count > 0 because "Must have audit trail to leave any state"
 ```
+
+---
+## Keyword vs Symbol Design Framework (Locked)
+
+Precept sits between Python and SQL on the keyword-symbol spectrum — keyword-dominant for structure and domain concepts, symbolic only for universal mathematical notation. This is not an inherited default from a host language; it is a deliberate position grounded in Precept's multi-audience design.
+
+### The spectrum
+
+```
+APL → Haskell → C → Rust → C# → TypeScript → Python → PRECEPT → SQL → COBOL → Gherkin
+                          ←— more symbolic              more keyword —→
+```
+
+More keyword-dominant than C#/TypeScript, but without the verbosity of COBOL or Gherkin. Principle #3 (minimal ceremony) prevents keyword bloat — `and` is 3 characters, not `PERFORM VARYING`.
+
+### Where the line is drawn
+
+**Structure and domain concepts use keywords.** Precept's architecture depends on keyword anchoring — the Superpower parser, IntelliSense completions, and semantic tokens all use keywords as parse points. Every statement starts with a recognizable keyword (`field`, `state`, `from`, `on`, `set`, `transition`). Domain-semantic operators like `contains` are keywords, not symbols. Every comparable external DSL with non-programmer audiences (Cedar, Drools, Gherkin) draws this same line.
+
+**Mathematical and comparison operators use symbols.** Arithmetic (`+`, `-`, `*`, `/`, `%`) and comparisons (`==`, `!=`, `>`, `<`, `>=`, `<=`) are universal mathematical notation. These symbols are learned once and recognized instantly by all audiences. Nobody benefits from spelling out `plus` or `greater than or equal to`.
+
+**Logical operators use keywords.** `and`, `or`, `not` — not `&&`, `||`, `!`. This is the one category where languages fundamentally disagree (Python and SQL use keywords; C# and Java use symbols), and Precept sides with keywords for three reasons:
+
+1. **Audience.** Precept's primary readers include domain experts validating business rules. `when not IsPremium and Score >= 680` reads as English that a business analyst can verify. `when !IsPremium && Score >= 680` reads as code that requires developer training.
+2. **Internal consistency.** `contains` is already a keyword operator. `and`, `or`, `not` as keywords unify all domain-semantic operators under one form.
+3. **The asymmetry with `!=` is natural, not problematic.** Unary negation (`not X`) and binary comparison (`X != Y`) are cognitively distinct — different operations, different arity, different linguistic roles. Every keyword-for-logic system (SQL, Python, Alloy, DMN) retains `!=` as a symbol without creating pressure to replace it. 50+ years of SQL and 33+ years of Python confirm: keyword `not` coexists with symbolic `!=` without confusion. Languages that went fully symbolic (APL) excluded non-programmer audiences. Languages that went fully keyword (COBOL) created verbosity. The keyword-for-logic, symbol-for-math split is the proven balance.
+
+**`->` is the exception — a structural symbol.** The arrow is the one structural symbol in Precept. It is justified by Principle #11: `→` is universal notation in state machines and formal logic, it creates clear visual separation between context and action, and every keyword alternative is weaker (`then` is taken by `if...then...else`; `do` sounds imperative, not declarative). The arrow's visual distinctness — a sigil that the eye tracks differently from keywords — makes it a stronger separator than any word.
+
+### Decision matrix for new syntax
+
+| Category | Rule | Examples |
+|----------|------|----------|
+| **Structural anchors** (start-of-statement, delimiters) | ALWAYS keywords | `field`, `state`, `from`, `on`, `set`, `transition` |
+| **Domain concepts** (ubiquitous language) | ALWAYS keywords | `invariant`, `assert`, `because`, `contains` |
+| **Logical operators** (boolean connectives) | Keywords | `and`, `or`, `not` |
+| **Math/comparison operators** | Symbols | `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `>`, `<`, `>=`, `<=` |
+| **Structural separators** | Symbols only if universally understood | `->` (state machine notation), `.` (member access) |
+| **Punctuation/grouping** | Symbols | `(`, `)`, `[`, `]`, `,`, `"`, `#` |
+
+**Tiebreaker:** Default to keyword. Symbols require memorized association; keywords are self-documenting. Only use a symbol when universal notation makes it more recognizable than any keyword alternative.
+
+### Current balance
+
+| Category | Count | Form |
+|----------|-------|------|
+| Keywords | ~50 | Structure, domain concepts, actions, types, logical operators |
+| Symbols | ~23 | Math, comparison, assignment, `->`, punctuation |
+| Ratio | ~2 : 1 | Keyword-dominant by design |
+
+### Logical operator migration (Implementation Pending — [#31](https://github.com/sfalik/Precept/issues/31))
+
+The following changes are decided but not yet implemented:
+
+| Current (symbolic) | Target (keyword) | Status |
+|-------------------|-----------------|--------|
+| `!` (unary NOT) | `not` | Pending — [#31](https://github.com/sfalik/Precept/issues/31) |
+| `&&` (logical AND) | `and` | Pending — [#31](https://github.com/sfalik/Precept/issues/31) |
+| `\\|\\|` (logical OR) | `or` | Pending — [#31](https://github.com/sfalik/Precept/issues/31) |
+| `!=` (inequality) | `!=` (no change) | Stays as-is |
+
+Until implementation, the runtime accepts `!`, `&&`, `||`. After implementation, the runtime will accept `not`, `and`, `or` as keywords, and `!`, `&&`, `||` will be removed.
 
 ---
 ## File Structure (Locked)
@@ -288,6 +352,8 @@ Full reserved keyword list:
 `set`, `add`, `remove`, `enqueue`, `dequeue`, `push`, `pop`, `clear`, `into`,
 `transition`, `no`, `reject`,
 `string`, `number`, `boolean`, `true`, `false`, `null`, `contains`
+
+**Pending additions ([#31](https://github.com/sfalik/Precept/issues/31)):** `and`, `or`, `not` — replacing symbolic `&&`, `||`, `!` for logical operators. See [Keyword vs Symbol Design Framework](#keyword-vs-symbol-design-framework-locked).
 
 ### Dual-use: `set`
 
@@ -760,8 +826,8 @@ on Cancel assert reason != "" because "Cancel requires a reason"
 The expression language supports:
 
 - arithmetic: `+`, `-`, `*`, `/`, `%`
-- unary: `-` (numeric negation), `!` (logical not)
-- logical: `&&`, `||`
+- unary: `-` (numeric negation), `!` (logical not) — **pending migration to `not` keyword per [#31](https://github.com/sfalik/Precept/issues/31)**
+- logical: `&&`, `||` — **pending migration to `and`, `or` keywords per [#31](https://github.com/sfalik/Precept/issues/31)**
 - comparisons: `==`, `!=`, `>`, `>=`, `<`, `<=`
 - membership: `contains`
 - parentheses
@@ -773,6 +839,8 @@ Collection accessor members carried forward conceptually:
 - `.peek` (queue/stack)
 
 Exact operator precedence and literal forms should align with the runtime expression parser.
+
+See [Keyword vs Symbol Design Framework](#keyword-vs-symbol-design-framework-locked) for the rationale behind using keywords for logical operators and symbols for math/comparison.
 
 ---
 

--- a/docs/research/language/README.md
+++ b/docs/research/language/README.md
@@ -36,6 +36,7 @@ This folder now follows a strict split:
 | `#17` | Computed / derived fields | `expressiveness/expression-language-audit.md`, `references/expression-evaluation.md` |
 | `#18` | Conditional outcome in `->` chain (rejected) | `expressiveness/linq.md`, `expressiveness/expression-language-audit.md` |
 | `#25` | Type system expansion (choice and date types) | `references/type-system-survey.md`, `expressiveness/expression-language-audit.md` |
+| `#22` | Data-only precepts (stateless domain definitions) | `expressiveness/data-only-precepts-research.md` |
 | `#31` | Replace `!` with `not` keyword for logical negation | `expressiveness/conditional-logic-strategy.md`, `references/conditional-invariant-survey.md` |
 
 ## Rule of engagement

--- a/docs/research/language/expressiveness/conditional-logic-strategy.md
+++ b/docs/research/language/expressiveness/conditional-logic-strategy.md
@@ -142,5 +142,16 @@ The design doc (around line 226) contains a `when` vs `if` comparison table show
 | #12 | Declined — semantic dual-meaning of `else` | Closed |
 | #14 | `when` guards on invariants and edit declarations | Open — proposal revised, `unless` dropped |
 | #25 | Choice type eliminates boolean negation at modeling level | Open |
-| #31 | Replace `!` with `not` keyword (language-wide) | Open — split from #14 |
+| #31 | Replace all symbolic logical operators with keywords (`and`, `or`, `not`) | Open — expanded from `not`-only to full logical operator migration |
 | #8 | Named rules — future composability for grouped constraints | Open |
+
+## Keyword vs Symbol Decision (April 6, 2026)
+
+The `not` keyword decision expanded into a broader design question: where should Precept draw the line between keywords and symbols across the entire language?
+
+Research across the keyword-symbol spectrum (APL through COBOL), cognitive readability studies, DSL design literature (Fowler), and a full inventory of Precept's 47 keywords / 26 symbols led to a settled framework now captured in `docs/PreceptLanguageDesign.md` § Keyword vs Symbol Design Framework (Locked):
+
+- **Keywords** for structure, domain concepts, and logical operators (`and`, `or`, `not`)
+- **Symbols** for math/comparison (`+`, `-`, `==`, `!=`) and the one structural exception `->` (universal state machine notation, defended by Principle #11)
+
+#31 was expanded from `not`-only to cover all three logical operators (`&&` → `and`, `||` → `or`, `!` → `not`). `!=` stays as a symbol — unary negation and binary comparison are different operator families, and every keyword-for-logic system (SQL, Python, Alloy, DMN) retains `!=` without issue.

--- a/docs/research/language/expressiveness/data-only-precepts-research.md
+++ b/docs/research/language/expressiveness/data-only-precepts-research.md
@@ -1,0 +1,95 @@
+# Data-Only Precepts: Research & Rationale
+
+Research grounding for [#22 — Data-only precepts](https://github.com/sfalik/Precept/issues/22).
+
+## The Mixed-Tooling Problem
+
+Precept's original design required every precept to have a state machine. This means entities without workflow needs (reference data, configuration, simple domain objects) must be modeled in a separate tool (Zod, FluentValidation, JSON Schema). For domains where some entities have workflows and others don't, this creates:
+
+- Two languages, two runtimes, two mental models
+- No single source of truth for the domain
+- Adoption barrier: users evaluate Precept for their complex entities, then realize they need a second tool for everything else
+
+This problem was identified by Shane during backlog grooming (April 7, 2026).
+
+## Precedent Survey
+
+### DSL Precedents for Optional Complexity
+
+| System | Simple Form | Complex Form | Optional? |
+|--------|-------------|--------------|-----------|
+| **Terraform** | Data sources (read-only) | Resources + lifecycle | Yes — coexist in same config |
+| **Protobuf** | Message definitions (pure data) | Message + external behavior | Yes — same language |
+| **GraphQL** | Queries (read schema) | Mutations/subscriptions | Yes — optional |
+| **SQL DDL** | Table + CHECK constraints | Triggers, stored procedures | Yes — same DDL |
+| **DDD** | Value objects (no identity) | Entities (identity + behavior) | Yes — same bounded context |
+
+**Key finding:** None of these systems require the complex form. All let users start simple and add complexity as needed. Precept's "everything is a state machine" requirement was the outlier.
+
+### Progressive Disclosure Principle
+
+Established as a UX/design principle since 1985 (Apple HIG). Successful languages follow it:
+
+- HTML: `<p>Hello</p>` → `<form>` + JS event handlers
+- CSS: `color: red` → `@keyframes` + `calc()` + grid
+- Python: scripts → classes → async
+
+Precept violates this principle by requiring state machines from the start.
+
+### DDD Pattern Match
+
+Evans (2003) explicitly recognizes that a single domain contains both:
+- **Value objects:** No identity, no behavior, immutable or simply-constrained data
+- **Entities:** Identity, state, business rules, lifecycle
+
+A domain modeling language that only supports entities forces value objects into a different tool.
+
+## Design Decisions
+
+### Editability: `edit all` / `edit Field1, Field2`
+
+**Decision:** Root-level `edit` for stateless precepts. `all` as field quantifier (parallel to `any` as state quantifier).
+
+**Alternatives rejected:**
+
+| Option | Why Rejected |
+|--------|-------------|
+| All fields editable by default | Violates Principle #2 (no silent defaults). Breaks "locked by default." |
+| `readonly` keyword | Inverts philosophy — stateful = locked, stateless = open. Inconsistent. |
+| `edit any` | Overloads `any` across state and field domains. Fails glance test. `any` is the state quantifier. |
+| No editability (invariants only) | Can't express read-only fields (IDs, timestamps shouldn't be user-editable). |
+
+**Why `all` not `any`:** `any` is established as the state-domain quantifier (`in any edit`, `from any assert`). Using it for the field domain creates semantic collision. `all` is a distinct word for a distinct domain. Two quantifiers: `any` for states, `all` for fields. They compose: `in any edit all`.
+
+**Graduation path:** Root-level `edit` is a compile error when states are declared. Compiler tells the user to use `in any edit all` or `in <State> edit ...`. No silent behavioral change.
+
+### API: Nullable CurrentState, Undefined Results
+
+**Decision:** `CurrentState` = null for stateless instances. `Fire()`/`Inspect(event)` return `Undefined` (not throw).
+
+**Why Undefined over throw:** Consistent with how `Fire()` already handles "event not valid from this state." Callers already handle this outcome — no new error-handling pattern needed.
+
+### Preview: Deferred
+
+**Decision:** No stateless preview rendering in current panel. Deferred to the full preview panel redesign.
+
+## Dead Ends Explored
+
+### "Close #22 — Out of Scope"
+
+The team initially recommended closing #22 (April 7, 2026). Arguments:
+- "Precept's identity is state machines" — but this framed Precept as a state machine tool, not a domain integrity platform
+- "All 20 samples are stateful" — circular: Precept doesn't support stateless, so no stateless samples can exist
+- "Better served by Zod/FluentValidation" — ignores the mixed-tooling adoption barrier
+
+Reversed after Shane's pushback on the mixed-tooling argument and the circular evidence problem.
+
+### `edit any` Syntax
+
+Proposed by Shane, evaluated and replaced with `edit all` after team analysis showed `any` was already claimed as a state quantifier. The semantic collision would cause confusion in documentation, autocomplete, and first-time learning.
+
+## Related Issues
+
+- **#22** — The proposal itself
+- **#31** — Keyword logical operators (`and`, `or`, `not`) — same wave, no dependency
+- **#9** — Conditional expressions (`if...then...else`) — same wave, no dependency


### PR DESCRIPTION
## Changes

- **Keyword-symbol design framework** — new Principle #13 and locked framework section in language design doc
- **#31 expanded** — from \
ot\ only to all logical operators (\nd\, \or\, \
ot\)
- **#22 promoted** — data-only precepts research doc and issue map entry added
- **Conditional logic research** — keyword-symbol decision section added
- **Wave milestones** — 5 milestones created, all 14 language issues assigned
- **#31 added to project board**

### Issues referenced
- #22 — promoted from placeholder to full Wave 1 proposal
- #31 — scope expanded to all keyword logical operators