### PR TITLE
fix: retroactive language PR audit — review fixes + completions overhaul

### DIFF
--- a/samples/hiring-pipeline.precept
+++ b/samples/hiring-pipeline.precept
@@ -22,6 +22,7 @@ state Rejected
 
 in InterviewLoop assert PendingInterviewers.count > 0 because "Interview loops require at least one pending interviewer"
 in Hired assert OfferAmount > 0 because "Hired candidates must have an offer amount"
+invariant CandidateName == null or CandidateName.length <= 100 because "Candidate name must be ≤100 characters"
 
 event SubmitApplication with Candidate as string notempty, Role as string notempty, Recruiter as string notempty
 

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -445,7 +445,7 @@ public static class DiagnosticCatalog
     public static readonly LanguageConstraint C56 = Register(
         "C56", "compile",
         "Member access on nullable string requires explicit null guard before '.length'.",
-        "'{field}.length' requires a null check — '{field}' is nullable. Use '{field} != null && {field}.length ...' or '{field} == null || {field}.length ...'.");
+        "'{field}.length' requires a null check — '{field}' is nullable. Use '{field} != null and {field}.length ...' or '{field} == null or {field}.length ...'.");
 
     // ═══════════════════════════════════════════════════════════════
     // Field-level constraint diagnostics (C57–C59)

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Precept;
 using Precept.LanguageServer;
 using Xunit;
 
@@ -929,6 +931,240 @@ public class PreceptAnalyzerCompletionTests
             because: ".length must not be offered after non-string identifiers");
     }
 
