### PR TITLE
feat: allow field and event arg modifiers in any order

### DIFF
--- a/.squad/agents/frank/history.md
+++ b/.squad/agents/frank/history.md
@@ -7,6 +7,19 @@
 - Technical-surface work flows through Elaine (UX), Peterman (brand compliance), Frank (architectural fit), then Shane (sign-off).
 - README and brand-spec changes should reflect actual runtime semantics, not speculative future behavior.
 
+## Learnings
+
+### 2026-04-11 — Modifier any-order investigation (Issue #13)
+- **Key architecture finding:** The fixed modifier order (`nullable → default → constraints → ordered`) is enforced ONLY by two parser combinator chains (`FieldDecl` line 697, `EventArg` line 774). Model types, type checker, runtime, grammar, and MCP are all already order-independent.
+- **Constraint zone is already any-order:** `ConstraintSuffix.Many()` already allows constraints in any order. The rigidity is only between the four zones (nullable, default, constraints, ordered).
+- **Completions are the heavy lift:** `PreceptAnalyzer.cs` has ~30 regex patterns that hardcode position-dependent modifier sequences. These must be replaced with a dynamic "remaining modifiers" approach. The parser change itself is ~50 lines.
+- **Doc inconsistency found:** `PreceptLanguageDesign.md` prose says constraints appear "between the type (and `nullable`) and the `default` clause" but the grammar spec and parser put default BEFORE constraints. Needs correction regardless of this issue.
+- **Implementation approach:** Discriminated union `FieldModifier` with `.Many()` combinator. Extract properties from modifier list post-parse. Duplicate modifier detection via type checker (consistent with C58 precedent).
+- **Event arg comma boundary:** Superpower's `.Many()` uses `TryParse` internally — modifier parsing naturally stops at comma delimiters. Needs explicit test verification.
+- **Collection fields unaffected:** They only take constraints (no nullable/default/ordered), so they're already flexible.
+- **Recommended slicing:** (A) parser + type checker + tests, (B) completions rework, (C) docs.
+- Full analysis: `.squad/decisions/inbox/frank-modifier-any-order-investigation.md`
+
 ## Recent Updates
 
 ### 2026-04-12 — Event hooks gap investigation + external FSM precedent survey

--- a/docs/ConstraintViolationDesign.md
+++ b/docs/ConstraintViolationDesign.md
@@ -642,6 +642,7 @@ Compile-phase and parse-phase diagnostics (DSL validity checks) use a separate v
 | C50 / PRECEPT050 | compile | Warning | Non-terminal state has outgoing rows but none can reach another state. Upgraded from `Hint` to `Warning` (2026-04-08). Rationale: a state where every outgoing path dead-ends is a structural smell that warrants author attention, not just an informational note. Consistent with the severity model for C49 (same kind of structural quality problem). |
 | C55 / PRECEPT055 | compile | Error | Root-level `edit` is not valid when states are declared. Message: `"Root-level \`edit\` is not valid when states are declared. Use \`in any edit all\` or \`in <State> edit <Fields>\` instead."` |
 | C69 / PRECEPT069 | compile | Error | Cross-scope guard reference in `when` clause. Guard expression references an identifier that belongs to a different scope than the declaration's guard allows. Invariant/state-assert/edit guards are entity-field-scoped; event-assert guards are event-arg-scoped. |
+| C70 / PRECEPT070 | parse | Error | Duplicate modifier on field or event argument declaration. Each modifier (`nullable`, `default`, `ordered`) may appear at most once per declaration. |
 
 **Distinction from runtime violations:** These are compile-time diagnostics, not runtime `ConstraintViolation` objects. They are reported during `PreceptCompiler.CompileFromText()` and surfaced via the language server (squiggles), MCP `precept_compile`, and CLI. They do not produce `ConstraintViolation` instances.
 

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -191,14 +191,13 @@ Statement          := FieldDecl | Invariant | StateDecl | StateAssert | StateAct
                     | EditDecl | EventDecl | EventAssert | TransitionRow
                     | Comment | Blank
 
-FieldDecl          := "field" Identifier ("," Identifier)* "as" TypeRef NullableOpt DefaultOpt ConstraintSuffix*
-NullableOpt        := ("nullable")?
+FieldDecl          := "field" Identifier ("," Identifier)* "as" TypeRef FieldModifier*
+FieldModifier      := "nullable" | "default" LiteralOrList | ConstraintSuffix | "ordered"
 ConstraintSuffix   := "nonnegative" | "positive" | "notempty"
                     | "min" NumberLiteral | "max" NumberLiteral
                     | "minlength" IntegerLiteral | "maxlength" IntegerLiteral
                     | "mincount" IntegerLiteral | "maxcount" IntegerLiteral
-                    | "maxplaces" IntegerLiteral | "ordered"
-DefaultOpt         := ("default" LiteralOrList)?
+                    | "maxplaces" IntegerLiteral
 
 Invariant          := "invariant" BoolExpr WhenOpt "because" StringLiteral
 
@@ -235,7 +234,7 @@ FieldTarget        := "all" | Identifier ("," Identifier)*
 
 EventDecl          := "event" Identifier ("," Identifier)* ("with" ArgList)?
 ArgList            := ArgDecl ("," ArgDecl)*
-ArgDecl            := Identifier "as" TypeRef NullableOpt DefaultOpt ConstraintSuffix*
+ArgDecl            := Identifier "as" TypeRef FieldModifier*
 
 EventAssert        := "on" Identifier "assert" BoolExpr WhenOpt "because" StringLiteral
 
@@ -512,10 +511,10 @@ from Draft on Submit when EmployeeName != null and AccessReason != null and Acce
 
 Forms:
 
-- `field <Name> as <Type> [nullable] [default <Literal>] [<constraint>...]`
-- `field <Name>, <Name>, ... as <Type> [nullable] [default <Literal>] [<constraint>...]`
+- `field <Name> as <Type> [<modifier>...]`
+- `field <Name>, <Name>, ... as <Type> [<modifier>...]`
 
-Multi-name declarations declare multiple fields sharing the same type, nullability, and default value. The type, `nullable`, and `default` clauses apply uniformly to every name in the list.
+Modifiers (`nullable`, `default <value>`, and constraint keywords) may appear in **any order** after the type. Each modifier may appear at most once per declaration (C70). Multi-name declarations declare multiple fields sharing the same type and modifiers.
 
 Defaults:
 - Non-nullable scalar fields must declare a `default ...`.

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -545,4 +545,14 @@ public static class DiagnosticCatalog
         "C69", "compile",
         "Cross-scope guard reference in when clause.",
         "Guard expression references '{name}' which belongs to a different scope. Invariant and edit guards can only reference entity fields; event assert guards can only reference event arguments.");
