### PR TITLE
squad: session log — issue #31 merged

### DIFF
--- a/.squad/agents/frank/history.md
+++ b/.squad/agents/frank/history.md
@@ -9,6 +9,9 @@
 
 ## Recent Updates
 
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
 ### 2026-04-10 - PR #50 final review — Issue #31 keyword logical operators
 
 **Verdict: APPROVED.** All 8 slices verified. 774/774 tests passing. Full review filed at `.squad/decisions/inbox/frank-31-review.md`.

--- a/.squad/agents/george/history.md
+++ b/.squad/agents/george/history.md
@@ -7,6 +7,9 @@
 
 ## Recent Updates
 
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
 ### 2026-04-10 - Issue #31 Slices 1-4 + Samples (keyword logical operators)
 - **Token names found:** `And`, `Or`, `Not` — already existed in `PreceptToken` enum with old `[TokenSymbol("&&")]`, `[TokenSymbol("||")]`, `[TokenSymbol("!")]`. Changed to `[TokenSymbol("and")]`, `[TokenSymbol("or")]`, `[TokenSymbol("not")]`. Both `TokenCategory.Operator` attributes were correct; no category changes needed.
 - **Tokenizer protection:** `requireDelimiters: true` on keyword registration (step 7 in `Build()`) is the mechanism that prevents `android` from matching `And` + `roid`. The operator entries (`&&`, `||`, `!`) were in steps 4-5 (plain span/character matches without delimiters) — removing them from those sections was sufficient, since `And`/`Or`/`Not` are now registered as keywords via the keyword loop.

--- a/.squad/agents/kramer/history.md
+++ b/.squad/agents/kramer/history.md
@@ -49,6 +49,9 @@
 - Recorded the reusable audit workflow at `.squad/skills/github-readme-width-audit/SKILL.md` and preserved the merged sizing outcome in `.squad/decisions.md`.
 - Key learning: for README hero images, composition guidance and final image-display limits are different measurements; size the shipped asset to the image cap, not the wider article container.
 
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
 ### 2026-04-10 - Slice 5: Grammar + Language Server (issue #31 — and/or/not keywords)
 
 - Grammar (`precept.tmLanguage.json`): added `and`, `or`, `not` to `actionKeywords` alternation (same group as `contains`) — these are operator-category tokens used in expression positions, so they fit naturally alongside `contains`.

--- a/.squad/agents/newman/history.md
+++ b/.squad/agents/newman/history.md
@@ -13,6 +13,9 @@
 
 ## Learnings
 
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
 ### Issue #31 Slice 6 — Operator Inventory (2026-04-10)
 
 - `LanguageTool.cs` is fully catalog-driven via `PreceptTokenMeta.GetSymbol(token)`. When George updates token symbols in `PreceptToken.cs`, the `precept_language` operator inventory updates automatically — no MCP code changes required.

--- a/.squad/agents/soup-nazi/history.md
+++ b/.squad/agents/soup-nazi/history.md
@@ -6,6 +6,9 @@
 
 ## Recent Updates
 
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
 ### 2026-04-10 - Issue #31 Slice 7: keyword logical operator tests
 - Updated 9 existing test files (8 in `test/Precept.Tests/`, 1 in `test/Precept.LanguageServer.Tests/`) to replace DSL symbols `&&` → `and`, `||` → `or`, `!` → `not` in all `.precept` string literals and operator assertions.
 - Created new `test/Precept.Tests/PreceptKeywordLogicalOperatorTests.cs` covering: basic keyword parsing (not/and/or), precedence validation (not > and > or), null narrowing through `not (Field == null)`, `!=` operator unaffected, old symbols `&&`/`||`/`!` produce parse errors, compound expression parse/evaluate, invariant context (or/and).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -6,6 +6,51 @@
 
 ---
 