+    // ════════════════════════════════════════════════════════════════════
+    // Pre-precept scope: blank / new files without a precept declaration
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Completions_BlankFile_OnlyOffersPrecept()
+    {
+        const string text = """
+            $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().ContainSingle()
+            .Which.Should().Be("precept");
+    }
+
+    [Fact]
+    public void Completions_FileWithCommentOnly_OnlyOffersPrecept()
+    {
+        const string text = """
+            # This is a new precept file
+            $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().ContainSingle()
+            .Which.Should().Be("precept");
+    }
+
+    [Fact]
+    public void Completions_TypingPreceptName_SuppressesAll()
+    {
+        const string text = """
+            precept My$$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().BeEmpty(because: "user is naming the precept — no suggestions");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Gap fixes: pipeline continuation, on + events, top-level, comments,
+    //            scalar types, event arg types
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Completions_AfterCompletedSetExpression_SuggestsArrow()
+    {
+        const string text = """
+            precept M
+            field Count as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Count = 42 $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("->",
+            because: "after a completed set expression, the pipeline arrow should be offered");
+    }
+
+    [Fact]
+    public void Completions_AfterCompletedAddExpression_SuggestsArrow()
+    {
+        const string text = """
+            precept M
+            field Tags as set of string
+            state A initial
+            state B
+            event Go
+            from A on Go -> add Tags "important" $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("->",
+            because: "after a completed add expression, the pipeline arrow should be offered");
+    }
+
+    [Fact]
+    public void Completions_OnAtLineStart_SuggestsEventNames()
+    {
+        const string text = """
+            precept M
+            state A initial
+            event Submit
+            event Cancel
+            on $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("Submit");
+        completions.Should().Contain("Cancel");
+        completions.Should().NotContain("set", because: "action keywords should not appear in event name position");
+    }
+
+    [Fact]
+    public void Completions_TopLevelBlankLine_OnlySuggestsDeclarationKeywords()
+    {
+        const string text = """
+            precept M
+            state A initial
+            event Go
+            $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        // Top-level declarations should be present
+        completions.Should().Contain("field");
+        completions.Should().Contain("state");
+        completions.Should().Contain("event");
+        completions.Should().Contain("from");
+        completions.Should().Contain("invariant");
+
+        // Action/outcome/grammar keywords should NOT be at top level
+        completions.Should().NotContain("set", because: "set is an action keyword, not a top-level declaration");
+        completions.Should().NotContain("transition", because: "transition is an outcome keyword, not a top-level declaration");
+        completions.Should().NotContain("nullable", because: "nullable is a grammar modifier, not a top-level declaration");
+        completions.Should().NotContain("nonnegative", because: "constraint keywords should not appear at top level");
+    }
+
+    [Fact]
+    public void Completions_CommentLine_SuppressesAll()
+    {
+        const string text = """
+            precept M
+            state A initial
+            # This is a comment $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().BeEmpty(because: "comment lines should suppress all completions");
+    }
+
+    [Fact]
+    public void Completions_EventArgAsPosition_SuggestsAllScalarTypes()
+    {
+        const string text = """
+            precept M
+            state A initial
+            event Go with Amount as $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("string");
+        completions.Should().Contain("number");
+        completions.Should().Contain("boolean");
+        completions.Should().Contain("integer");
+        completions.Should().Contain("decimal");
+        completions.Should().Contain(c => c.StartsWith("choice", StringComparison.Ordinal),
+            because: "choice type should be offered for event args");
+    }
+
+    [Fact]
+    public void Completions_EventArgIntegerType_SuggestsNumberConstraints()
+    {
+        const string text = """
+            precept M
+            state A initial
+            event Go with Count as integer $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("nonnegative");
+        completions.Should().Contain("positive");
+        completions.Should().Contain("min");
+        completions.Should().Contain("max");
+        completions.Should().Contain("nullable");
+        completions.Should().Contain(",");
+    }
+
+    [Fact]
+    public void Completions_EventArgDecimalType_SuggestsDecimalConstraints()
+    {
+        const string text = """
+            precept M
+            state A initial
+            event Go with Amount as decimal $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("nonnegative");
+        completions.Should().Contain("positive");
+        completions.Should().Contain("min");
+        completions.Should().Contain("max");
+        completions.Should().Contain(c => c.StartsWith("maxplaces", StringComparison.Ordinal),
+            because: "maxplaces must be offered for decimal event args");
+        completions.Should().Contain("nullable");
+        completions.Should().Contain(",");
+    }
+
+    [Fact]
+    public void Completions_CollectionOfPosition_SuggestsAllScalarTypes()
+    {
+        const string text = """
+            precept M
+            state A initial
+            field Items as set of $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("string");
+        completions.Should().Contain("number");
+        completions.Should().Contain("boolean");
+        completions.Should().Contain("integer");
+        completions.Should().Contain("decimal");
+        completions.Should().Contain(c => c.StartsWith("choice", StringComparison.Ordinal),
+            because: "choice type should be offered as collection inner type");
+    }
+
     private static (string text, Position position) ExtractPosition(string textWithMarker)
     {
         var index = textWithMarker.IndexOf("$$", StringComparison.Ordinal);
@@ -940,5 +1176,185 @@ public class PreceptAnalyzerCompletionTests
         var lastNewLine = prefix.LastIndexOf('\n');
         var character = lastNewLine >= 0 ? prefix.Length - lastNewLine - 1 : prefix.Length;
         return (text, new Position(line, character));
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Completions ↔ Token Catalog Drift Tests
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // These tests enforce that the static completion lists in PreceptAnalyzer
+    // stay in sync with the PreceptToken enum. When someone adds a new token
+    // with [TokenCategory(Type)] or [TokenCategory(Constraint)] etc., these
+    // tests fail until the corresponding completion list is updated.
+
+    [Fact]
+    public void AllTypeTokens_AppearInTypeItems()
+    {
+        var typeSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Type)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var completionLabels = PreceptAnalyzer.TypeItems
+            .Select(i => i.Label)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Snippet labels like "choice(...)" won't match the raw symbol "choice",
+        // so also check whether the label starts with the symbol.
+        var missing = typeSymbols
+            .Where(sym => !completionLabels.Contains(sym!)
+                && !completionLabels.Any(label => label.StartsWith(sym!, StringComparison.Ordinal)))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every token with [TokenCategory(Type)] must appear in PreceptAnalyzer.TypeItems — "
+            + "add new type keywords there when extending the language");
+    }
+
+    [Fact]
+    public void AllConstraintTokens_AppearInAtLeastOneConstraintList()
+    {
+        var constraintSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Constraint)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var allConstraintLabels = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in PreceptAnalyzer.NumberConstraintItems) allConstraintLabels.Add(item.Label);
+        foreach (var item in PreceptAnalyzer.StringConstraintItems) allConstraintLabels.Add(item.Label);
+        foreach (var item in PreceptAnalyzer.CollectionConstraintItems) allConstraintLabels.Add(item.Label);
+        foreach (var item in PreceptAnalyzer.DecimalConstraintItems) allConstraintLabels.Add(item.Label);
+        foreach (var item in PreceptAnalyzer.ChoiceConstraintItems) allConstraintLabels.Add(item.Label);
+
+        // Snippet labels like "maxplaces N" start with the symbol "maxplaces"
+        var missing = constraintSymbols
+            .Where(sym => !allConstraintLabels.Contains(sym!)
+                && !allConstraintLabels.Any(label => label.StartsWith(sym!, StringComparison.Ordinal)))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every token with [TokenCategory(Constraint)] must appear in at least one constraint "
+            + "completion list (Number/String/Collection/Decimal/Choice) — add new constraint "
+            + "keywords to the appropriate list when extending the language");
+    }
+
+    [Fact]
+    public void AllActionTokens_AppearInArrowItems()
+    {
+        var actionSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Action)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var arrowLabels = PreceptAnalyzer.ArrowItems
+            .Select(i => i.Label)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = actionSymbols
+            .Where(sym => !arrowLabels.Contains(sym!))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every token with [TokenCategory(Action)] must appear in PreceptAnalyzer.ArrowItems — "
+            + "add new action keywords there when extending the language");
+    }
+
+    [Fact]
+    public void AllOutcomeTokens_AppearInArrowItems()
+    {
+        var outcomeSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Outcome)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var arrowLabels = PreceptAnalyzer.ArrowItems
+            .Select(i => i.Label)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // "no" appears as the composite "no transition" in ArrowItems
+        var missing = outcomeSymbols
+            .Where(sym => !arrowLabels.Contains(sym!)
+                && !arrowLabels.Any(label => label.StartsWith(sym!, StringComparison.Ordinal)))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every token with [TokenCategory(Outcome)] must appear in PreceptAnalyzer.ArrowItems — "
+            + "add new outcome keywords there when extending the language");
+    }
+
+    [Fact]
+    public void AllLiteralTokens_AppearInLiteralItems()
+    {
+        var literalSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Literal)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var literalLabels = PreceptAnalyzer.LiteralItems
+            .Select(i => i.Label)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = literalSymbols
+            .Where(sym => !literalLabels.Contains(sym!))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every token with [TokenCategory(Literal)] must appear in PreceptAnalyzer.LiteralItems — "
+            + "add new literal keywords there when extending the language");
+    }
+
+    [Fact]
+    public void AllKeywordOperatorTokens_AppearInExpressionOperatorItems()
+    {
+        // Keyword operators (alphabetic symbols with Operator category) must be offered
+        // in expression contexts. Non-alphabetic operators (==, >=, etc.) are also there
+        // but this test focuses on the ones that could drift as new keyword operators are added.
+        var keywordOperatorSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Operator)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null && s.All(char.IsLetter))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var operatorLabels = PreceptAnalyzer.ExpressionOperatorItems
+            .Select(i => i.Label)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = keywordOperatorSymbols
+            .Where(sym => !operatorLabels.Contains(sym!))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every keyword operator (alphabetic symbol with [TokenCategory(Operator)]) must appear "
+            + "in PreceptAnalyzer.ExpressionOperatorItems — add new keyword operators there "
+            + "when extending the language");
+    }
+
+    [Fact]
+    public void AllScalarTypeTokens_AppearInScalarTypeItems()
+    {
+        // ScalarTypeItems is used after "of" (collection inner type) and for event arg types.
+        // It must include every scalar type the parser accepts — excluding collection-only types
+        // (set, queue, stack) which are not valid as event arg types or collection inner types.
+        var collectionOnlySymbols = new HashSet<string>(StringComparer.Ordinal) { "set", "queue", "stack" };
+
+        var scalarTypeSymbols = PreceptTokenMeta.GetByCategory(TokenCategory.Type)
+            .Select(t => PreceptTokenMeta.GetSymbol(t))
+            .Where(s => s is not null && !collectionOnlySymbols.Contains(s))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var scalarLabels = PreceptAnalyzer.ScalarTypeItems
+            .Select(i => i.Label)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Snippet labels like "choice(...)" won't match the raw symbol "choice",
+        // so also check whether the label starts with the symbol.
+        var missing = scalarTypeSymbols
+            .Where(sym => !scalarLabels.Contains(sym!)
+                && !scalarLabels.Any(label => label.StartsWith(sym!, StringComparison.Ordinal)))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every scalar type token must appear in PreceptAnalyzer.ScalarTypeItems — "
+            + "this list is used for event arg types and collection inner types. "
+            + "Add new scalar type keywords there when extending the language");
     }
 }

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -892,6 +892,43 @@ public class PreceptAnalyzerCompletionTests
         completions.Should().NotContain("!", "symbolic logical operators were replaced by keyword forms");
     }
 