+
+    // ═══════════════════════════════════════════════════════════════
+    // Modifier diagnostics (C70+)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>Duplicate modifier on field or event argument declaration.</summary>
+    public static readonly LanguageConstraint C70 = Register(
+        "C70", "parse",
+        "Duplicate modifier on field or event argument declaration.",
+        "Duplicate modifier '{modifier}' on '{name}'. Each modifier may appear at most once per declaration.");
 }

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -828,7 +828,7 @@ public static class PreceptParser
         .Named("field declaration")
             .Register(new ConstructInfo(
                 "field-declaration",
-                "field <Name>[, <Name>, ...] as <Type> [nullable] [default <Value>]",
+                "field <Name>[, <Name>, ...] as <Type> [<modifier>...]",
                 "top-level",
                 "Declares a scalar or collection data field",
                 "field Priority as number default 3"));
@@ -897,7 +897,7 @@ public static class PreceptParser
         .Named("event declaration")
             .Register(new ConstructInfo(
                 "event-declaration",
-                "event <Name>[, <Name>, ...] [with <Arg> as <Type> [nullable] [default <Val>], ...]",
+                "event <Name>[, <Name>, ...] [with <Arg> as <Type> [<modifier>...], ...]",
                 "top-level",
                 "Declares an external trigger with optional typed arguments",
                 "event Submit with Comment as string"));

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -85,7 +85,20 @@ public static class PreceptParser
             return (null, diagnostics);
         }
 
-        var result = RawFileParser.TryParse(tokens);
+        Superpower.Model.TokenListParserResult<PreceptToken, ((string Name, int SourceLine) Header, StatementResult[] Statements)> result;
+        try
+        {
+            result = RawFileParser.TryParse(tokens);
+        }
+        catch (ConstraintViolationException cve)
+        {
+            // ConstraintViolationException may be thrown from modifier extraction during parsing
+            // (e.g. C70 duplicate modifier detection in BuildFieldResult/BuildEventArgResult).
+            var cveLine = cve.SourceLine > 0 ? cve.SourceLine : 1;
+            diagnostics.Add(new ParseDiagnostic(cveLine, 0, cve.Message, DiagnosticCatalog.ToDiagnosticCode(cve.Constraint.Id)));
+            return (null, diagnostics);
+        }
+
         if (result.HasValue && result.Remainder.IsAtEnd)
         {
             try
@@ -516,6 +529,115 @@ public static class PreceptParser
             select (FieldConstraint)new FieldConstraint.Maxplaces((int)n.ToNumberValue()));
 
     // ═══════════════════════════════════════════════════════════════════
+    // Unified Field Modifier Parser (any-order modifiers)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Discriminated union for any modifier that can follow a type reference.
+    /// Parsed via <c>.Many()</c> to allow any-order specification.
+    /// </summary>
+    private abstract record FieldModifier;
+    private sealed record NullableModifier : FieldModifier;
+    private sealed record DefaultModifier(object? Value) : FieldModifier;
+    private sealed record ConstraintModifier(FieldConstraint Constraint) : FieldModifier;
+    private sealed record OrderedModifier : FieldModifier;
+
+    /// <summary>
+    /// Parses a single field modifier (nullable, default, constraint, or ordered) for field declarations.
+    /// Uses <see cref="DefaultValue"/> which supports both scalar and list literals.
+    /// </summary>
+    private static readonly TokenListParser<PreceptToken, FieldModifier> AnyFieldModifier =
+        Token.EqualTo(PreceptToken.Nullable).Value((FieldModifier)new NullableModifier()).Try()
+        .Or(Token.EqualTo(PreceptToken.Default)
+            .IgnoreThen(DefaultValue)
+            .Select(v => (FieldModifier)new DefaultModifier(v)).Try())
+        .Or(ConstraintSuffix.Select(c => (FieldModifier)new ConstraintModifier(c)).Try())
+        .Or(Token.EqualTo(PreceptToken.Ordered).Value((FieldModifier)new OrderedModifier()));
+
+    /// <summary>
+    /// Parses a single field modifier for event argument declarations.
+    /// Uses <see cref="ScalarLiteral"/> (no list literals for event args).
+    /// </summary>
+    private static readonly TokenListParser<PreceptToken, FieldModifier> AnyEventArgModifier =
+        Token.EqualTo(PreceptToken.Nullable).Value((FieldModifier)new NullableModifier()).Try()
+        .Or(Token.EqualTo(PreceptToken.Default)
+            .IgnoreThen(ScalarLiteral)
+            .Select(v => (FieldModifier)new DefaultModifier(v)).Try())
+        .Or(ConstraintSuffix.Select(c => (FieldModifier)new ConstraintModifier(c)).Try())
+        .Or(Token.EqualTo(PreceptToken.Ordered).Value((FieldModifier)new OrderedModifier()));
+
+    /// <summary>
+    /// Extracts typed modifier properties from a flat array of <see cref="FieldModifier"/> values.
+    /// Detects duplicate modifiers and throws <see cref="ConstraintViolationException"/> (C70).
+    /// </summary>
+    private static (bool IsNullable, bool HasDefault, object? DefaultValue, FieldConstraint[] Constraints, bool IsOrdered)
+        ExtractModifiers(FieldModifier[] modifiers, string firstName, int sourceLine)
+    {
+        // SYNC:CONSTRAINT:C70
+        if (modifiers.OfType<NullableModifier>().Count() > 1)
+            throw DiagnosticCatalog.C70.ToException(sourceLine, ("modifier", "nullable"), ("name", firstName));
+        if (modifiers.OfType<DefaultModifier>().Count() > 1)
+            throw DiagnosticCatalog.C70.ToException(sourceLine, ("modifier", "default"), ("name", firstName));
+        if (modifiers.OfType<OrderedModifier>().Count() > 1)
+            throw DiagnosticCatalog.C70.ToException(sourceLine, ("modifier", "ordered"), ("name", firstName));
+
+        var isNullable = modifiers.OfType<NullableModifier>().Any();
+        var dflt = modifiers.OfType<DefaultModifier>().FirstOrDefault();
+        var constraints = modifiers.OfType<ConstraintModifier>().Select(m => m.Constraint).ToArray();
+        var isOrdered = modifiers.OfType<OrderedModifier>().Any();
+        return (isNullable, dflt is not null, dflt?.Value, constraints, isOrdered);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="StatementResult"/> from parsed field declaration components.
+    /// Called from the <see cref="FieldDecl"/> combinator's select clause.
+    /// </summary>
+    private static StatementResult BuildFieldResult(
+        Token<PreceptToken> kw,
+        Token<PreceptToken>[] names,
+        (bool IsCollection, PreceptScalarType ScalarType, PreceptCollectionKind? CollectionKind, IReadOnlyList<string>? ChoiceValues) typeRef,
+        FieldModifier[] modifiers)
+    {
+        int sourceLine = kw.Span.Position.Line;
+        var (nullable, hasDefault, defaultValue, constraints, ordered) = ExtractModifiers(modifiers, names[0].ToText(), sourceLine);
+
+        if (typeRef.IsCollection)
+            return new CollectionFieldResult(
+                names.Select(n => new PreceptCollectionField(
+                    n.ToText(), typeRef.CollectionKind!.Value, typeRef.ScalarType,
+                    constraints.Length > 0 ? constraints : null,
+                    typeRef.ChoiceValues,
+                    SourceLine: sourceLine)).ToArray());
+
+        return new FieldResult(
+            names.Select(n => new PreceptField(
+                n.ToText(), typeRef.ScalarType, nullable,
+                hasDefault || nullable,
+                hasDefault ? defaultValue : null,
+                constraints.Length > 0 ? constraints : null,
+                typeRef.ChoiceValues, ordered,
+                SourceLine: sourceLine)).ToArray());
+    }
+
+    /// <summary>
+    /// Builds a <see cref="PreceptEventArg"/> from parsed event argument components.
+    /// Called from the <see cref="EventArg"/> combinator's select clause.
+    /// </summary>
+    private static PreceptEventArg BuildEventArgResult(
+        Token<PreceptToken> name,
+        (PreceptScalarType Type, IReadOnlyList<string>? ChoiceValues) typeRef,
+        FieldModifier[] modifiers)
+    {
+        var (nullable, hasDefault, defaultValue, constraints, ordered) = ExtractModifiers(modifiers, name.ToText(), name.Span.Position.Line);
+        return new PreceptEventArg(name.ToText(), typeRef.Type, nullable,
+            hasDefault,
+            hasDefault ? defaultValue : null,
+            constraints.Length > 0 ? constraints : null,
+            typeRef.ChoiceValues, ordered,
+            SourceLine: name.Span.Position.Line);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     // State Target Parser
     // ═══════════════════════════════════════════════════════════════════
 
@@ -694,32 +816,15 @@ public static class PreceptParser
                 "Names the workflow",
                 "precept BugTracker"));
 