+### 2026-04-10T12:00:00Z: Issue #31 merged — keyword logical operators (and/or/not replace &&/||/!)
+**By:** George (Runtime Dev), Kramer (Tooling Dev), Newman (MCP/AI Dev), Soup Nazi (Tester), Frank (Lead/Architect), Coordinator
+**Status:** Merged — PR #50, main SHA `305ec03`
+
+`&&`/`||`/`!` have been removed from the Precept DSL and replaced with keyword forms `and`/`or`/`not` across all 8 slices. All 775 tests passing. Issue #31 closed.
+
+**Runtime (George — Slices 1-4 + Samples):**
+- `[TokenSymbol]` attributes on `PreceptToken.And`/`Or`/`Not` changed to `"and"`/`"or"`/`"not"`. Old operator entries removed from tokenizer steps 4-5. Keyword loop (step 7, `requireDelimiters: true`) handles them automatically — `android` cannot match `And`.
+- All operator string comparisons updated in: parser (AST strings), type-checker main switch, `ApplyNarrowing()` (~line 889, a critical second update site distinct from the main switch), and expression evaluator.
+- 17 of 24 sample files updated; 7 unchanged (no logical operators used).
+- Commit: `83497aa`.
+
+**Grammar + Language Server (Kramer — Slice 5):**
+- `and`/`or`/`not` added to `actionKeywords` alternation in grammar (same group as `contains` — expression-position, operator-category tokens).
+- Old `keyword.operator.logical.precept` block (`&&|\|\||!`) removed from grammar entirely; `!=` untouched.
+- `ExpressionOperatorItems` in `PreceptAnalyzer.cs` updated: `&&`/`||`/`!` `Operator` items replaced with `and`/`or`/`not` `Keyword` items. Global keyword discovery via `BuildKeywordItems()` auto-picks up `And`/`Or`/`Not` from enum — no explicit additions needed.
+- Semantic tokens handler unchanged — catalog-driven via `[TokenCategory(Operator)]`.
+- Commit: `8f3bdab`.
+
+**MCP Operator Inventory (Newman — Slice 6):**
+- Zero code changes to MCP tools. `LanguageTool.cs` is fully catalog-driven via `PreceptTokenMeta.GetSymbol(token)`. George's `[TokenSymbol]` attribute update automatically propagates to `precept_language` output.
+- `docs/McpServerDesign.md` already used `and` in expression examples — no doc changes needed.
+- New test: `LogicalOperatorsAreKeywordForms` — asserts `and`/`or`/`not` present in operator inventory, `&&`/`||` absent. Canonical dual-assertion pattern for operator renames.
+
+**Tests (Soup Nazi — Slice 7):**
+- 10 existing test files updated (symbol substitutions: `&&`→`and`, `||`→`or`, `!`→`not`).
+- New `PreceptKeywordLogicalOperatorTests.cs` (15 tests): basic parsing, precedence (`not > and > or`), null narrowing through `not (Field == null)`, `!=` unaffected, old symbols produce `InvalidOperationException`, compound expressions, invariant context.
+
+**Docs (Frank — Slice 8):**
+- `docs/PreceptLanguageDesign.md` fully synchronized: migration table heading updated ("Implemented"), "Until implementation…" paragraph removed, `and`/`or`/`not` added to reserved keywords list, nullability Pattern 1/2 code examples updated, "pending migration" annotations removed from expressions section, event asserts and Minimal Example updated.
+- `docs/research/language/references/cel-comparison.md` created: full Precept vs. CEL language-level comparison.
+
+**PR Review (Frank):**
+- APPROVED. All 8 slices verified. Architecture sound. Coverage complete.
+- Key architectural confirmation: `BuildKeywordDictionary()` uses `symbol.All(char.IsLetter)` — operator-to-keyword migration for alphabetic symbols requires only `[TokenSymbol]` attribute change; no tokenizer code changes. Correct pattern for future migrations.
+- Non-blocking: `LogicalOperatorsAreKeywordForms` does not assert `!` absent. Acceptable — `!` removed from tokenizer entirely, no path to operator inventory.
+
+**Coordinator final action:**
+- Added `NotContain("!")` assertion to `LogicalOperatorsAreKeywordForms`. Merged as 775th test.
+
+**Open item (deferred):**
+- Grammar group classification: `and`/`or`/`not` in `actionKeywords` is correct per current convention but a semantic visual system session should formally address whether expression-position operator-category tokens warrant a distinct scope token from structural action keywords. Deferred by Shane.
+
+---
+
 ### 2026-04-08T23:50:00Z: Soup Nazi exploratory MCP regression — methodology validated, 5 authoring corrections captured
 **By:** Soup Nazi (Tester)
 **Status:** Applied


### PR DESCRIPTION
Squad session log and decision inbox merge for issue #31 (keyword logical operators). `.squad/` only — no production code changes.