+    [Fact]
+    public void Completions_StringFieldDotTrigger_SuggestsLength()
+    {
+        const string text = """
+            precept M
+            field Name as string default ""
+            state A initial
+            event Go
+            from A on Go when Name.$$ -> no transition
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("Name.length",
+            because: ".length must be offered after string-typed field identifiers");
+    }
+
+    [Fact]
+    public void Completions_NonStringFieldDotTrigger_DoesNotSuggestLength()
+    {
+        const string text = """
+            precept M
+            field Count as number default 0
+            field Active as boolean default true
+            state A initial
+            event Go
+            from A on Go when Count.$$ -> no transition
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().NotContain("Count.length",
+            because: ".length must not be offered after non-string identifiers");
+    }
+
     private static (string text, Position position) ExtractPosition(string textWithMarker)
     {
         var index = textWithMarker.IndexOf("$$", StringComparison.Ordinal);

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -870,6 +870,28 @@ public class PreceptAnalyzerCompletionTests
         completions.Should().Contain("\"Closed\"");
     }
 
+    [Fact]
+    public void Completions_GuardExpression_SuggestsKeywordLogicalOperators()
+    {
+        const string text = """
+            precept M
+            field Active as boolean default true
+            state A initial
+            event Go
+            from A on Go when $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("and");
+        completions.Should().Contain("or");
+        completions.Should().Contain("not");
+        completions.Should().NotContain("&&", "symbolic logical operators were replaced by keyword forms");
+        completions.Should().NotContain("||", "symbolic logical operators were replaced by keyword forms");
+        completions.Should().NotContain("!", "symbolic logical operators were replaced by keyword forms");
+    }
+
     private static (string text, Position position) ExtractPosition(string textWithMarker)
     {
         var index = textWithMarker.IndexOf("$$", StringComparison.Ordinal);

--- a/test/Precept.LanguageServer.Tests/PreceptIntellisenseNavigationTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptIntellisenseNavigationTests.cs
@@ -147,6 +147,28 @@ public class PreceptIntellisenseNavigationTests
         diagnostics.Should().Contain(diagnostic => diagnostic.Message.Contains("no path forward", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void Hover_StringLengthAccessor_ShowsReturnType()
+    {
+        const string text = """
+            precept M
+            field Name as string default ""
+            state A initial
+            event Go
+            from A on Go when Name.len$$gth >= 1 -> no transition
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var info = PreceptDocumentIntellisense.Analyze(code);
+
+        var hover = PreceptDocumentIntellisense.CreateHover(info, position);
+
+        hover.Should().NotBeNull("hover over .length must return content");
+        hover!.Contents.ToString().Should().Contain("number",
+            because: ".length returns number (UTF-16 code unit count)");
+        hover.Contents.ToString().Should().Contain("Name.length");
+    }
+
     private static (string text, Position position) ExtractPosition(string textWithMarker)
     {
         var index = textWithMarker.IndexOf("$$", StringComparison.Ordinal);

--- a/test/Precept.Mcp.Tests/CompileToolTests.cs
+++ b/test/Precept.Mcp.Tests/CompileToolTests.cs
@@ -345,4 +345,23 @@ public class CompileToolTests
         amountField.Should().NotBeNull();
         amountField!.Constraints.Should().Contain("maxplaces 2");
     }