-    // field <Name>[, <Name>, ...] as <Type> [nullable] [default <Value>] [constraint...] [ordered]
+    // field <Name>[, <Name>, ...] as <Type> [modifier...] (nullable, default, constraints, ordered — any order)
     private static readonly TokenListParser<PreceptToken, StatementResult> FieldDecl =
         (from kw in Token.EqualTo(PreceptToken.Field)
          from names in Token.EqualTo(PreceptToken.Identifier)
              .AtLeastOnceDelimitedBy(Token.EqualTo(PreceptToken.Comma))
          from _ in Token.EqualTo(PreceptToken.As)
          from typeRef in TypeRef
-         from nullable in Token.EqualTo(PreceptToken.Nullable).Value(true).OptionalOrDefault(false)
-         from dflt in OptionalDefault
-         from constraints in ConstraintSuffix.Many()
-         from ordered in Token.EqualTo(PreceptToken.Ordered).Value(true).OptionalOrDefault(false)
-         select typeRef.IsCollection
-            ? (StatementResult)new CollectionFieldResult(
-                names.Select(n => new PreceptCollectionField(
-                    n.ToText(), typeRef.CollectionKind!.Value, typeRef.ScalarType,
-                    constraints.Length > 0 ? constraints : null,
-                    typeRef.ChoiceValues,
-                    SourceLine: kw.Span.Position.Line)).ToArray())
-            : new FieldResult(
-                names.Select(n => new PreceptField(
-                    n.ToText(), typeRef.ScalarType, nullable,
-                    dflt.Specified || nullable,
-                    dflt.Specified ? dflt.Value : null,
-                    constraints.Length > 0 ? constraints : null,
-                    typeRef.ChoiceValues, ordered,
-                    SourceLine: kw.Span.Position.Line)).ToArray()))
+         from modifiers in AnyFieldModifier.Many()
+         select BuildFieldResult(kw, names, typeRef, modifiers))
         .Named("field declaration")
             .Register(new ConstructInfo(
                 "field-declaration",
@@ -771,21 +876,13 @@ public static class PreceptParser
                 "state Idle initial"));
 
     // event <Name> [with <ArgList>]
-    // where ArgList = Name as Type [nullable] [default val] [constraint...] [ordered] separated by commas
+    // where ArgList = Name as Type [modifier...] (nullable, default, constraints, ordered — any order) separated by commas
     private static readonly TokenListParser<PreceptToken, PreceptEventArg> EventArg =
         from name in Token.EqualTo(PreceptToken.Identifier)
         from _ in Token.EqualTo(PreceptToken.As)
         from typeRef in ScalarTypeOrChoice
-        from nullable in Token.EqualTo(PreceptToken.Nullable).Value(true).OptionalOrDefault(false)
-        from dflt in OptionalScalarDefault
-        from constraints in ConstraintSuffix.Many()
-        from ordered in Token.EqualTo(PreceptToken.Ordered).Value(true).OptionalOrDefault(false)
-        select new PreceptEventArg(name.ToText(), typeRef.Type, nullable,
-            dflt.Specified,
-            dflt.Specified ? dflt.Value : null,
-            constraints.Length > 0 ? constraints : null,
-            typeRef.ChoiceValues, ordered,
-            SourceLine: name.Span.Position.Line);
+        from modifiers in AnyEventArgModifier.Many()
+        select BuildEventArgResult(name, typeRef, modifiers);
 
     private static readonly TokenListParser<PreceptToken, StatementResult> EventDecl =
         (from kw in Token.EqualTo(PreceptToken.Event)

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -436,7 +436,8 @@ public class PreceptAnalyzerCompletionTests
         var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
 
         completions.Should().Contain(",");
-        completions.Should().HaveCount(1);
+        completions.Should().Contain("nullable", "any-order: nullable is valid after default");
+        completions.Should().NotContain("default", "already present in the declaration");
     }
 
     [Fact]
@@ -729,8 +730,8 @@ public class PreceptAnalyzerCompletionTests
         completions.Should().Contain("positive");
         completions.Should().Contain("min");
         completions.Should().Contain("max");
-        completions.Should().NotContain("nullable");
-        completions.Should().NotContain("default");
+        completions.Should().Contain("nullable", "any-order: nullable is valid after default");
+        completions.Should().NotContain("default", "already present in the declaration");
         completions.Should().NotContain("notempty");
     }
 
@@ -745,10 +746,12 @@ public class PreceptAnalyzerCompletionTests
         var (code, position) = ExtractPosition(text);
         var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
 
-        completions.Should().Contain("nonnegative");
         completions.Should().Contain("positive");
         completions.Should().Contain("min");
         completions.Should().Contain("max");
+        completions.Should().Contain("nullable", "any-order: nullable is valid after constraints");
+        completions.Should().Contain("default", "any-order: default is valid after constraints");
+        completions.Should().NotContain("nonnegative", "already present in the declaration");
         completions.Should().NotContain("notempty");
     }
 
@@ -766,8 +769,8 @@ public class PreceptAnalyzerCompletionTests
         completions.Should().Contain("notempty");
         completions.Should().Contain("minlength");
         completions.Should().Contain("maxlength");
-        completions.Should().NotContain("nullable");
-        completions.Should().NotContain("default");
+        completions.Should().Contain("nullable", "any-order: nullable is valid after default");
+        completions.Should().NotContain("default", "already present in the declaration");
         completions.Should().NotContain("nonnegative");
     }
 
@@ -1470,5 +1473,79 @@ public class PreceptAnalyzerCompletionTests
         var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
 
         completions.Should().Contain("because");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // COMPLETIONS — Any-order field modifier suggestions
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Completions_FieldAfterConstraintThenDefault_OffersNullableAndRemainingConstraints()
+    {
+        const string text = """
+            precept M
+            field Amount as number nonnegative default 5 $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("nullable", "any-order: nullable valid after default");
+        completions.Should().Contain("positive");
+        completions.Should().Contain("min");
+        completions.Should().Contain("max");
+        completions.Should().NotContain("default", "already present");
+        completions.Should().NotContain("nonnegative", "already present");
+    }
+
+    [Fact]
+    public void Completions_FieldNullableThenConstraint_OffersDefaultAndRemainingConstraints()
+    {
+        const string text = """
+            precept M
+            field Notes as string nullable notempty $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("default", "any-order: default valid after constraints");
+        completions.Should().Contain("minlength");
+        completions.Should().Contain("maxlength");
+        completions.Should().NotContain("nullable", "already present");
+        completions.Should().NotContain("notempty", "already present");
+    }
+
+    [Fact]
+    public void Completions_FieldAllModifiersExhausted_OffersNothing()
+    {
+        const string text = """
+            precept M
+            field Active as boolean nullable default false $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().BeEmpty("boolean has no constraints; nullable and default already present");
+    }
+
+    [Fact]
+    public void Completions_EventArgAfterConstraint_OffersNullableDefaultAndComma()
+    {
+        const string text = """
+            precept M
+            state A initial
+            event Submit with Amount as number nonnegative $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("nullable");
+        completions.Should().Contain("default");
+        completions.Should().Contain(",");
+        completions.Should().Contain("positive");
+        completions.Should().NotContain("nonnegative", "already present");
     }
 }

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -1548,4 +1548,20 @@ public class PreceptAnalyzerCompletionTests
         completions.Should().Contain("positive");
         completions.Should().NotContain("nonnegative", "already present");
     }