+
+    [Fact]
+    public void StringLengthInvariant_CompilesCleanly()
+    {
+        var text = """
+            precept Test
+            field Name as string default ""
+            state A initial
+            state B
+            event Go
+            invariant Name.length <= 100 because "Name must be \u2264100 characters"
+            from A on Go -> transition B
+            """;
+
+        var result = CompileTool.Run(text);
+
+        result.Valid.Should().BeTrue();
+        result.Diagnostics.Should().BeEmpty();
+    }
 }

--- a/test/Precept.Mcp.Tests/InspectToolTests.cs
+++ b/test/Precept.Mcp.Tests/InspectToolTests.cs
@@ -278,4 +278,32 @@ public class InspectToolTests
         result.Error.Should().BeNull();
         result.EditableFields.Should().BeNull();
     }
+
+    [Fact]
+    public void StringLengthConstraint_ShowsViolationInPreview()
+    {
+        const string text = """
+precept Test
+field Name as string default "valid"
+state Open initial
+state Done
+event Update with NewName as string
+invariant Name.length >= 2 because "Name must be at least 2 characters"
+from Open on Update -> set Name = Update.NewName -> transition Done
+""";
+
+        var data = new Dictionary<string, object?> { ["Name"] = "valid" };
+        var eventArgs = new Dictionary<string, Dictionary<string, object?>>
+        {
+            ["Update"] = new() { ["NewName"] = "x" }
+        };
+        var result = InspectTool.Inspect(text, "Open", data, eventArgs);
+
+        result.Error.Should().BeNull();
+        var update = result.Events.FirstOrDefault(e => e.Event == "Update");
+        update.Should().NotBeNull();
+        update!.Outcome.Should().Be("ConstraintFailure");
+        update.Violations.Should().NotBeEmpty();
+        update.Violations[0].Message.Should().Contain("Name must be at least 2 characters");
+    }
 }