+
+    [Fact]
+    public void Completions_ChoiceFieldAfterOrdered_OffersNullableDefaultNotOrdered()
+    {
+        const string text = """
+            precept M
+            field Priority as choice("Low", "Medium", "High") ordered $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("nullable");
+        completions.Should().Contain("default");
+        completions.Should().NotContain("ordered", "already present in the declaration");
+    }
 }

--- a/test/Precept.LanguageServer.Tests/PreceptIntellisenseNavigationTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptIntellisenseNavigationTests.cs
@@ -71,7 +71,7 @@ public class PreceptIntellisenseNavigationTests
         var hover = PreceptDocumentIntellisense.CreateHover(info, position);
 
         hover.Should().NotBeNull();
-        hover!.Contents.ToString().Should().Contain("field <Name>[, <Name>, ...] as <Type> [nullable] [default <Value>]");
+        hover!.Contents.ToString().Should().Contain("field <Name>[, <Name>, ...] as <Type> [<modifier>...]");
         hover.Contents.ToString().Should().Contain("Declares a scalar or collection data field");
     }
 

--- a/test/Precept.Tests/CatalogDriftTests.cs
+++ b/test/Precept.Tests/CatalogDriftTests.cs
@@ -598,6 +598,10 @@ public class CatalogDriftTests
             "invariant X >= 0 when Go.Amount > 0 because \"bad\"\n" +
             "from A on Go -> no transition\n", "different scope"),
 
+        // C70: duplicate modifier on field/arg declaration
+        ["C70"] = new(H + "field X as number default 0 default 1\n" + S2 +
+            "event Go\nfrom A on Go -> no transition\n", "Duplicate modifier"),
+
         // ── Runtime-phase (C33–C37) ───────────────────────────────────
 
         // C33: CreateInstance with empty initial state
@@ -1344,6 +1348,9 @@ public class CatalogDriftTests
 
         // C69: cross-scope guard reference — invariant on line 4
         ["C69"] = ("precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go with Amount as number\ninvariant X >= 0 when Go.Amount > 0 because \"bad\"\nfrom A on Go -> no transition\n", "compile", 6),
+
+        // C70: duplicate modifier — field on line 2
+        ["C70"] = ("precept Test\nfield X as number default 0 default 1\nstate A initial\n", "parse", 2),
     };
 
     [Theory]

--- a/test/Precept.Tests/NewSyntaxParserTests.cs
+++ b/test/Precept.Tests/NewSyntaxParserTests.cs
@@ -1758,4 +1758,278 @@ public class NewSyntaxParserTests
         sa.WhenText.Should().NotBeNull();
         sa.Reason.Should().Be("Notes required before leaving Draft");
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // PARSING — Any-order field modifiers
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_FieldModifiers_DefaultBeforeNullable()
+    {
+        const string dsl = """
+            precept Test
+            field Name as string default "unknown" nullable
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.Name.Should().Be("Name");
+        f.IsNullable.Should().BeTrue();
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be("unknown");
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_ConstraintBeforeDefault()
+    {
+        const string dsl = """
+            precept Test
+            field Amount as number nonnegative default 5
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be(5.0);
+        f.Constraints.Should().Contain(c => c is FieldConstraint.Nonnegative);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_ConstraintBeforeNullable()
+    {
+        const string dsl = """
+            precept Test
+            field Notes as string maxlength 500 nullable
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.IsNullable.Should().BeTrue();
+        f.Constraints.OfType<FieldConstraint.Maxlength>().Should().ContainSingle().Which.Value.Should().Be(500);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_ConstraintThenDefaultThenNullable()
+    {
+        const string dsl = """
+            precept Test
+            field Score as number min 0 default 10 nullable
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.IsNullable.Should().BeTrue();
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be(10.0);
+        f.Constraints.OfType<FieldConstraint.Min>().Should().ContainSingle().Which.Value.Should().Be(0);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_NullableBeforeConstraint()
+    {
+        const string dsl = """
+            precept Test
+            field Label as string nullable notempty
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.IsNullable.Should().BeTrue();
+        f.Constraints.Should().Contain(c => c is FieldConstraint.Notempty);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_DefaultBetweenConstraints()
+    {
+        const string dsl = """
+            precept Test
+            field Amount as number min 0 default 50 max 100
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be(50.0);
+        f.Constraints.Should().HaveCount(2);
+        f.Constraints.OfType<FieldConstraint.Min>().Should().ContainSingle().Which.Value.Should().Be(0);
+        f.Constraints.OfType<FieldConstraint.Max>().Should().ContainSingle().Which.Value.Should().Be(100);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_MultipleConstraintsThenNullableThenDefault()
+    {
+        const string dsl = """
+            precept Test
+            field Bio as string notempty maxlength 1000 nullable default "N/A"
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.IsNullable.Should().BeTrue();
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be("N/A");
+        f.Constraints.Should().HaveCount(2);
+        f.Constraints.Should().Contain(c => c is FieldConstraint.Notempty);
+        f.Constraints.Should().Contain(c => c is FieldConstraint.Maxlength);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_ChoiceOrderedBeforeDefault()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as choice("Low", "Medium", "High") ordered default "Low"
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be("Low");
+        f.IsOrdered.Should().BeTrue();
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // PARSING — Any-order event argument modifiers
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_EventArgModifiers_DefaultBeforeNullable()
+    {
+        const string dsl = """
+            precept Test
+            state A initial
+            event Submit with Name as string default "" nullable
+            from A on Submit -> no transition
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var arg = model.Events[0].Args[0];
+
+        arg.IsNullable.Should().BeTrue();
+        arg.HasDefaultValue.Should().BeTrue();
+        arg.DefaultValue.Should().Be("");
+    }
+
+    [Fact]
+    public void Parse_EventArgModifiers_ConstraintBeforeDefault()
+    {
+        const string dsl = """
+            precept Test
+            state A initial
+            event Deposit with Amount as number nonnegative default 0
+            from A on Deposit -> no transition
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var arg = model.Events[0].Args[0];
+
+        arg.HasDefaultValue.Should().BeTrue();
+        arg.DefaultValue.Should().Be(0.0);
+        arg.Constraints.Should().Contain(c => c is FieldConstraint.Nonnegative);
+    }
+
+    [Fact]
+    public void Parse_EventArgModifiers_NullableAfterConstraint()
+    {
+        const string dsl = """
+            precept Test
+            state A initial
+            event Update with Label as string notempty nullable
+            from A on Update -> no transition
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var arg = model.Events[0].Args[0];
+
+        arg.IsNullable.Should().BeTrue();
+        arg.Constraints.Should().Contain(c => c is FieldConstraint.Notempty);
+    }
+
+    [Fact]
+    public void Parse_EventArgModifiers_MultiArgsMixedOrder()
+    {
+        const string dsl = """
+            precept Test
+            state A initial
+            event Submit with Amount as number min 0 default 10, Label as string nullable notempty
+            from A on Submit -> no transition
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+
+        var amount = model.Events[0].Args.Single(a => a.Name == "Amount");
+        amount.HasDefaultValue.Should().BeTrue();
+        amount.DefaultValue.Should().Be(10.0);
+        amount.Constraints.Should().Contain(c => c is FieldConstraint.Min);
+
+        var label = model.Events[0].Args.Single(a => a.Name == "Label");
+        label.IsNullable.Should().BeTrue();
+        label.Constraints.Should().Contain(c => c is FieldConstraint.Notempty);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // PARSING — C70: Duplicate modifier detection
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ParseWithDiagnostics_DuplicateDefault_ProducesC70()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0 default 1
+            state A initial
+            """;
+
+        var (model, diagnostics) = PreceptParser.ParseWithDiagnostics(dsl);
+
+        model.Should().BeNull();
+        diagnostics.Should().ContainSingle(d => d.Code == "PRECEPT070");
+    }
+
+    [Fact]
+    public void ParseWithDiagnostics_DuplicateNullable_ProducesC70()
+    {
+        const string dsl = """
+            precept Test
+            field X as string nullable nullable
+            state A initial
+            """;
+
+        var (model, diagnostics) = PreceptParser.ParseWithDiagnostics(dsl);
+
+        model.Should().BeNull();
+        diagnostics.Should().ContainSingle(d => d.Code == "PRECEPT070");
+    }
+
+    [Fact]
+    public void ParseWithDiagnostics_DuplicateEventArgModifier_ProducesC70()
+    {
+        const string dsl = """
+            precept Test
+            state A initial
+            event Go with X as number default 0 default 1
+            from A on Go -> no transition
+            """;
+
+        var (model, diagnostics) = PreceptParser.ParseWithDiagnostics(dsl);
+
+        model.Should().BeNull();
+        diagnostics.Should().ContainSingle(d => d.Code == "PRECEPT070");
+    }
 }

--- a/test/Precept.Tests/NewSyntaxParserTests.cs
+++ b/test/Precept.Tests/NewSyntaxParserTests.cs
@@ -1904,6 +1904,43 @@ public class NewSyntaxParserTests
         f.IsOrdered.Should().BeTrue();
     }
 
+    [Fact]
+    public void Parse_FieldModifiers_DecimalMaxplacesBeforeDefault()
+    {
+        const string dsl = """
+            precept Test
+            field Price as decimal maxplaces 2 default 0.00
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var f = model.Fields[0];
+
+        f.HasDefaultValue.Should().BeTrue();
+        f.DefaultValue.Should().Be(0.00);
+        f.Constraints.OfType<FieldConstraint.Maxplaces>().Should().ContainSingle().Which.Places.Should().Be(2);
+    }
+
+    [Fact]
+    public void Parse_FieldModifiers_MultiNameWithNonStandardOrder()
+    {
+        const string dsl = """
+            precept Test
+            field X, Y as number nonnegative default 0
+            state A initial
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+
+        model.Fields.Should().HaveCount(2);
+        foreach (var f in model.Fields)
+        {
+            f.HasDefaultValue.Should().BeTrue();
+            f.DefaultValue.Should().Be(0.0);
+            f.Constraints.Should().Contain(c => c is FieldConstraint.Nonnegative);
+        }
+    }
+
     // ════════════════════════════════════════════════════════════════════
     // PARSING — Any-order event argument modifiers
     // ════════════════════════════════════════════════════════════════════
@@ -2025,6 +2062,21 @@ public class NewSyntaxParserTests
             state A initial
             event Go with X as number default 0 default 1
             from A on Go -> no transition
+            """;
+
+        var (model, diagnostics) = PreceptParser.ParseWithDiagnostics(dsl);
+
+        model.Should().BeNull();
+        diagnostics.Should().ContainSingle(d => d.Code == "PRECEPT070");
+    }
+
+    [Fact]
+    public void ParseWithDiagnostics_DuplicateOrdered_ProducesC70()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as choice("Low", "Medium", "High") ordered ordered
+            state A initial
             """;
 
         var (model, diagnostics) = PreceptParser.ParseWithDiagnostics(dsl);

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -275,64 +275,12 @@ internal sealed class PreceptAnalyzer
         if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+(?:set|queue|stack)\s+$", RegexOptions.IgnoreCase))
             return [new CompletionItem { Label = "of", Kind = CompletionItemKind.Keyword }];
 
-        // After "field Name as Type nullable " → suggest "default" + type constraints
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+number\s+nullable\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..NumberConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+string\s+nullable\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..StringConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+boolean\s+nullable\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+integer\s+nullable\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..NumberConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+decimal\s+nullable\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..DecimalConstraintItems];
-
-        // After "field Name as TYPE [nullable] default VALUE " → type constraints only
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+number(?:\s+nullable)?\s+default\s+(?:-?\d+(?:\.\d+)?|true|false|null)\s+$", RegexOptions.IgnoreCase))
-            return NumberConstraintItems;
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+string(?:\s+nullable)?\s+default\s+(?:""[^""\n]*""|\S+)\s+$", RegexOptions.IgnoreCase))
-            return StringConstraintItems;
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+integer(?:\s+nullable)?\s+default\s+(?:-?\d+(?:\.\d+)?|true|false|null)\s+$", RegexOptions.IgnoreCase))
-            return NumberConstraintItems;
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+decimal(?:\s+nullable)?\s+default\s+(?:-?\d+(?:\.\d+)?|true|false|null)\s+$", RegexOptions.IgnoreCase))
-            return DecimalConstraintItems;
-
-        // After already having constraints on a number field → offer more
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+number\b.*\b(?:nonnegative|positive|(?:min|max)\s+\S+)\s+$", RegexOptions.IgnoreCase))
-            return NumberConstraintItems;
-        // After already having constraints on a string field → offer more
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+string\b.*\b(?:notempty|(?:minlength|maxlength)\s+\S+)\s+$", RegexOptions.IgnoreCase))
-            return StringConstraintItems;
-        // After already having constraints on an integer field → offer more
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+integer\b.*\b(?:nonnegative|positive|(?:min|max)\s+\S+)\s+$", RegexOptions.IgnoreCase))
-            return NumberConstraintItems;
-        // After already having constraints on a decimal field → offer more
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+decimal\b.*\b(?:nonnegative|positive|(?:min|max|maxplaces)\s+\S+)\s+$", RegexOptions.IgnoreCase))
-            return DecimalConstraintItems;
-        // After already having ordered on a choice field → nothing more to offer
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+choice\([^)]*\)\b.*\bordered\s+$", RegexOptions.IgnoreCase))
-            return Array.Empty<CompletionItem>();
-
-        // After "field Name as set|queue|stack of TYPE " → collection constraints
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+(?:set|queue|stack)\s+of\s+\w+\s+$", RegexOptions.IgnoreCase))
-            return CollectionConstraintItems;
-        // After already having constraints on a collection field → offer more
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+(?:set|queue|stack)\b.*\b(?:notempty|(?:mincount|maxcount)\s+\S+)\s+$", RegexOptions.IgnoreCase))
-            return CollectionConstraintItems;
-
-        // After "field Name as Type " (scalar type completed) → suggest "nullable", "default", type constraints
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+number\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..NumberConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+string\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..StringConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+boolean\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+integer\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..NumberConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+decimal\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..DecimalConstraintItems];
-        if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+choice\([^)]*\)\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, ..ChoiceConstraintItems];
+        // ── Field modifier zone: any-order modifiers after type ──
+        // Unified handler for all field modifier completions (nullable, default, constraints, ordered).
+        // Detects the field type, scans existing modifiers, offers remaining items.
+        var fieldModifiers = TryGetFieldModifierCompletions(beforeCursor);
+        if (fieldModifiers is not null)
+            return fieldModifiers;
 
         // After "field Name as " (typing type) → suggest type keywords
         if (Regex.IsMatch(beforeCursor, @"^\s*field\s+[A-Za-z_]\w*\s+as\s+\w*$", RegexOptions.IgnoreCase))
@@ -460,34 +408,16 @@ internal sealed class PreceptAnalyzer
                     .Concat(BuildItems(dataFields, CompletionItemKind.Field))
                     .Concat(BuildItems(collectionFields, CompletionItemKind.Field)));
 
-        // After "event Name with Arg as Type [nullable] [default Value] " → suggest delimiter / modifiers
-        // Split by type to include type-appropriate constraint keywords.
-        // The preceding-args pattern uses a broad type alternation to handle all scalar types + choice.
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:number|integer)\\s+nullable\\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..NumberConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+decimal\\s+nullable\\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..DecimalConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+string\\s+nullable\\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, ..StringConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:boolean|choice\\([^)]*\\))\\s+nullable\\s+$", RegexOptions.IgnoreCase))
-            return [DefaultItem, CommaItem];
-
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null)\\s*$", RegexOptions.IgnoreCase))
-            return [CommaItem];
+        // ── Event arg modifier zone: any-order modifiers after type ──
+        // Unified handler for event argument modifier completions (nullable, default, constraints, comma).
+        var eventArgModifiers = TryGetEventArgModifierCompletions(beforeCursor);
+        if (eventArgModifiers is not null)
+            return eventArgModifiers;
 
         // After a comma in an event arg list, the user is starting the next arg name.
         // Avoid unrelated global keyword fallback in this position.
         if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+.*\\,\\s*$", RegexOptions.IgnoreCase))
             return Array.Empty<CompletionItem>();
-
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:number|integer)\\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..NumberConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+decimal\\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..DecimalConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|\\S+))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+string\\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, ..StringConstraintItems, CommaItem];
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:boolean|choice\\([^)]*\\))\\s+$", RegexOptions.IgnoreCase))
-            return [NullableItem, DefaultItem, CommaItem];
 
         // After "event Name with ArgName as " → suggest type keywords
         if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+\\w*$", RegexOptions.IgnoreCase))
@@ -1293,6 +1223,153 @@ internal sealed class PreceptAnalyzer
 
     private static bool EndsWithCompletedExpression(string text)
         => Regex.IsMatch(text, "(?:[A-Za-z0-9_\\)\"]|true|false|null)\\s+$", RegexOptions.IgnoreCase);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Field/Arg Modifier Completion Helpers (any-order modifier support)
+    // ═══════════════════════════════════════════════════════════════════
+
+    // Matches a scalar field declaration in the modifier zone: field Name as <type> <rest...>
+    private static readonly Regex FieldScalarModifierZoneRegex = new(
+        @"^\s*field\s+(?:[A-Za-z_]\w*\s*,\s*)*[A-Za-z_]\w*\s+as\s+(?<type>number|string|boolean|integer|decimal|choice\([^)]*\))\s+(?<rest>.*)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // Matches a collection field declaration in the modifier zone: field Name as set|queue|stack of <inner> <rest...>
+    private static readonly Regex FieldCollectionModifierZoneRegex = new(
+        @"^\s*field\s+(?:[A-Za-z_]\w*\s*,\s*)*[A-Za-z_]\w*\s+as\s+(?:set|queue|stack)\s+of\s+\w+\s+(?<rest>.*)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Detects if the cursor is in a field declaration modifier zone and returns the
+    /// remaining modifiers appropriate for the field type. Returns null if not in modifier zone.
+    /// </summary>
+    private static IReadOnlyList<CompletionItem>? TryGetFieldModifierCompletions(string beforeCursor)
+    {
+        if (!beforeCursor.EndsWith(' '))
+            return null;
+
+        // Try scalar field
+        var scalarMatch = FieldScalarModifierZoneRegex.Match(beforeCursor);
+        if (scalarMatch.Success)
+        {
+            var rest = scalarMatch.Groups["rest"].Value;
+            if (rest.Length > 0 && IsValueExpectingKeyword(rest.TrimEnd().Split(' ')[^1]))
+                return null;
+            return ComputeRemainingModifiers(scalarMatch.Groups["type"].Value, rest, isCollection: false, isEventArg: false);
+        }
+
+        // Try collection field
+        var colMatch = FieldCollectionModifierZoneRegex.Match(beforeCursor);
+        if (colMatch.Success)
+        {
+            var rest = colMatch.Groups["rest"].Value;
+            if (rest.Length > 0 && IsValueExpectingKeyword(rest.TrimEnd().Split(' ')[^1]))
+                return null;
+            return ComputeRemainingModifiers("collection", rest, isCollection: true, isEventArg: false);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Detects if the cursor is in an event argument modifier zone and returns the
+    /// remaining modifiers. Returns null if not in modifier zone.
+    /// </summary>
+    private static IReadOnlyList<CompletionItem>? TryGetEventArgModifierCompletions(string beforeCursor)
+    {
+        if (!beforeCursor.EndsWith(' '))
+            return null;
+
+        var eventMatch = NewEventWithArgsRegex.Match(beforeCursor);
+        if (!eventMatch.Success)
+            return null;
+
+        var argsText = eventMatch.Groups["args"].Value;
+        var lastArg = ExtractLastEventArg(argsText);
+
+        var argTypeMatch = Regex.Match(lastArg,
+            @"^[A-Za-z_][A-Za-z0-9_]*\s+as\s+(?<type>string|number|boolean|integer|decimal|choice\([^)]*\))\s+(?<rest>.*)$",
+            RegexOptions.IgnoreCase);
+        if (!argTypeMatch.Success)
+            return null;
+
+        var rest = argTypeMatch.Groups["rest"].Value;
+        if (rest.Length > 0 && IsValueExpectingKeyword(rest.TrimEnd().Split(' ')[^1]))
+            return null;
+
+        return ComputeRemainingModifiers(argTypeMatch.Groups["type"].Value, rest, isCollection: false, isEventArg: true);
+    }
+
+    /// <summary>
+    /// Extracts the last event argument text from a comma-delimited arg list,
+    /// correctly handling commas inside choice(...) parentheses.
+    /// </summary>
+    private static string ExtractLastEventArg(string argsText)
+    {
+        int depth = 0;
+        int lastComma = -1;
+        for (int i = 0; i < argsText.Length; i++)
+        {
+            switch (argsText[i])
+            {
+                case '(': depth++; break;
+                case ')': depth--; break;
+                case ',' when depth == 0: lastComma = i; break;
+            }
+        }
+        return lastComma >= 0 ? argsText[(lastComma + 1)..].TrimStart() : argsText.TrimStart();
+    }
+
+    private static bool IsValueExpectingKeyword(string word)
+        => word.Equals("default", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("min", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("max", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("minlength", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("maxlength", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("mincount", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("maxcount", StringComparison.OrdinalIgnoreCase) ||
+           word.Equals("maxplaces", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Computes the remaining modifier completions for a field or event argument,
+    /// given the type and any modifiers already present in the text.
+    /// </summary>
+    private static IReadOnlyList<CompletionItem> ComputeRemainingModifiers(
+        string typeStr, string existingModifierText, bool isCollection, bool isEventArg)
+    {
+        bool isChoice = typeStr.StartsWith("choice", StringComparison.OrdinalIgnoreCase);
+        string normalizedType = isCollection ? "collection" : isChoice ? "choice" : typeStr.ToLowerInvariant();
+
+        bool hasNullable = Regex.IsMatch(existingModifierText, @"\bnullable\b", RegexOptions.IgnoreCase);
+        bool hasDefault = Regex.IsMatch(existingModifierText, @"\bdefault\b", RegexOptions.IgnoreCase);
+
+        var items = new List<CompletionItem>();
+
+        if (!isCollection)
+        {
+            if (!hasNullable) items.Add(NullableItem);
+            if (!hasDefault) items.Add(DefaultItem);
+        }
+
+        IReadOnlyList<CompletionItem> constraintPool = normalizedType switch
+        {
+            "number" or "integer" => NumberConstraintItems,
+            "decimal" => DecimalConstraintItems,
+            "string" => StringConstraintItems,
+            "collection" => CollectionConstraintItems,
+            "choice" => ChoiceConstraintItems,
+            _ => Array.Empty<CompletionItem>()
+        };
+
+        foreach (var item in constraintPool)
+        {
+            var keyword = item.Label.Split(' ')[0];
+            if (!Regex.IsMatch(existingModifierText, $@"\b{Regex.Escape(keyword)}\b", RegexOptions.IgnoreCase))
+                items.Add(item);
+        }
+
+        if (isEventArg) items.Add(CommaItem);
+        return items.Count > 0 ? items.ToArray() : Array.Empty<CompletionItem>();
+    }
 
     private static CompletionItem SnippetItem(string label, string snippet, string detail)
         => new()

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -420,11 +420,11 @@ internal sealed class PreceptAnalyzer
             return Array.Empty<CompletionItem>();
 
         // After "event Name with ArgName as " → suggest type keywords
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+\\w*$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+(?:nullable|nonnegative|positive|notempty|ordered|(?:(?:default|min|max|minlength|maxlength|mincount|maxcount|maxplaces)\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null|\\[\"[^\"]*\"(?:,\\s*\"[^\"]*\")*\\]))))*)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+\\w*$", RegexOptions.IgnoreCase))
             return ScalarTypeItems;
 
         // After "event Name with ArgName " → suggest "as"
-        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+nullable)?(?:\\s+default\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null))?)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+$", RegexOptions.IgnoreCase))
+        if (Regex.IsMatch(beforeCursor, "^\\s*event\\s+[A-Za-z_][A-Za-z0-9_]*\\s+with\\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*\\s+as\\s+(?:string|number|boolean|integer|decimal|choice\\([^)]*\\))(?:\\s+(?:nullable|nonnegative|positive|notempty|ordered|(?:(?:default|min|max|minlength|maxlength|mincount|maxcount|maxplaces)\\s+(?:\"[^\"\\n]*\"|-?\\d+(?:\\.\\d+)?|true|false|null|\\[\"[^\"]*\"(?:,\\s*\"[^\"]*\")*\\]))))*)\\s*,\\s*)*[A-Za-z_][A-Za-z0-9_]*\\s+$", RegexOptions.IgnoreCase))
             return [AsItem];
 
         // After "event Name with " → user is typing arg name, no suggestions


### PR DESCRIPTION
## Summary

Modifiers on field declarations and event argument declarations (`nullable`, `default`, constraints like `nonnegative`/`min`/`maxlength`, and `ordered`) can now appear in **any order** after the type. Previously the parser enforced a fixed ordering: `nullable` → `default` → constraints.

Closes #13

## Motivation

The fixed ordering was arbitrary and burdensome — users had to remember that `nullable` and `default` must precede constraints, even though the runtime model is order-independent. A natural declaration like `field Amount as number nonnegative default 5` was a parse error.

## Changes

### Parser (`PreceptParser.cs`)
- Added `FieldModifier` discriminated union (`NullableModifier`, `DefaultModifier`, `ConstraintModifier`, `OrderedModifier`)
- Added `AnyFieldModifier` and `AnyEventArgModifier` combinators using `.Many()` for any-order parsing
- Added `ExtractModifiers` helper that extracts typed properties from the flat modifier array
- Rewrote `FieldDecl` and `EventArg` combinators to use `AnyFieldModifier.Many()` / `AnyEventArgModifier.Many()`

### Diagnostics (`DiagnosticCatalog.cs`)
- Added **C70**: duplicate modifier on field or event argument declaration (nullable, default, ordered)
- Duplicate constraint keywords (e.g. `nonnegative nonnegative`) continue to be caught by existing C58 at compile time

### Completions (`PreceptAnalyzer.cs`)
- Replaced ~40 hardcoded position-dependent regex patterns with two unified helpers:
  - `TryGetFieldModifierCompletions` — detects field modifier zone, returns remaining modifiers
  - `TryGetEventArgModifierCompletions` — same for event arguments
- `ComputeRemainingModifiers` — filters out already-present modifiers and returns type-appropriate completions
- Completions now correctly offer `nullable` and `default` at any position, not just before constraints

### Tests
- **12 new parser tests**: any-order field modifiers (8 permutations), any-order event arg modifiers (4 permutations)
- **3 new C70 tests**: duplicate nullable, duplicate default, duplicate event arg modifier
- **4 new completion tests**: modifiers after constraint+default, exhausted modifiers, event arg after constraint
- **4 existing tests updated** to reflect any-order behavior

### Docs (`PreceptLanguageDesign.md`)
- Grammar updated: `FieldDecl := ... FieldModifier*` (replaces old `NullableOpt DefaultOpt ConstraintSuffix*`)
- `ArgDecl` updated similarly
- Field declaration section notes any-order and C70

## What's NOT changed
- **Model types** (`PreceptField`, `PreceptEventArg`): already order-independent
- **Type checker**: already validates by named property, not position
- **TextMate grammar**: already matches keywords without positional anchoring
- **MCP tools**: no surface change

## Test Results
All 1,183 tests pass (964 core + 145 LS + 74 MCP).