--- a/test/Precept.Tests/PreceptRulesTests.cs
+++ b/test/Precept.Tests/PreceptRulesTests.cs
@@ -1147,11 +1147,11 @@ public class PreceptRulesTests
             from Active on ClearBalance -> set Balance = ClearBalance.NewBalance -> transition Active
             """;
 
-        // compile must succeed: default value null satisfies 'null || null >= 0' = true
+        // compile must succeed: default value null satisfies 'null or null >= 0' = true
         var workflow = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
         var instance = workflow.CreateInstance("Active", new Dictionary<string, object?> { ["Balance"] = 100.0 });
 
-        // Setting Balance to null via nullable arg — 'Balance == null || Balance >= 0' passes
+        // Setting Balance to null via nullable arg — 'Balance == null or Balance >= 0' passes
         var result = workflow.Fire(instance, "ClearBalance", new Dictionary<string, object?> { ["NewBalance"] = null });
 
         (result.Outcome is TransitionOutcome.Transition or TransitionOutcome.NoTransition).Should().BeTrue();

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -87,6 +87,24 @@ internal sealed class PreceptAnalyzer
             ? lineText[..(int)position.Character]
             : lineText;
 
+        // ── Comment lines: suppress completions entirely ──
+        if (beforeCursor.TrimStart().StartsWith('#'))
+            return Array.Empty<CompletionItem>();
+
+        // ── Pre-precept scope: before any precept declaration, only offer 'precept' ──
+        var hasPreceptDecl = info.Lines.Any(static l => Regex.IsMatch(l, @"^\s*precept\s+", RegexOptions.IgnoreCase));
+        if (!hasPreceptDecl)
+        {
+            // If the user is on a line starting with 'precept', they're naming it — suppress
+            if (Regex.IsMatch(beforeCursor, @"^\s*precept\s+\S*$", RegexOptions.IgnoreCase))
+                return Array.Empty<CompletionItem>();
+
+            return
+            [
+                new CompletionItem { Label = "precept", Kind = CompletionItemKind.Keyword, Detail = "Top-level precept declaration" }
+            ];
+        }
+
         var states = info.States;
         var events = info.Events;
         var dataFields = info.Fields;
@@ -156,6 +174,13 @@ internal sealed class PreceptAnalyzer
             // After "add|remove|push|enqueue <Field> ", suggest expression (the value to add/push/remove)
             if (Regex.IsMatch(beforeCursor, "(?:^|->)\\s*(?:add|remove|push|enqueue)\\s+[A-Za-z_][A-Za-z0-9_]*\\s+[^\\n]*$", RegexOptions.IgnoreCase))
             {
+                // If expression looks complete (ends with identifier/literal + space), offer -> for pipeline continuation.
+                // Only check after the value portion has started — the regex requires at least one non-space token
+                // past the field name to distinguish "add Field |" (needs value) from "add Field value |" (needs ->).
+                var valueMatch = Regex.Match(beforeCursor, "(?:^|->)\\s*(?:add|remove|push|enqueue)\\s+[A-Za-z_][A-Za-z0-9_]*\\s+(?<value>\\S.*)$", RegexOptions.IgnoreCase);
+                if (valueMatch.Success && EndsWithCompletedExpression(valueMatch.Groups["value"].Value))
+                    return [ArrowPipelineItem];
+
                 var typedItems = TryBuildTypedCollectionMutationExpressionCompletions(
                     text,
                     lines,
@@ -176,6 +201,10 @@ internal sealed class PreceptAnalyzer
 
         if (Regex.IsMatch(beforeCursor, "(?:^|->)\\s*set\\s+[A-Za-z_][A-Za-z0-9_]*\\s*=\\s*[^\\n]*$", RegexOptions.IgnoreCase))
         {
+            // If expression looks complete (ends with identifier/literal + space), offer -> for pipeline continuation
+            if (EndsWithCompletedExpression(beforeCursor))
+                return [ArrowPipelineItem];
+
             var typedItems = TryBuildTypedSetExpressionCompletions(
                 text,
                 lines,
@@ -337,6 +366,10 @@ internal sealed class PreceptAnalyzer
         if (Regex.IsMatch(beforeCursor, "^\\s*on\\s+[A-Za-z_][A-Za-z0-9_]*\\s+$", RegexOptions.IgnoreCase))
             return [new CompletionItem { Label = "assert", Kind = CompletionItemKind.Keyword }];
 
+        // After "on " (typing or choosing event name) → suggest event names
+        if (Regex.IsMatch(beforeCursor, @"^\s*on\s+\w*$", RegexOptions.IgnoreCase))
+            return BuildItems(events, CompletionItemKind.Event);
+
         // After "in/to StateName " → suggest assert, ->, edit (in only)
         if (Regex.IsMatch(beforeCursor, "^\\s*in\\s+[A-Za-z_][A-Za-z0-9_]*(?:\\s*,\\s*[A-Za-z_][A-Za-z0-9_]*)*\\s+$", RegexOptions.IgnoreCase))
             return
@@ -385,15 +418,18 @@ internal sealed class PreceptAnalyzer
                     .Concat(BuildItems(collectionFields, CompletionItemKind.Field)));
 
         // After "event Name with Arg as Type [nullable] [default Value] " → suggest delimiter / modifiers
-        // Split by type to include type-appropriate constraint keywords
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+number\\s+nullable\\s+$", RegexOptions.IgnoreCase))
+        // Split by type to include type-appropriate constraint keywords.
+        // The preceding-args pattern uses a broad type alternation to handle all scalar types + choice.
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:number|integer)\\s+nullable\\s+$", RegexOptions.IgnoreCase))
             return [DefaultItem, ..NumberConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+string\\s+nullable\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+decimal\\s+nullable\\s+$", RegexOptions.IgnoreCase))
+            return [DefaultItem, ..DecimalConstraintItems, CommaItem];
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+string\\s+nullable\\s+$", RegexOptions.IgnoreCase))
             return [DefaultItem, ..StringConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+boolean\\s+nullable\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:boolean|choice\\([^)]*\\))\\s+nullable\\s+$", RegexOptions.IgnoreCase))
             return [DefaultItem, CommaItem];
 
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null)\\s*$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null)\\s*$", RegexOptions.IgnoreCase))
             return [CommaItem];
 
         // After a comma in an event arg list, the user is starting the next arg name.
@@ -401,19 +437,21 @@ internal sealed class PreceptAnalyzer
         if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+.*\\,\\s*$", RegexOptions.IgnoreCase))
             return Array.Empty<CompletionItem>();
 
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+number\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:number|integer)\\s+$", RegexOptions.IgnoreCase))
             return [NullableItem, DefaultItem, ..NumberConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+string\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+decimal\\s+$", RegexOptions.IgnoreCase))
+            return [NullableItem, DefaultItem, ..DecimalConstraintItems, CommaItem];
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+string\\s+$", RegexOptions.IgnoreCase))
             return [NullableItem, DefaultItem, ..StringConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+boolean\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:boolean|choice\\([^)]*\\))\\s+$", RegexOptions.IgnoreCase))
             return [NullableItem, DefaultItem, CommaItem];
 
         // After "event Name with ArgName as " → suggest type keywords
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+\\w*$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+\\w*$", RegexOptions.IgnoreCase))
             return ScalarTypeItems;
 
         // After "event Name with ArgName " → suggest "as"
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean)(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+$", RegexOptions.IgnoreCase))
             return [AsItem];
 
         // After "event Name with " → user is typing arg name, no suggestions
@@ -433,7 +471,7 @@ internal sealed class PreceptAnalyzer
         if (Regex.IsMatch(beforeCursor, @"^\s*state\s+.*\binitial\s+$", RegexOptions.IgnoreCase))
             return [new CompletionItem { Label = ",", Kind = CompletionItemKind.Operator, Detail = "add another state name" }];
 
-        return DistinctAndSort(KeywordItems.Concat(GlobalSnippetItems));
+        return DistinctAndSort(TopLevelItems.Concat(GlobalSnippetItems));
     }
 
     internal IReadOnlyList<RejectOnlyStateEventIssue> GetRejectOnlyStateEventIssues(DocumentUri uri)
@@ -1000,7 +1038,7 @@ internal sealed class PreceptAnalyzer
             })
             .ToArray();
 
-    private static readonly IReadOnlyList<CompletionItem> KeywordItems = BuildKeywordItems();
+    internal static readonly IReadOnlyList<CompletionItem> KeywordItems = BuildKeywordItems();
 
     /// <summary>
     /// Builds the fallback keyword completion list from <see cref="PreceptTokenMeta"/> attributes.
@@ -1039,7 +1077,46 @@ internal sealed class PreceptAnalyzer
         return items;
     }
 
-    private static readonly IReadOnlyList<CompletionItem> ExpressionOperatorItems =
+    /// <summary>
+    /// Top-level declaration keywords appropriate for blank lines / statement start.
+    /// Excludes action keywords (set, add), outcome keywords (transition, reject),
+    /// grammar modifiers (as, nullable, because), and constraint keywords that only
+    /// make sense inside specific declaration contexts.
+    /// </summary>
+    private static readonly IReadOnlyList<CompletionItem> TopLevelItems = BuildTopLevelItems();
+
+    private static IReadOnlyList<CompletionItem> BuildTopLevelItems()
+    {
+        var topLevelCategories = new HashSet<TokenCategory>
+        {
+            TokenCategory.Declaration,
+            TokenCategory.Control
+        };
+
+        var items = new List<CompletionItem>();
+
+        foreach (var token in Enum.GetValues<PreceptToken>())
+        {
+            var category = PreceptTokenMeta.GetCategory(token);
+            var symbol = PreceptTokenMeta.GetSymbol(token);
+            var description = PreceptTokenMeta.GetDescription(token);
+
+            if (category is null || symbol is null) continue;
+            if (!symbol.All(char.IsLetter)) continue;
+            if (!topLevelCategories.Contains(category.Value)) continue;
+
+            items.Add(new CompletionItem
+            {
+                Label = symbol,
+                Kind = CompletionItemKind.Keyword,
+                Detail = description
+            });
+        }
+
+        return items;
+    }
+
+    internal static readonly IReadOnlyList<CompletionItem> ExpressionOperatorItems =
     [
         new CompletionItem { Label = "+", Kind = CompletionItemKind.Operator },
         new CompletionItem { Label = "-", Kind = CompletionItemKind.Operator },
@@ -1059,7 +1136,7 @@ internal sealed class PreceptAnalyzer
         SnippetItem("round(expr, N)", "round(${1:expr}, ${2:2})", "Round a decimal value to N places")
     ];
 
-    private static readonly IReadOnlyList<CompletionItem> LiteralItems =
+    internal static readonly IReadOnlyList<CompletionItem> LiteralItems =
     [
         new CompletionItem { Label = "true", Kind = CompletionItemKind.Constant },
         new CompletionItem { Label = "false", Kind = CompletionItemKind.Constant },
@@ -1084,15 +1161,18 @@ internal sealed class PreceptAnalyzer
     // ── New-syntax item lists ──────────────────────────────────────────
 
     /// <summary>Scalar type keywords for positions after "as" / "of" / event arg type.</summary>
-    private static readonly IReadOnlyList<CompletionItem> ScalarTypeItems =
+    internal static readonly IReadOnlyList<CompletionItem> ScalarTypeItems =
     [
         new CompletionItem { Label = "string", Kind = CompletionItemKind.TypeParameter },
         new CompletionItem { Label = "number", Kind = CompletionItemKind.TypeParameter },
-        new CompletionItem { Label = "boolean", Kind = CompletionItemKind.TypeParameter }
+        new CompletionItem { Label = "boolean", Kind = CompletionItemKind.TypeParameter },
+        new CompletionItem { Label = "integer", Kind = CompletionItemKind.TypeParameter, Detail = "Whole number (no decimal point)" },
+        new CompletionItem { Label = "decimal", Kind = CompletionItemKind.TypeParameter, Detail = "Exact base-10 decimal number" },
+        SnippetItem("choice(...)", "choice(\"${1:A}\", \"${2:B}\")", "Constrained value from a predefined set")
     ];
 
     /// <summary>All type keywords for positions after "field Name as" (scalar + collection).</summary>
-    private static readonly IReadOnlyList<CompletionItem> TypeItems =
+    internal static readonly IReadOnlyList<CompletionItem> TypeItems =
     [
         new CompletionItem { Label = "string", Kind = CompletionItemKind.TypeParameter },
         new CompletionItem { Label = "number", Kind = CompletionItemKind.TypeParameter },
@@ -1106,7 +1186,7 @@ internal sealed class PreceptAnalyzer
     ];
 
     /// <summary>Action/outcome keywords available after "->" in flat transition rows.</summary>
-    private static readonly IReadOnlyList<CompletionItem> ArrowItems =
+    internal static readonly IReadOnlyList<CompletionItem> ArrowItems =
     [
         new CompletionItem { Label = "set", Kind = CompletionItemKind.Keyword, Detail = "Data assignment" },
         new CompletionItem { Label = "transition", Kind = CompletionItemKind.Keyword, Detail = "Transition to state" },
@@ -1130,7 +1210,7 @@ internal sealed class PreceptAnalyzer
     private static readonly CompletionItem ArrowPipelineItem = new() { Label = "->", Kind = CompletionItemKind.Operator, Detail = "action/outcome pipeline" };
     private static readonly CompletionItem CommaItem = new() { Label = ",", Kind = CompletionItemKind.Operator, Detail = "Next event argument" };
 
-    private static readonly IReadOnlyList<CompletionItem> NumberConstraintItems =
+    internal static readonly IReadOnlyList<CompletionItem> NumberConstraintItems =
     [
         new CompletionItem { Label = "nonnegative", Kind = CompletionItemKind.Keyword, Detail = "number constraint", Documentation = new StringOrMarkupContent("Field must be >= 0") },
         new CompletionItem { Label = "positive",    Kind = CompletionItemKind.Keyword, Detail = "number constraint", Documentation = new StringOrMarkupContent("Field must be > 0") },
@@ -1138,21 +1218,21 @@ internal sealed class PreceptAnalyzer
         new CompletionItem { Label = "max",         Kind = CompletionItemKind.Keyword, Detail = "number constraint", Documentation = new StringOrMarkupContent("Field must be <= value") },
     ];
 
-    private static readonly IReadOnlyList<CompletionItem> StringConstraintItems =
+    internal static readonly IReadOnlyList<CompletionItem> StringConstraintItems =
     [
         new CompletionItem { Label = "notempty",   Kind = CompletionItemKind.Keyword, Detail = "string constraint", Documentation = new StringOrMarkupContent("Field must not be empty") },
         new CompletionItem { Label = "minlength",  Kind = CompletionItemKind.Keyword, Detail = "string constraint", Documentation = new StringOrMarkupContent("Field must have at least N characters") },
         new CompletionItem { Label = "maxlength",  Kind = CompletionItemKind.Keyword, Detail = "string constraint", Documentation = new StringOrMarkupContent("Field must have at most N characters") },
     ];
 
-    private static readonly IReadOnlyList<CompletionItem> CollectionConstraintItems =
+    internal static readonly IReadOnlyList<CompletionItem> CollectionConstraintItems =
     [
         new CompletionItem { Label = "notempty",  Kind = CompletionItemKind.Keyword, Detail = "collection constraint", Documentation = new StringOrMarkupContent("Collection must not be empty") },
         new CompletionItem { Label = "mincount",  Kind = CompletionItemKind.Keyword, Detail = "collection constraint", Documentation = new StringOrMarkupContent("Collection must have at least N items") },
         new CompletionItem { Label = "maxcount",  Kind = CompletionItemKind.Keyword, Detail = "collection constraint", Documentation = new StringOrMarkupContent("Collection must have at most N items") },
     ];
 
-    private static readonly IReadOnlyList<CompletionItem> DecimalConstraintItems =
+    internal static readonly IReadOnlyList<CompletionItem> DecimalConstraintItems =
     [
         new CompletionItem { Label = "nonnegative", Kind = CompletionItemKind.Keyword, Detail = "decimal constraint", Documentation = new StringOrMarkupContent("Field must be >= 0") },
         new CompletionItem { Label = "positive",    Kind = CompletionItemKind.Keyword, Detail = "decimal constraint", Documentation = new StringOrMarkupContent("Field must be > 0") },
@@ -1161,7 +1241,7 @@ internal sealed class PreceptAnalyzer
         SnippetItem("maxplaces N", "maxplaces ${1:2}", "Maximum decimal places"),
     ];
 
-    private static readonly IReadOnlyList<CompletionItem> ChoiceConstraintItems =
+    internal static readonly IReadOnlyList<CompletionItem> ChoiceConstraintItems =
     [
         new CompletionItem { Label = "ordered", Kind = CompletionItemKind.Keyword, Detail = "choice constraint", Documentation = new StringOrMarkupContent("Enables ordinal comparison of choice values") },
     ];

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -820,7 +820,7 @@ internal sealed class PreceptAnalyzer
     private static IReadOnlyList<CompletionItem> BuildStringMemberItems(string fieldName, bool isNullable)
     {
         var doc = isNullable
-            ? "Returns the string's character count (UTF-16 code units). Use 'field != null && field.length ...' for nullable strings."
+            ? "Returns the string's character count (UTF-16 code units). Use 'field != null and field.length ...' for nullable strings."
             : "Returns the string's character count (UTF-16 code units).";
         return
         [

--- a/tools/Precept.LanguageServer/PreceptDocumentIntellisense.cs
+++ b/tools/Precept.LanguageServer/PreceptDocumentIntellisense.cs
@@ -264,6 +264,28 @@ internal static class PreceptDocumentIntellisense
             return true;
         }
 
+        if (string.Equals(identifier, "length", StringComparison.Ordinal) &&
+            info.Declarations.Fields.TryGetValue(leftIdentifier, out var stringFieldDecl) &&
+            info.FieldTypeKinds.TryGetValue(leftIdentifier, out var fieldKind) &&
+            (fieldKind & StaticValueKind.String) != 0)
+        {
+            var isNullable = (fieldKind & StaticValueKind.Null) != 0;
+            var doc = isNullable
+                ? $"```precept\n{leftIdentifier}.length\n```\n\nString accessor returning `number` (UTF-16 code unit count).\nRequires null guard: `{leftIdentifier} != null and {leftIdentifier}.length ...`"
+                : $"```precept\n{leftIdentifier}.length\n```\n\nString accessor returning `number` (UTF-16 code unit count).";
+            resolved = new PreceptResolvedSymbol(
+                new PreceptDeclaredSymbol(
+                    $"{leftIdentifier}.length",
+                    PreceptDeclaredSymbolKind.CollectionAccessor,
+                    "number",
+                    stringFieldDecl.Range,
+                    stringFieldDecl.SelectionRange,
+                    stringFieldDecl.ContainerName,
+                    doc),
+                referenceRange);
+            return true;
+        }
+
         return false;
     }
 

--- a/tools/Precept.VsCode/package.json
+++ b/tools/Precept.VsCode/package.json
@@ -165,7 +165,8 @@
 
     "configurationDefaults": {
       "[precept]": {
-        "editor.semanticHighlighting.enabled": true
+        "editor.semanticHighlighting.enabled": true,
+        "editor.wordBasedSuggestions": "off"
       },
       "editor.semanticTokenColorCustomizations": {
         "rules": {
@@ -199,7 +200,7 @@
             { "scope": "constant.other.value.precept",           "settings": { "foreground": "#84929F" } },
             { "scope": "constant.language.precept",              "settings": { "foreground": "#84929F" } },
             { "scope": "constant.numeric.precept",               "settings": { "foreground": "#84929F" } },
-            { "scope": "entity.name.precept.message.precept",    "settings": { "foreground": "#FBBF24" } },
+            { "scope": "entity.name.precept.message.precept",    "settings": { "foreground": "#B0BEC5", "fontStyle": "bold" } },
             { "scope": "string.quoted.double.precept",           "settings": { "foreground": "#84929F" } },
             { "scope": "string.quoted.double.message.precept",   "settings": { "foreground": "#FBBF24" } },
             { "scope": "keyword.operator.comparison.precept",    "settings": { "foreground": "#6366F1" } },


### PR DESCRIPTION
## Summary

Retroactive review of merged language PRs (#48, #50+#53, #56, #57) plus a comprehensive completions audit.

### Review fixes (prior commits)
- PR #56: diagnostic message uses keyword operators, hover/completions gaps, MCP test coverage
- PR #56: close remaining review gaps

### Completions overhaul (this session)

**6 gap fixes:**
- Pipeline `->` offered after completed set/add expressions
- `on` at line start suggests event names
- Top-level fallback narrowed to declaration/control keywords only
- `ScalarTypeItems` expanded with integer, decimal, choice
- Comment lines suppress all completions
- Event arg regexes updated for integer/decimal/choice types

**Pre-precept scope:**
- Blank/new files only offer `precept` keyword (not full keyword list)

**19 new tests:**
- 7 drift tests mapping TokenCategory to completion lists (prevents future sync drift)
- 9 behavioral tests covering all gap fixes
- 3 pre-precept scope tests

**Extension UX:**
- Suppress VS Code word-based suggestions for .precept files
- Fix precept name color: gold -> bright slate bold (brand-spec alignment)

**Test results:** 1,043/1,044 pass (1 pre-existing failure from scratch file)