### PR TITLE
feat: comprehensive built-in function library (#16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ tools/Precept.VsCode/server/
 .squad/sessions/
 # Squad: SubSquad activation file (local to this machine)
 .squad-workstream
+
+# Private keys — never commit
+*.pem

--- a/.squad/agents/frank/history.md
+++ b/.squad/agents/frank/history.md
@@ -20,6 +20,13 @@
 - **Recommended slicing:** (A) parser + type checker + tests, (B) completions rework, (C) docs.
 - Full analysis: `.squad/decisions/inbox/frank-modifier-any-order-investigation.md`
 
+### 2026-04-11 — Variadic min/max decision (Issue #16)
+- Updated proposal for comprehensive built-in functions to make min/max variadic (≥ 2 args, no upper limit) per Shane's approved decision.
+- Binary-only min/max was the original draft; variadic is the locked form. The mathematical arity-independence of min/max justifies the exception to fixed-arity signatures.
+- Collection overloads for min/max rejected — `.min`/`.max` accessors already serve that role. Added as explicit exclusion.
+- Key proposal changes: 6 signature updates, new locked decision #8, exclusion rewrite, new semantic rule, teachable error message, acceptance criteria updates, 3-arg example.
+- Decision filed: `.squad/decisions/inbox/frank-variadic-min-max.md`
+
 ## Recent Updates
 
 ### 2026-04-12 — Event hooks gap investigation + external FSM precedent survey

--- a/.squad/agents/newman/history.md
+++ b/.squad/agents/newman/history.md
@@ -183,3 +183,13 @@ Both skills use `precept_language` for syntax authority, handle Mermaid diagrams
 - **JSON shapes match design spec exactly:** no field additions, no name drift
 - **Catalog-driven:** `LanguageTool` uses `ConstructCatalog` + `DiagnosticCatalog` + `PreceptToken` metadata — all single source of truth
 - **DTOs stay in sync:** `ViolationDtoMapper` handles all 4 source types × 5 target types automatically via switch statements
+
+### Issue #16 — MCP function catalog (2026-04-12)
+
+- **`LanguageTool.cs`:** Added `Functions` section to `LanguageResult`. New DTOs: `FunctionDto(Name, Description, Signatures)`, `FunctionSignatureDto(Parameters, ReturnType, IsVariadic)`, `FunctionParamDto(Name, Type, Constraint?)`. Built dynamically from `FunctionRegistry.AllFunctions` — zero hardcoded function metadata in MCP layer.
+- **`FunctionRegistry.cs`:** Added `Description` field to `FunctionDefinition` record. Added `AllFunctions` property. Registered all 18 functions (abs, ceil, clamp, endsWith, floor, left, max, mid, min, pow, right, round, sqrt, startsWith, toLower, toUpper, trim, truncate) with overloads, parameter types, return types, and constraints.
+- **`CompileTool.cs`:** No changes needed. Expressions are string-based via `ExpressionText` / `ReconstituteExpr`. `PreceptFunctionCallExpression` case already exists in parser's `ReconstituteExpr` (produces `"round(Amount, 2)"` etc.). Nested function calls serialize correctly.
+- **`PreceptParser.cs`:** Updated ConstructInfo ID from `round-function` to `function-call`. Updated description to list all 18 available functions. Kept `round` as lead keyword in Form for backward compatibility with `SampleFiles_CoverAllConstructs` drift test.
+- **`StaticValueKind` display:** `FormatValueKind` helper collapses `Number|Integer|Decimal` → `"number"`, surfaces specific types otherwise. `FormatArgConstraint` maps `MustBeIntegerLiteral` → `"must be integer literal"`.
+- **Test impact:** Fixed assertion in `ConstructsIncludeRoundFunction` (checks description contains "built-in function" instead of form starts with "round"). Updated `CatalogDriftTests` switch case for new construct ID. All 1187 tests pass.
+- **Docs note:** `docs/McpServerDesign.md` needs a `functions` section added in the final doc sync slice. The existing `round()` reference table should expand to cover all 18 functions.

--- a/.squad/skills/pr-review/SKILL.md
+++ b/.squad/skills/pr-review/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: "pr-review"
+description: "How to produce and post structured PR reviews with inline code comments via squad-reviewer[bot]. Covers the full review conversation lifecycle: initial review, dev fix replies, re-review verification, and thread resolution — mirroring how humans use GitHub."
+domain: "code review, design review, PR review"
+confidence: "high"
+source: "earned — PR #68 review cycle 2026-04-12; established squad-reviewer GitHub App, structured JSON format, and conversational review lifecycle"
+---
+
+# Skill: PR Review — Conversational Review Lifecycle
+
+## The Problem
+
+AI agent reviews that create new, disconnected threads for re-review don't work like human reviews. Humans comment, devs reply with fixes, reviewers verify and resolve — all in one conversation thread. Bots should work the same way.
+
+## The Pattern
+
+**Every PR review follows a three-phase conversation lifecycle that mirrors how humans use GitHub:**
+
+1. **Initial review** — Reviewers post `REQUEST_CHANGES` with inline comments on specific files and lines.
+2. **Dev fix** — Devs fix the code, push, and **reply** to each review thread explaining the fix.
+3. **Re-review** — Reviewers verify by **replying** to the same threads, **resolve** satisfied threads, and submit `APPROVE`.
+
+All interactions happen within the same review thread — no orphaned duplicate threads.
+
+## Phase 1: Initial Review
+
+Reviewers produce a **structured JSON file**. The coordinator posts it via the review script.
+
+```json
+{
+  "event": "REQUEST_CHANGES",
+  "body": "## {emoji} {AgentName} — {Review Type}\n\n**BLOCKED** — {one-line verdict}\n\n### Blockers\n\n**B1:** ...\n\n### Warnings (non-blocking)\n\n**W1:** ...\n\n### What's strong\n\n**G1:** ...",
+  "comments": [
+    {
+      "path": "src/Precept/Dsl/FunctionRegistry.cs",
+      "line": 42,
+      "body": "**B1:** Explanation of what's wrong and what to fix."
+    }
+  ]
+}
+```
+
+### Comment Requirements
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | Yes | File path relative to repo root (forward slashes) |
+| `line` | Yes | Line number in the PR's HEAD commit — must be in the diff |
+| `body` | Yes | Markdown. Prefix: `B{N}:` blockers, `W{N}:` warnings, `G{N}:` positive callouts |
+
+### Rules
+
+1. **Every blocker MUST have an inline comment** on the relevant file and line.
+2. **Warnings SHOULD have inline comments** when they reference specific code.
+3. **Line numbers must be accurate.** Read the actual file first — don't guess.
+4. **Use `REQUEST_CHANGES`** when any blocker exists. `APPROVE` only when all blocking criteria pass.
+
+### How to Post (Initial Review)
+
+```
+node tools/scripts/squad-review.js <pr-number> <review-file.json>
+```
+
+## Phase 2: Dev Fix Response
+
+After fixing the code and pushing, the coordinator replies to each original review thread explaining what was fixed. This keeps the conversation in one place.
+
+### Coordinator Workflow
+
+1. Run `node tools/scripts/squad-review.js <pr-number> threads --unresolved` to list open threads.
+2. Map each thread's `commentId` to the fix that addresses it.
+3. Construct a reply JSON and post it.
+
+### Reply JSON Format (Dev Fix)
+
+```json
+{
+  "replies": [
+    {
+      "commentId": 123456,
+      "body": "Fixed in commit `abc1234`. Added `RequiresNonNegativeProof` case to `FormatArgConstraint`."
+    },
+    {
+      "commentId": 789012,
+      "body": "Fixed in commit `abc1234`. Added `TypeChecker_C72_MinSingleArg` and `TypeChecker_C72_MaxSingleArg` tests."
+    }
+  ]
+}
+```
+
+No `event` or `body` — just replies. No review is submitted; this is the dev responding.
+
+### How to Post (Dev Fix)
+
+```
+node tools/scripts/squad-review.js <pr-number> <fix-reply.json>
+```
+
+## Phase 3: Re-Review and Resolve
+
+Reviewers verify fixes by replying to the same threads. Satisfied threads are resolved. An `APPROVE` review is submitted alongside the replies.
+
+### Reply JSON Format (Re-Review)
+
+```json
+{
+  "event": "APPROVE",
+  "body": "## {emoji} {AgentName} — Re-Review\n\n**APPROVED** — All blockers resolved.",
+  "replies": [
+    {
+      "commentId": 123456,
+      "body": "✅ **B1 — Verified.** RequiresNonNegativeProof now serialized correctly.",
+      "resolve": true
+    },
+    {
+      "commentId": 789012,
+      "body": "✅ **B3 — Verified.** Both min/max single-arg C72 tests present and correct.",
+      "resolve": true
+    }
+  ],
+  "comments": [
+    {
+      "path": "src/Precept/Dsl/FunctionRegistry.cs",
+      "line": 55,
+      "body": "**B4:** New finding during re-review — this overload is unreachable."
+    }
+  ]
+}
+```
+
+- `replies`: Respond to existing threads. `resolve: true` resolves the thread.
+- `comments`: New inline comments for issues discovered during re-review. Same format as initial review comments.
+- `event` + `body`: Submits the review. New comments are attached to this review.
+- If new blockers are found, use `REQUEST_CHANGES` with the new comments, resolve the satisfied threads, and leave unsatisfied threads open.
+
+### How to Post (Re-Review)
+
+```
+node tools/scripts/squad-review.js <pr-number> <rereview.json>
+```
+
+The script posts all replies first, resolves marked threads, then submits the review.
+
+## Listing Threads
+
+The coordinator lists existing review threads to map findings to comment IDs:
+
+```
+node tools/scripts/squad-review.js <pr-number> threads [--unresolved]
+```
+
+Output (JSON array):
+```json
+[
+  {
+    "threadId": "PRRT_...",
+    "commentId": 123456,
+    "path": "tools/Precept.Mcp/Tools/LanguageTool.cs",
+    "line": 134,
+    "body": "**B1:** FormatArgConstraint returns null for RequiresNonNegativeProof...",
+    "author": "squad-reviewer",
+    "createdAt": "2026-04-12T14:59:02Z",
+    "isResolved": false
+  }
+]
+```
+
+Use `--unresolved` to filter to open threads only.
+
+## Review Types
+
+This skill applies to ALL review types. The format is the same; the criteria differ by role:
+
+### Code Review (Frank — Lead/Architect)
+
+- Doc accuracy vs. implementation
+- Diagnostic message correctness
+- Grammar sync (TextMate grammar matches parser)
+- Completions/hover sync
+- MCP sync (DTOs match core types)
+- Dead code scan
+- Design philosophy compliance
+
+### Test Review (Soup Nazi — Tester)
+
+- AC-to-test matrix (every behavioral criterion has a test)
+- Test quality (FluentAssertions, edge cases, error paths)
+- Disabled test scan
+- CatalogDriftTests coverage
+- Cross-surface drift (tests across all 3 test projects)
+
+### Design Review (Frank — facilitated)
+
+- Philosophy filter
+- Impact assessment (runtime, tooling, MCP)
+- Rationale completeness
+- Precedent grounding
+- Inline comments on specific doc sections
+
+## Spawn Prompt Additions
+
+### Initial Review Spawn
+
+```
+REVIEW OUTPUT FORMAT: You MUST output a JSON object (not Markdown) with this structure:
+{
+  "event": "REQUEST_CHANGES" | "APPROVE" | "COMMENT",
+  "body": "## {emoji} {YourName} — {Review Type}\n\n**{APPROVED|BLOCKED}** — ...",
+  "comments": [
+    { "path": "relative/file/path.cs", "line": <number>, "body": "**B1:** ..." }
+  ]
+}
+
+Every blocker MUST have an inline comment with the exact file path and line number.
+Read the actual files to determine correct line numbers — do not guess.
+```
+
+### Re-Review Spawn
+
+When spawning a reviewer for re-review, include the existing thread data so they can verify each one:
+
+```
+RE-REVIEW: You are verifying fixes for blockers from a previous review.
+The following review threads exist on the PR (unresolved):
+
+{thread list from `threads --unresolved` output}
+
+For EACH thread, verify whether the fix is satisfactory. Also do a fresh pass —
+if you find NEW issues not in the original threads, add them as new comments.
+
+Output a JSON object:
+{
+  "event": "APPROVE" | "REQUEST_CHANGES",
+  "body": "## {emoji} {YourName} — Re-Review\n\n**{APPROVED|BLOCKED}** — ...",
+  "replies": [
+    { "commentId": <from thread data>, "body": "✅ B1 — Verified. ...", "resolve": true },
+    { "commentId": <from thread data>, "body": "❌ B2 — Still broken. ...", "resolve": false }
+  ],
+  "comments": [
+    { "path": "relative/file.cs", "line": <number>, "body": "**B4:** New finding..." }
+  ]
+}
+
+Use resolve: true for satisfied threads, resolve: false for unresolved issues.
+Include "comments" only if you find NEW issues not covered by existing threads.
+Use APPROVE only when ALL threads can be resolved AND no new blockers found.
+REQUEST_CHANGES if any thread remains open or any new blocker is added.
+```
+
+## Coordinator Workflow (Complete Lifecycle)
+
+### After Initial Review
+
+1. Parse JSON from reviewer agent's response.
+2. Write to `temp/{agent-name}-review.json`.
+3. Run `node tools/scripts/squad-review.js <pr> temp/{agent-name}-review.json`.
+4. Report results to user.
+
+### After Dev Fix
+
+1. Run `node tools/scripts/squad-review.js <pr> threads --unresolved` to list open threads.
+2. Map each fix to its thread's `commentId`.
+3. Construct reply JSON with fix explanations (no event/body — just replies).
+4. Write to `temp/{agent-name}-fix-reply.json`.
+5. Run `node tools/scripts/squad-review.js <pr> temp/{agent-name}-fix-reply.json`.
+
+### After Re-Review
+
+1. Run `node tools/scripts/squad-review.js <pr> threads --unresolved` to get current threads.
+2. Spawn reviewer with thread data in prompt.
+3. Parse reviewer's reply JSON output.
+4. Write to `temp/{agent-name}-rereview.json`.
+5. Run `node tools/scripts/squad-review.js <pr> temp/{agent-name}-rereview.json`.
+6. Confirm threads resolved and APPROVE posted.
+
+## History
+
+- **2026-04-12:** Established during PR #68 review cycle. GitHub blocks `REQUEST_CHANGES` on own PRs, so we created the Squad Reviewer GitHub App (`squad-reviewer[bot]`). Structured JSON format with inline comments adopted as the standard.
+- **2026-04-12 (v2):** Upgraded to conversational lifecycle. Reviews now follow a three-phase pattern: initial review → dev fix reply → re-review with resolve. All interactions happen in the same thread, mirroring how humans use GitHub. Script extended with `threads`, `reply`, and `resolve` support.

--- a/.squad/skills/pr-review/SKILL.md
+++ b/.squad/skills/pr-review/SKILL.md
@@ -90,6 +90,8 @@ After fixing the code and pushing, the coordinator replies to each original revi
 
 No `event` or `body` — just replies. No review is submitted; this is the dev responding.
 
+**⚠️ NEVER include `resolve: true` in fix replies.** Resolution is the reviewer's job in Phase 3. The dev explains the fix; the reviewer verifies and resolves.
+
 ### How to Post (Dev Fix)
 
 ```

--- a/.squad/skills/proposal-review/SKILL.md
+++ b/.squad/skills/proposal-review/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: "proposal-review"
+description: "How to produce and post structured proposal reviews on GitHub issues. Covers review criteria, output format, issue comment format, and integration with the design gate."
+domain: "proposal review, design review, language design"
+confidence: "high"
+source: "earned — PR #68 review process formalization 2026-04-12; mirrors pr-review skill for the issue surface"
+---
+
+# Skill: Proposal Review — Structured Reviews on GitHub Issues
+
+## The Problem
+
+Proposal reviews happen in chat, get buried in Squad logs, or land as unstructured comments that don't clearly distinguish blockers from suggestions. The proposer can't tell what must change before the proposal advances, and the principal (Shane) can't see the review status without asking the coordinator.
+
+## The Pattern
+
+**Every proposal review is posted as a structured GitHub issue comment** via the GitHub API. Reviews follow a consistent format with clear verdicts, numbered findings, and explicit gate criteria. This mirrors the pr-review skill but targets the issue surface (no diff, no inline file comments).
+
+## When This Applies
+
+- Any GitHub issue that is a **proposal** (language feature, architecture change, tooling proposal, process change)
+- Triggered when: "review proposal #N", "evaluate this proposal", "Frank, review the design", design review ceremony on an issue
+- Does NOT apply to bug reports, task issues, or implementation PRs (use `pr-review` for PRs)
+
+## Review Criteria
+
+### Language Proposals (Frank — Lead/Architect)
+
+1. **Philosophy filter** — Apply the 7 questions from `.squad/skills/dsl-philosophy-filter/SKILL.md`:
+   - Domain integrity, determinism, keyword clarity, truth boundaries, locality, compile-time soundness, alias creep/AI legibility
+   - Each question gets a PASS/FAIL/NA verdict
+
+2. **Impact assessment** — All three categories MUST be covered:
+   - **Runtime** — parser, type checker, evaluator, engine, diagnostics
+   - **Tooling** — syntax highlighting (all positions), completions (all contexts), hover, semantic tokens
+   - **MCP** — type vocabulary in `precept_language`, DTOs in `precept_compile`, serialization in fire/inspect/update
+   - A proposal missing any impact category is incomplete — send it back
+
+3. **Rationale completeness** — Every locked decision must have:
+   - Why this choice (not just what)
+   - Alternatives considered and rejected (with reasons)
+   - Precedent from research base
+   - Tradeoff accepted (known downside)
+
+4. **Research grounding** — Does the proposal reference `research/language/` evidence? Are claims supported by the comparative studies?
+
+5. **Acceptance criteria quality** — Are ACs behavioral (testable), specific, and complete? Do they cover error paths and edge cases?
+
+### Test Feasibility Review (Soup Nazi — Tester)
+
+1. **Edge case enumeration** — How many edge cases does this construct introduce?
+2. **Test surface estimate** — Rough count of new test cases (parser, type checker, evaluator, runtime each)
+3. **Regression risk** — Does this interact with existing constructs in ways that could break tests?
+4. **Verdict** — clean / manageable / high-risk
+
+### General Proposals (any reviewer)
+
+1. **Scope clarity** — Is the proposal scoped tightly enough to implement?
+2. **Dependencies** — Does it depend on unfinished work?
+3. **Documentation impact** — Which docs need updating?
+
+## Output Format
+
+Reviewers MUST produce a **structured JSON object** — not plain Markdown. The coordinator writes it to a temp file and posts it as an issue comment.
+
+```json
+{
+  "issueNumber": 16,
+  "verdict": "APPROVED" | "BLOCKED" | "NEEDS_REVISION",
+  "body": "## {emoji} {AgentName} — Proposal Review\n\n**{verdict}** — {one-line summary}\n\n### Philosophy Filter\n...\n### Impact Assessment\n...\n### Blockers\n...\n### Warnings\n...\n### What's strong\n..."
+}
+```
+
+### Field Requirements
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `issueNumber` | Yes | The GitHub issue number being reviewed |
+| `verdict` | Yes | `APPROVED` — ready to implement; `BLOCKED` — must fix before advancing; `NEEDS_REVISION` — close but needs specific changes |
+| `body` | Yes | Full review content (Markdown). Posted as the issue comment body |
+
+### Verdict Definitions
+
+| Verdict | Meaning | What happens next |
+|---------|---------|-------------------|
+| `APPROVED` | Proposal meets all gate criteria. Ready for Shane's sign-off, then implementation | Coordinator presents to Shane for approval |
+| `BLOCKED` | Fundamental issues — missing impact category, philosophy violation, unsound design | Proposer must revise. Re-review required after changes |
+| `NEEDS_REVISION` | Mostly sound but specific items need work — incomplete ACs, missing rationale, unclear scope | Proposer addresses items, re-review may be waived for minor fixes |
+
+### Body Structure
+
+```markdown
+## {emoji} {AgentName} — Proposal Review
+
+**{APPROVED|BLOCKED|NEEDS_REVISION}** — {one-line verdict}
+
+### Philosophy Filter
+| Question | Verdict | Notes |
+|----------|---------|-------|
+| Domain integrity | PASS | ... |
+| Determinism | PASS | ... |
+| ... | ... | ... |
+
+### Impact Assessment
+- **Runtime:** {covered/missing — details}
+- **Tooling:** {covered/missing — details}
+- **MCP:** {covered/missing — details}
+
+### Blockers
+**B1:** ...
+**B2:** ...
+
+### Warnings (non-blocking)
+**W1:** ...
+
+### What's strong
+**G1:** ...
+**G2:** ...
+
+### Rationale Check
+- Locked decisions with rationale: {count}
+- Locked decisions missing rationale: {list}
+
+### Test Feasibility (if Soup Nazi reviewed)
+- Edge cases: {count}
+- Estimated test cases: {count}
+- Regression risk: clean / manageable / high-risk
+```
+
+## How to Post
+
+The coordinator posts the review as a GitHub issue comment:
+
+```bash
+# Using gh CLI
+gh issue comment <issue-number> --body-file temp/<agent>-proposal-review.md
+
+# Or programmatically via the GitHub API / MCP tools
+```
+
+Unlike PR reviews, issue comments don't have `APPROVE` / `REQUEST_CHANGES` events. The verdict is conveyed in the structured body. To make the verdict machine-scannable, the first line after the heading MUST be:
+
+```
+**APPROVED** — ...
+**BLOCKED** — ...
+**NEEDS_REVISION** — ...
+```
+
+## Spawn Prompt Addition
+
+When the coordinator spawns a proposal reviewer, include this in the prompt:
+
+```
+PROPOSAL REVIEW OUTPUT FORMAT: You MUST output a JSON object with this structure:
+{
+  "issueNumber": <number>,
+  "verdict": "APPROVED" | "BLOCKED" | "NEEDS_REVISION",
+  "body": "## {emoji} {YourName} — Proposal Review\n\n**{verdict}** — ..."
+}
+
+Apply the philosophy filter (7 questions from .squad/skills/dsl-philosophy-filter/SKILL.md).
+Verify all 3 impact categories (Runtime, Tooling, MCP) are covered.
+Check rationale completeness for every locked decision.
+Read .squad/skills/proposal-review/SKILL.md for the full review format spec.
+```
+
+## Coordinator Post-Review Workflow
+
+After collecting reviewer output:
+
+1. Parse the JSON from the agent's response
+2. Extract the `body` field
+3. Write to `temp/{agent-name}-proposal-review.md`
+4. Post: `gh issue comment {issueNumber} --body-file temp/{agent-name}-proposal-review.md`
+5. Report verdict to the user
+6. If `APPROVED` → present to Shane for sign-off
+7. If `BLOCKED` or `NEEDS_REVISION` → route back to the proposer with specific items to address
+
+## Relationship to Other Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `pr-review` | Sibling — same structured approach, different surface (PRs vs. issues) |
+| `dsl-philosophy-filter` | Input — the 7 philosophy questions are a required section of language proposal reviews |
+| `proposal-gate-analysis` | Downstream — after a proposal is APPROVED and reviewed, the PM uses gate analysis to identify minimum sign-off decisions before execution |
+| `constraint-holder-review-gate` | Complementary — the constraint-holder must also review the post-implementation artifact |
+| `language-design` | Input — research location and design doc references used during review |
+
+## History
+
+- **2026-04-12:** Created alongside `pr-review` skill during PR #68 review process formalization. Addresses the gap where proposal reviews were informal chat responses rather than structured, trackable issue comments.

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -52,6 +52,46 @@
 - **`docs/` is not a design bucket** — it holds technical design docs, implementation plans, research, and explanatory material rather than canonical visual-system rules.
 - **Shared review is required** when a change affects both brand meaning and reusable product-surface guidance.
 
+## Review Policy
+
+**All PR reviews follow a conversational lifecycle that mirrors how humans use GitHub.** See `.squad/skills/pr-review/SKILL.md` for the full spec.
+
+### Lifecycle
+
+1. **Initial review** — Reviewers post `REQUEST_CHANGES` with inline comments on specific files and lines.
+2. **Dev fix** — Devs fix the code, push, and **reply** to each review thread explaining the fix.
+3. **Re-review** — Reviewers verify by **replying** to the same threads, **resolve** satisfied threads, and submit `APPROVE`.
+
+### Rules
+
+- Reviews are posted as `squad-reviewer[bot]` via the Squad Reviewer GitHub App.
+- Reviewers output **structured JSON** (not Markdown) with inline comments on specific files and lines.
+- Every blocker MUST have an inline comment. Top-level-only blockers are incomplete reviews.
+- Dev fix replies and reviewer verifications happen **in the same thread** — no new duplicate threads.
+- Reviewers resolve threads only after verifying the fix in re-review.
+- The decisions inbox is still used for team-relevant decisions — review findings belong on the PR.
+
+### Script
+
+```bash
+# Initial review
+node tools/scripts/squad-review.js <pr> <review.json>
+
+# Dev fix reply (reply to existing threads)
+node tools/scripts/squad-review.js <pr> <fix-reply.json>
+
+# Re-review (reply + resolve + APPROVE)
+node tools/scripts/squad-review.js <pr> <rereview.json>
+
+# List threads (for mapping)
+node tools/scripts/squad-review.js <pr> threads [--unresolved]
+```
+
+## Review Governance
+
+- **Authors can fix their own rejected code.** They know it best — routing fixes to a different agent who isn't familiar with the code creates worse problems than it solves.
+- **Authors cannot review their own code.** The review gate requires fresh eyes. A different agent (or Shane) must review every PR — the original author never marks their own work as approved.
+
 ## Issue Source
 
 - **Provider:** GitHub

--- a/docs/ConstraintViolationDesign.md
+++ b/docs/ConstraintViolationDesign.md
@@ -643,6 +643,13 @@ Compile-phase and parse-phase diagnostics (DSL validity checks) use a separate v
 | C55 / PRECEPT055 | compile | Error | Root-level `edit` is not valid when states are declared. Message: `"Root-level \`edit\` is not valid when states are declared. Use \`in any edit all\` or \`in <State> edit <Fields>\` instead."` |
 | C69 / PRECEPT069 | compile | Error | Cross-scope guard reference in `when` clause. Guard expression references an identifier that belongs to a different scope than the declaration's guard allows. Invariant/state-assert/edit guards are entity-field-scoped; event-assert guards are event-arg-scoped. |
 | C70 / PRECEPT070 | parse | Error | Duplicate modifier on field or event argument declaration. Each modifier (`nullable`, `default`, `ordered`) may appear at most once per declaration. |
+| C71 / PRECEPT071 | compile | Error | Unknown function name in expression. The identifier is not a recognized built-in function. |
+| C72 / PRECEPT072 | compile | Error | Function called with incorrect number of arguments, or argument types do not match any overload. Message includes the function name and argument count. |
+| C73 / PRECEPT073 | compile | Error | Function argument type mismatch. A specific parameter expects one type but received another. Message identifies the parameter and the expected vs. actual types. |
+| C74 / PRECEPT074 | compile | Error | `round()` precision argument must be a non-negative integer literal. The second argument to `round(value, places)` cannot be a field reference or expression — it must be a compile-time constant like `2`. |
+| C75 / PRECEPT075 | compile | Error | `pow()` exponent must be integer type. The second argument to `pow(base, exponent)` must resolve to `integer`, not `number` or `decimal`. This ensures totality — integer exponentiation always produces a finite result. |
+| C76 / PRECEPT076 | compile | Error | `sqrt()` requires a non-negative argument. The argument may be negative at runtime. Add a `nonnegative` constraint to the field, or guard the expression with `field >= 0 and ...`. Also accepted: literal values ≥ 0 and `abs()` results. |
+| C77 / PRECEPT077 | compile | Error | Function does not accept nullable arguments. The argument may be null at runtime. Add a null check (e.g., `field != null and ...`) before calling the function. Same pattern as C56 for string `.length`. |
 
 **Distinction from runtime violations:** These are compile-time diagnostics, not runtime `ConstraintViolation` objects. They are reported during `PreceptCompiler.CompileFromText()` and surfaced via the language server (squiggles), MCP `precept_compile`, and CLI. They do not produce `ConstraintViolation` instances.
 

--- a/docs/McpServerDesign.md
+++ b/docs/McpServerDesign.md
@@ -121,11 +121,31 @@ The `vocabulary` object contains the following keyword lists, each reflecting `P
 | `maxplaces N` | `decimal` | Caps decimal places to N (e.g. `maxplaces 2` ensures at most 2 decimal digits) |
 | `ordered` | `choice` | Enables ordinal comparison operators on choice fields; values compare in declaration order |
 
-**Built-in function reference** — built-in functions are not keywords but appear in the `constructs` catalog:
+**Built-in function reference** — built-in functions are exposed in the `functions` section of the `precept_language` output, with full signature, parameter, and description metadata:
 
-| Function | Description |
-|---|---|
-| `round(expr, N)` | Rounds a decimal expression to N decimal places (banker's rounding / MidpointRounding.ToEven). Valid in `set` RHS and invariant/assert expressions. |
+| Function | Category | Signatures | Description |
+|---|---|---|---|
+| `abs(value)` | numeric | `int→int`, `dec→dec`, `num→num` | Absolute value (type-preserving) |
+| `floor(value)` | numeric | `dec→int`, `num→int` | Round toward negative infinity |
+| `ceil(value)` | numeric | `dec→int`, `num→int` | Round toward positive infinity |
+| `round(value)` | numeric | `int→int`, `dec→int`, `num→num` | Banker's rounding to nearest integer |
+| `round(value, places)` | numeric | `(num, int-literal)→dec` | Precision rounding |
+| `truncate(value)` | numeric | `dec→int`, `num→int` | Truncate toward zero |
+| `min(a, b, ...)` | numeric | `int*→int`, `dec*→dec`, `num*→num` | Smallest of 2+ values (variadic) |
+| `max(a, b, ...)` | numeric | `int*→int`, `dec*→dec`, `num*→num` | Largest of 2+ values (variadic) |
+| `clamp(value, min, max)` | numeric | `(int×3)→int`, `(dec×3)→dec`, `(num×3)→num` | Constrain to range |
+| `pow(base, exp)` | numeric | `(int, int)→int`, `(dec, int)→dec`, `(num, int)→num` | Integer exponent power |
+| `sqrt(value)` | numeric | `dec→dec`, `num→num` | Square root (requires non-negative proof) |
+| `toLower(value)` | string | `str→str` | Lowercase (invariant culture) |
+| `toUpper(value)` | string | `str→str` | Uppercase (invariant culture) |
+| `trim(value)` | string | `str→str` | Remove leading/trailing whitespace |
+| `startsWith(value, prefix)` | string | `(str, str)→bool` | Case-sensitive prefix test |
+| `endsWith(value, suffix)` | string | `(str, str)→bool` | Case-sensitive suffix test |
+| `left(value, count)` | string | `(str, num)→str` | Leftmost N chars (clamping) |
+| `right(value, count)` | string | `(str, num)→str` | Rightmost N chars (clamping) |
+| `mid(value, start, length)` | string | `(str, num, num)→str` | Substring, 1-indexed (clamping) |
+
+The `functions` section in the JSON output provides structured `FunctionDto` objects with `name`, `description`, and `signatures` (each containing `parameters` with name/type/constraint, and `returnType`).
 
 **Implementation:** Serializes `ConstructCatalog.Constructs` + `DiagnosticCatalog.Diagnostics` + reflected `PreceptToken` vocabulary. No MCP-specific data — everything comes from core infrastructure.
 

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -1029,9 +1029,31 @@ Dotted member accessors:
 
 Built-in functions:
 
-| Function | Valid in | Description |
-|---|---|---|
-| `round(expr, N)` | `set` RHS, `invariant`, `in`/`to`/`from` assert, `when` guard | Rounds a `decimal` expression to N decimal places using banker's rounding (MidpointRounding.ToEven). `expr` must resolve to `decimal`; `N` must be a non-negative integer literal. |
+| Function | Signatures | Returns | Description |
+|---|---|---|---|
+| `abs(value)` | `integer → integer`, `decimal → decimal`, `number → number` | Same as input | Absolute value. Type-preserving. |
+| `floor(value)` | `decimal → integer`, `number → integer` | `integer` | Rounds toward negative infinity. |
+| `ceil(value)` | `decimal → integer`, `number → integer` | `integer` | Rounds toward positive infinity. |
+| `round(value)` | `integer → integer`, `decimal → integer`, `number → number` | See signatures | 1-arg: banker's rounding (MidpointRounding.ToEven) to nearest integer. |
+| `round(value, places)` | `(numeric, integer-literal) → decimal` | `decimal` | 2-arg: precision rounding. `places` must be a non-negative integer literal (C74). |
+| `truncate(value)` | `decimal → integer`, `number → integer` | `integer` | Truncates toward zero (not toward negative infinity like `floor`). |
+| `min(a, b, ...)` | `integer* → integer`, `decimal* → decimal`, `number* → number` | Same as input | Smallest of 2+ values. Variadic. All args must match the same numeric type. |
+| `max(a, b, ...)` | `integer* → integer`, `decimal* → decimal`, `number* → number` | Same as input | Largest of 2+ values. Variadic. All args must match the same numeric type. |
+| `clamp(value, min, max)` | `(integer, integer, integer) → integer`, `(decimal×3) → decimal`, `(number×3) → number` | Same as input | Constrains value to [min, max]. Type-preserving. |
+| `pow(base, exponent)` | `(integer, integer) → integer`, `(decimal, integer) → decimal`, `(number, integer) → number` | Same as base | Integer exponent only (C75). Type-preserving. `pow(0, 0) = 1` (IEEE 754). |
+| `sqrt(value)` | `decimal → decimal`, `number → number` | Same as input | Square root. Requires compile-time non-negative proof: field must have `nonnegative`, `positive`, or `min >= 0` constraint, or argument must be guarded with `>= 0` (C76). |
+| `toLower(value)` | `string → string` | `string` | Lowercase using invariant culture. |
+| `toUpper(value)` | `string → string` | `string` | Uppercase using invariant culture. |
+| `trim(value)` | `string → string` | `string` | Removes leading and trailing whitespace. |
+| `startsWith(value, prefix)` | `(string, string) → boolean` | `boolean` | Case-sensitive prefix test. |
+| `endsWith(value, suffix)` | `(string, string) → boolean` | `boolean` | Case-sensitive suffix test. |
+| `left(value, count)` | `(string, numeric) → string` | `string` | Leftmost N characters. Clamping: negative count → empty, count > length → full string. |
+| `right(value, count)` | `(string, numeric) → string` | `string` | Rightmost N characters. Clamping semantics. |
+| `mid(value, start, length)` | `(string, numeric, numeric) → string` | `string` | Substring. 1-indexed start. Clamping: start > length → empty, length beyond end → to end. |
+
+All functions are valid in `set` RHS, `invariant`, `in`/`to`/`from` assert, and `when` guard expression positions. Functions that return `boolean` (`startsWith`, `endsWith`) are additionally valid as standalone guard conditions.
+
+Function arguments must be non-nullable — passing a nullable field without a null guard emits C77. `min` and `max` share tokens with constraint keywords; the parser disambiguates by position (function call requires `(` after the name).
 
 Exact operator precedence and literal forms should align with the runtime expression parser.
 

--- a/research/language/README.md
+++ b/research/language/README.md
@@ -60,6 +60,7 @@ Use this table when you already know the issue number and need its research grou
 | [expressiveness/expression-language-audit.md](./expressiveness/expression-language-audit.md) | Runtime-grounded inventory of current expression limits and proposal pressure. |
 | [expressiveness/internal-verbosity-analysis.md](./expressiveness/internal-verbosity-analysis.md) | Corpus evidence for compactness and declaration-pressure work. |
 | [expressiveness/conditional-logic-strategy.md](./expressiveness/conditional-logic-strategy.md) | Guard vocabulary and conditional-shape guidance across the language surface. |
+| [expressiveness/case-insensitive-comparison-survey.md](./expressiveness/case-insensitive-comparison-survey.md) | `~=` precedent survey, CI comparison patterns across 15+ systems, cascade analysis. Supports `#16`. |
 | [domain-map.md](./domain-map.md) | Full durable map of every language research domain. |
 | [domain-research-batches.md](./domain-research-batches.md) | Sequencing plan for active and horizon domain research. |
 | [references/cel-comparison.md](./references/cel-comparison.md) | Full Precept vs CEL language-level comparison — validates expression expansion priorities. |

--- a/research/language/expressiveness/README.md
+++ b/research/language/expressiveness/README.md
@@ -41,6 +41,7 @@ These files compare Precept against adjacent tools and systems. They are not pro
 | File | Comparative focus | Most useful for |
 |---|---|---|
 | [../references/cel-comparison.md](../references/cel-comparison.md) | Google CEL: expression model, type system, logical operators, extension model, safety guarantees | Expression expansion, keyword vs symbol surface |
+| [function-library-comparison.md](./function-library-comparison.md) | Excel, SQL, .NET `System.Math`: function-by-function mapping against Precept's proposed 23-signature library | `#16` built-in function library validation |
 
 ## Cross-cutting analysis docs
 
@@ -65,7 +66,7 @@ Every open proposal in this lane should be traceable back to a domain packet her
 | `#13` | Field-level range / basic constraints | [constraint-composition-domain.md](./constraint-composition-domain.md) | [zod-valibot.md](./zod-valibot.md), [fluent-validation.md](./fluent-validation.md), [fluent-assertions.md](./fluent-assertions.md) |
 | `#14` | Conditional invariants / guarded declarations | [constraint-composition-domain.md](./constraint-composition-domain.md) | [conditional-logic-strategy.md](./conditional-logic-strategy.md), [fluent-validation.md](./fluent-validation.md) |
 | `#15` | String `.contains()` | [expression-expansion-domain.md](./expression-expansion-domain.md) | [expression-language-audit.md](./expression-language-audit.md), [zod-valibot.md](./zod-valibot.md) |
-| `#16` | Built-in function library | [expression-expansion-domain.md](./expression-expansion-domain.md) | [expression-language-audit.md](./expression-language-audit.md), [linq.md](./linq.md), [polly.md](./polly.md) |
+| `#16` | Built-in function library | [expression-expansion-domain.md](./expression-expansion-domain.md) | [expression-language-audit.md](./expression-language-audit.md), [linq.md](./linq.md), [polly.md](./polly.md), [function-library-comparison.md](./function-library-comparison.md) |
 | `#17` | Computed / derived fields | [entity-modeling-surface.md](./entity-modeling-surface.md), [computed-fields.md](./computed-fields.md) | [expression-language-audit.md](./expression-language-audit.md) |
 | `#22` | Data-only precepts | [entity-modeling-surface.md](./entity-modeling-surface.md), [data-only-precepts-research.md](./data-only-precepts-research.md) | [expression-tracking-notes.md](./expression-tracking-notes.md) |
 | `#25` | `choice` type | [type-system-domain-survey.md](./type-system-domain-survey.md) | [expression-language-audit.md](./expression-language-audit.md) |

--- a/research/language/expressiveness/case-insensitive-comparison-survey.md
+++ b/research/language/expressiveness/case-insensitive-comparison-survey.md
@@ -1,0 +1,232 @@
+# Case-Insensitive Comparison Operator Survey
+
+**Research question:** Is there precedent for `~=` as a case-insensitive comparison operator? How do languages and DSLs handle case-insensitive string comparison? What are the cascade implications?
+
+**Context:** Precept Issue #16 is evaluating whether to add a `~=` operator for case-insensitive string equality. This survey catalogs prior art across 15+ systems.
+
+---
+
+## 1. `~=` Precedent Analysis
+
+### Systems that use `~=`
+
+| System | `~=` meaning | Confusability risk |
+|--------|-------------|-------------------|
+| **Lua 5.4** | **Inequality** (not equal). From §3.4.4: "The operator `~=` is exactly the negation of equality (`==`)." The `~` alone is bitwise XOR/NOT. | **Critical.** Lua has 350K+ GitHub repos. A Precept `~=` meaning "case-insensitive equal" would directly contradict a well-known operator in a widely-used language. |
+| **CSS Selectors** | `[attr~=value]` matches when `value` is a whitespace-separated word in the attribute. Not case-insensitive — it's a containment test on space-delimited tokens. | **High.** Different semantics entirely. Web developers would misread `~=` as token-matching. |
+
+### Systems that use `=~`
+
+| System | `=~` meaning | Notes |
+|--------|-------------|-------|
+| **Perl** | Regex binding operator. `$str =~ /pattern/i` applies a regex. The `/i` flag makes it case-insensitive. | `=~` is regex, not CI comparison |
+| **Ruby** | Regex match. `"hello" =~ /world/` returns match position or `nil`. | Same as Perl — regex, not CI |
+
+### Verdict
+
+**No language or DSL uses `~=` for case-insensitive comparison.** The symbol is taken by Lua (inequality) and CSS (word-match). The reversed form `=~` is taken by Perl and Ruby (regex binding). Using `~=` for CI comparison would be unprecedented and confusing.
+
+---
+
+## 2. Case-Insensitive Comparison Catalog
+
+### Pattern A: Function Composition (`toLower`/`toUpper` wrapping)
+
+The most common approach. No dedicated CI operator — users wrap operands with case-conversion functions.
+
+| System | Approach | Example |
+|--------|----------|---------|
+| **OData 4.01** | `tolower()` / `toupper()` functions. Spec explicitly states: "case-insensitive comparison can be achieved in combination with tolower or toupper." All string functions (`contains`, `startswith`, `endswith`, `indexof`) are case-sensitive. | `$filter=tolower(Name) eq 'milk'` |
+| **FEEL / DMN** | `lower case()` / `upper case()` functions. `contains()`, `starts with()`, `ends with()` are all case-sensitive. | `lower case(Name) = "milk"` |
+| **XPath / XQuery** | `lower-case()` / `upper-case()` functions from the Functions and Operators spec. | `lower-case($name) = 'milk'` |
+| **SQL (standard)** | `LOWER()` / `UPPER()` functions. Case sensitivity depends on collation. | `WHERE LOWER(name) = 'milk'` |
+
+**Characteristics:** Explicit, composable, no new operators needed, but verbose when comparing both sides. Every string operation must be independently wrapped.
+
+### Pattern B: Three-Variant Operator Family (PowerShell)
+
+PowerShell has the most comprehensive CI system of any language surveyed. Default comparison is case-insensitive, with explicit prefixes for CI/CS variants.
+
+| Base operator | CI variant | CS variant | Purpose |
+|--------------|-----------|-----------|---------|
+| `-eq` | `-ieq` | `-ceq` | Equality |
+| `-ne` | `-ine` | `-cne` | Inequality |
+| `-lt` | `-ilt` | `-clt` | Less than |
+| `-gt` | `-igt` | `-cgt` | Greater than |
+| `-le` | `-ile` | `-cle` | Less or equal |
+| `-ge` | `-ige` | `-cge` | Greater or equal |
+| `-like` | `-ilike` | `-clike` | Wildcard match |
+| `-match` | `-imatch` | `-cmatch` | Regex match |
+| `-contains` | `-icontains` | `-ccontains` | Collection contains |
+| `-replace` | `-ireplace` | `-creplace` | String replace |
+
+**Characteristics:** Complete cascade — CI extends to every string-touching operator. Systematic naming with `-i`/`-c` prefix. But requires tripling the operator surface.
+
+### Pattern C: Modifier Flag / Parameter
+
+A flag or parameter attached to the comparison that toggles case sensitivity.
+
+| System | Approach | Example |
+|--------|----------|---------|
+| **CSS Selectors 4** | `i` flag suffix on attribute selectors. `s` flag for explicit case-sensitive. | `[data-name="foo" i]` |
+| **Perl regex** | `/i` flag on regex patterns. | `$str =~ /pattern/i` |
+| **Ruby regex** | `/i` flag on regex literals. | `str =~ /pattern/i` |
+| **Kotlin** | `ignoreCase` parameter on string methods. | `a.equals(b, ignoreCase = true)` |
+| **C# (.NET)** | `StringComparison` enum parameter. | `string.Equals(a, b, StringComparison.OrdinalIgnoreCase)` |
+
+**Characteristics:** Localized control per-comparison. No new operators. But the flag mechanism varies widely (suffix, parameter, enum).
+
+### Pattern D: Dedicated CI Method / Function
+
+A named method specifically for case-insensitive comparison.
+
+| System | Approach | Example |
+|--------|----------|---------|
+| **Ruby** | `casecmp` method returns 0/-1/1. `casecmp?` returns boolean. | `"ABC".casecmp?("abc") # => true` |
+| **C (POSIX)** | `strcasecmp()` function. | `strcasecmp(a, b) == 0` |
+| **Python** | `str.casefold()` for aggressive CI, or `str.lower()` comparison. No CI operator. | `a.casefold() == b.casefold()` |
+| **Java** | `String.equalsIgnoreCase()` method. | `a.equalsIgnoreCase(b)` |
+
+**Characteristics:** Self-documenting, discoverable, single-purpose. But only covers equality — doesn't extend to contains/startsWith/etc.
+
+### Pattern E: Environment / Session Setting
+
+Case sensitivity controlled at environment or schema level, not per-comparison.
+
+| System | Approach | Notes |
+|--------|----------|-------|
+| **SQL collation** | Column/table/database-level collation (`CI`/`CS` suffixes). | `COLLATE SQL_Latin1_General_CP1_CI_AS` — all comparisons on that column become CI |
+| **Bash** | `shopt -s nocasematch` toggles CI for `case` and `[[` pattern matching. | Session-wide, affects all subsequent comparisons |
+| **MySQL** | Default collation is `utf8mb4_0900_ai_ci` (accent-insensitive, case-insensitive). | CI is the default in MySQL |
+
+**Characteristics:** Set-and-forget, no per-comparison boilerplate. But makes behavior non-local and harder to reason about.
+
+### Pattern F: No CI Support
+
+Some policy/rule DSLs deliberately omit case-insensitive comparison.
+
+| System | Notes |
+|--------|-------|
+| **Cedar** | `==` is case-sensitive. `"Something" == "something"` is `false`. No `toLower`/`toUpper` functions. No CI mechanism at all. String operations limited to `like` (wildcard match, case-sensitive). Cedar's philosophy prioritizes simplicity and formal verification over string manipulation convenience. |
+
+---
+
+## 3. Cascade Analysis
+
+The critical design question: if you add CI equality, does CI need to extend to `contains`, `startsWith`, `endsWith`, `!=`, relational operators?
+
+### Systems with Full Cascade
+
+| System | Cascade scope | Mechanism |
+|--------|--------------|-----------|
+| **PowerShell** | All operators — equality, relational, wildcard, regex, contains, replace | `-i`/`-c` prefix on every operator |
+| **SQL collation** | All comparisons, `LIKE`, ordering, grouping on that column | Schema-level setting |
+
+### Systems with No Cascade (Manual)
+
+| System | What happens | User burden |
+|--------|-------------|-------------|
+| **OData** | Must wrap both sides with `tolower()` for every single operation | `$filter=contains(tolower(Name),tolower('milk'))` |
+| **FEEL** | Same — `lower case()` on every comparison | `contains(lower case(Name), lower case("milk"))` |
+| **Kotlin** | Each method has its own `ignoreCase` parameter | `a.contains(b, ignoreCase = true)` |
+| **C# (.NET)** | Each method has its own `StringComparison` parameter | `a.Contains(b, StringComparison.OrdinalIgnoreCase)` |
+
+### Cascade Pressure
+
+If Precept adds `~=` for CI equality, users will immediately ask:
+1. What about `~!=` (CI not-equal)?
+2. What about CI `contains`? (`~contains`? `icontains`?)
+3. What about CI `startsWith` / `endsWith`?
+4. What about CI relational comparisons (`~<`, `~>`)?
+
+PowerShell's experience shows this cascade is real — they needed 30+ operator variants. OData and FEEL avoided it by not having a CI operator at all, pushing CI to the function layer.
+
+---
+
+## 4. Pattern Taxonomy Summary
+
+| Pattern | Symbol cost | Cascade cost | Readability | Discoverability | Precept fit |
+|---------|------------|-------------|-------------|----------------|-------------|
+| **A. Function composition** | None | None (already scales) | Medium (verbose) | High | **Strong** — already has `toLower`/`toUpper` |
+| **B. Operator variants** | Very high (3x operators) | Built-in | Medium | Low (must memorize prefixes) | **Poor** — violates keyword-dominant principle |
+| **C. Modifier flag** | Low | Per-operation | High | Medium | **Medium** — could work as keyword modifier |
+| **D. Dedicated function** | Low | Each function independently | High | High | **Strong** — fits function library |
+| **E. Environment setting** | None | Implicit (all comparisons) | Low (non-local) | Low | **Poor** — violates explicitness principle |
+| **F. No support** | None | None | N/A | N/A | Viable but limits expressiveness |
+
+---
+
+## 5. Recommendation for Precept
+
+### Against `~=` as an Operator
+
+1. **No precedent.** Zero languages use `~=` for case-insensitive comparison. Lua uses it for inequality. CSS uses it for word-matching. This is not an obscure risk — Lua is widely known.
+
+2. **Cascade pressure.** Adding `~=` creates immediate demand for `~!=`, CI `contains`, CI `startsWith`, CI `endsWith`. PowerShell needed 30+ variants. Precept has no mechanism to satisfy this demand without a proliferation of symbolic operators.
+
+3. **Violates Keyword vs Symbol Framework.** From the locked design framework: "Symbols are reserved for universal mathematical notation" and "Default to keyword." CI comparison is not universal math notation — it's a domain-specific string behavior. The tiebreaker says keyword.
+
+4. **Violates Principle #13.** "Keywords for domain, symbols for math." Case-insensitive comparison is domain behavior, not math.
+
+### Recommended Alternatives (in preference order)
+
+#### Option 1: Function composition (do nothing — already supported)
+
+```
+toLower(Status) == toLower(userInput)
+```
+
+Precept already has `toLower` and `toUpper`. This is how OData, FEEL, XPath, and SQL handle CI comparison. It's explicit, composable, and introduces zero new syntax.
+
+**Pro:** No language surface change. Already works.
+**Con:** Verbose for repeated use.
+
+#### Option 2: Dedicated `equalsIgnoreCase` function
+
+```
+equalsIgnoreCase(Status, userInput)
+```
+
+Following Java's `equalsIgnoreCase`, Ruby's `casecmp?`, and C's `strcasecmp`. A named function is self-documenting and discoverable.
+
+**Pro:** Keyword-based, self-documenting, follows Precept conventions.
+**Con:** Only covers equality. Would need `containsIgnoreCase`, `startsWithIgnoreCase`, etc. for cascade.
+
+#### Option 3: `ignorecase` keyword modifier (future consideration)
+
+```
+Status == userInput ignorecase
+```
+
+A keyword modifier that can attach to any comparison operator. Similar to CSS's `i` flag but using a keyword per Precept conventions.
+
+**Pro:** Composes with all operators. Keyword-based.
+**Con:** New syntactic concept (post-expression modifier). Needs careful design.
+
+### Bottom Line
+
+**Do not add `~=`.** The function composition pattern (Option 1) already works, matches the dominant industry approach, and avoids all cascade and confusability problems. If CI comparison becomes a frequent enough pain point in real usage, consider Option 2 (named function) as a convenience — but only after empirical evidence of need.
+
+---
+
+## 6. Risk Matrix
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|-----------|------------|
+| `~=` confused with Lua's inequality | Critical | High | Don't use `~=` |
+| `~=` confused with CSS word-match | High | Medium | Don't use `~=` |
+| Cascade demand after adding any CI operator | High | Certain | Use function pattern instead |
+| `toLower`/`toUpper` wrapping too verbose | Medium | Medium | Add `equalsIgnoreCase` function if needed |
+| No CI support at all | Low | Low | Function composition already covers this |
+
+---
+
+## Sources
+
+- Lua 5.4 Reference Manual §3.4.4 — https://www.lua.org/manual/5.4/manual.html
+- CSS Selectors Level 4 §7 — https://www.w3.org/TR/selectors-4/#attribute-case
+- PowerShell about_Comparison_Operators — https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators
+- Cedar Operators and Functions — https://docs.cedarpolicy.com/policies/syntax-operators.html
+- OData 4.01 URL Conventions §5.1.1 — https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html
+- DMN FEEL Handbook — https://kiegroup.github.io/dmn-feel-handbook/
+- Precept Language Design §Keyword vs Symbol Design Framework — `docs/PreceptLanguageDesign.md`

--- a/research/language/expressiveness/case-insensitive-implementation-survey.md
+++ b/research/language/expressiveness/case-insensitive-implementation-survey.md
@@ -1,0 +1,267 @@
+# Case-Insensitive Comparison: Implementation Survey
+
+> **Context**: Issue #16 (built-in functions) — evaluating whether Precept should add a `~=` operator for case-insensitive string comparison. This survey documents how other constraint, rule, and expression systems handle case-insensitive comparison, what the tilde symbol means across languages, and what cascade implications a prefix-modifier operator would introduce.
+
+---
+
+## 1. Rule Engines
+
+### Drools DRL (JBoss / Red Hat)
+
+- **No dedicated case-insensitive operator.**
+- Standard relational operators: `==` (uses `equals()`), `!=` (uses `!equals()`), `<`, `<=`, `>`, `>=`.
+- `matches` / `not matches` — Java regex pattern matching. Case-insensitive comparison achievable via `(?i)` inline flag: `name matches "(?i)john"`.
+- `soundslike` — Soundex-based phonetic matching (fuzzy, not CI).
+- `str[startsWith]`, `str[endsWith]`, `str[length]` — bracket-parameter string operators, all case-sensitive.
+- `contains` / `not contains` — collection membership AND string substring check, case-sensitive.
+- `in` / `notin` — value in a list, case-sensitive.
+- MVEL expression dialect available but adds no CI operator.
+- **Pattern**: Regex with `(?i)` flag, or method call to Java's `equalsIgnoreCase()`.
+
+### NRules (.NET)
+
+- **No dedicated case-insensitive operator.**
+- Rules are authored as C# classes with lambda-expression conditions: `.Match(() => quote, q => q.Driver.Name == "John")`.
+- Since conditions are native C# expressions, CI comparison uses `string.Equals(other, StringComparison.OrdinalIgnoreCase)` or `string.Compare()`.
+- **Pattern**: Defers entirely to the host language (C#).
+
+### InRule (Commercial .NET)
+
+- Commercial product with closed documentation.
+- Rule authoring uses .NET expression syntax.
+- Expected to follow the same pattern as NRules: defers to .NET string comparison APIs.
+
+### Easy Rules (Java)
+
+- Minimal Java rule engine with MVEL expression support.
+- No dedicated CI operator. Uses MVEL/Java method calls for CI comparison.
+- **Pattern**: Host language method calls.
+
+---
+
+## 2. Validation Frameworks
+
+### FluentValidation (.NET)
+
+- **No dedicated case-insensitive operator.**
+- `.Equal()` / `.NotEqual()` accept a `StringComparer` parameter: `.Equal("expected", StringComparer.OrdinalIgnoreCase)`.
+- `.IsEnumName(caseSensitive: false)` — boolean parameter for CI.
+- `.Matches()` — accepts regex (which can include `(?i)` flag).
+- **Pattern**: Parameter-based CI — the comparison method takes an explicit comparer or boolean flag.
+
+### Zod (TypeScript)
+
+- **No case-insensitive string comparison.**
+- String validations (all case-sensitive): `.regex()`, `.includes()`, `.startsWith()`, `.endsWith()`.
+- String transforms: `.toLowerCase()`, `.toUpperCase()`, `.trim()`.
+- `z.stringbool()` has `case: "sensitive"` option (defaults to CI for boolean parsing).
+- **Pattern**: Transform-then-validate — normalize input via `.toLowerCase()`, then compare.
+
+### Valibot (TypeScript)
+
+- Similar architecture to Zod. String validations are case-sensitive.
+- CI comparison achieved through `transform()` pipeline step followed by validation.
+- **Pattern**: Transform-then-validate, same as Zod.
+
+### JSON Schema
+
+- `pattern` keyword uses ECMA 262 (JavaScript) regex syntax.
+- **No support for regex flags in the `pattern` keyword itself** — cannot specify `(?i)` inline in a portable way.
+- Recommended to "stick to the subset" of ECMA 262. Inline modifiers like `(?i)` are not widely supported across JSON Schema implementations.
+- Must use verbose character classes like `[jJ][oO][hH][nN]` for CI matching.
+- **Pattern**: Regex-only, no flags, no CI support in practice.
+
+---
+
+## 3. Policy Languages
+
+### Cedar (AWS)
+
+- **No case-insensitive comparison at all.**
+- `"Something" == "something"` evaluates to `false`.
+- `like` operator exists for wildcard matching only (`*` as wildcard), case-sensitive.
+- No `toLowerCase()` / `toUpperCase()` functions exist.
+- No string manipulation functions of any kind.
+- **Pattern**: Deliberate omission — Cedar's security model avoids ambiguity from locale-dependent case folding.
+
+### OPA / Rego (Open Policy Agent)
+
+- **No dedicated case-insensitive operator.**
+- Standard operators only: `==`, `!=`, `<`, `>`, `<=`, `>=`.
+- Built-in string functions: `lower()`, `upper()`, `contains()`, `startswith()`, `endswith()`, `trim()`, `sprintf()`.
+- CI comparison idiom: `lower(input.name) == lower("John")`.
+- **Pattern**: Function-based normalization — `lower()` + standard `==`.
+
+### Casbin (Apache)
+
+- **No dedicated case-insensitive operator.**
+- Matcher expressions use standard operators: `r.sub == p.sub && r.obj == p.obj`.
+- Built-in functions for pattern matching: `keyMatch()`, `regexMatch()`, `globMatch()`.
+- CI comparison via `regexMatch()` with `(?i)` flag or custom function.
+- **Pattern**: Built-in function with regex, or custom function registration.
+
+---
+
+## 4. Expression Languages
+
+### SpEL (Spring Expression Language)
+
+- **No dedicated case-insensitive operator.**
+- Relational operators: `==`, `!=`, `<`, `<=`, `>`, `>=` (also textual aliases: `eq`, `ne`, `lt`, `gt`, `le`, `ge` — these keyword aliases are case-insensitive as tokens, but do NOT perform case-insensitive comparison).
+- `matches` operator — Java regex pattern matching. CI via `(?i)` flag: `'hello' matches '(?i)HELLO'`.
+- `between` operator — range check, case-sensitive for strings.
+- String operators: `+` (concatenation), `-` (char subtraction), `*` (repeat). No CI operator.
+- `OperatorOverloader` mechanism exists but only for math operations (`ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE`, `MODULUS`, `POWER`).
+- CI comparison in practice: call Java method `'hello'.equalsIgnoreCase('HELLO')`.
+- **Pattern**: `matches` with regex `(?i)` flag, or host-language method call.
+
+### FEEL (DMN / Camunda)
+
+- **No dedicated case-insensitive operator.**
+- Standard comparison: `=`, `!=`, `<`, `<=`, `>`, `>=` — all case-sensitive.
+- String functions: `upper case(string)`, `lower case(string)`, `contains(string, match)`, `starts with(string, match)`, `ends with(string, match)`, `substring()`, `string length()`, `trim()`.
+- `matches(input, pattern, flags)` — regex with **explicit `"i"` flag** for case-insensitive matching: `matches("FooBar", "foo", "i")` → `true`.
+- `replace(input, pattern, replacement, flags)` — also supports `"i"` flag.
+- CI equality idiom: `lower case(a) = lower case(b)`.
+- **Pattern**: Function-based normalization (`lower case()` + `=`) or regex with flag parameter (`matches(x, y, "i")`).
+
+### MVEL (Standalone)
+
+- Java-based expression language used in Drools and Easy Rules.
+- Supports direct Java method calls: `name.equalsIgnoreCase("John")`.
+- No dedicated CI operator in the expression syntax itself.
+- **Pattern**: Host-language method call.
+
+### JEXL (Apache Commons)
+
+- Java-based expression language.
+- Standard operators only. Supports method calls on Java objects.
+- CI comparison via `str.equalsIgnoreCase(other)`.
+- **Pattern**: Host-language method call.
+
+---
+
+## 5. Tilde (`~`) Semantics Across Languages
+
+The tilde symbol carries **widely divergent meanings** across programming languages. The proposed `~=` operator for Precept would enter a crowded semantic space:
+
+| Language/Context | Operator | Meaning |
+|---|---|---|
+| **Lua** | `~=` | **Inequality (NOT EQUAL)** — core relational operator |
+| **Lua** | `~` (unary) | Bitwise NOT |
+| **Lua** | `~` (binary) | Bitwise XOR |
+| **C / C++ / C# / Java / Python / JavaScript / PHP** | `~` | Bitwise NOT (unary complement) |
+| **AWK** | `~`, `!~` | Regex match / regex not-match |
+| **Perl** | `=~`, `!~` | Regex binding operator |
+| **Groovy** | `=~`, `==~` | Regex find / regex match |
+| **PostgreSQL** | `~`, `~*`, `!~`, `!~*` | POSIX regex match (CI variant: `~*`) |
+| **Eiffel** | `~` | Object equality (deep, field-by-field `is_equal`) |
+| **D** | `~` | Concatenation operator |
+| **R** | `~` | Model formula separator (LHS ~ RHS) |
+| **Raku** | `~~` | Smartmatch operator |
+| **Raku** | `~` | String concatenation |
+| **CSS** | `~` | Subsequent-sibling combinator |
+| **Haskell** | `~` | Lazy pattern match / type equality constraint |
+| **APL / MATLAB** | `~` | Logical NOT |
+| **Standard ML** | `~` | Prefix for negative numbers |
+| **Mathematics** | `~`, `≈` | Equivalence relation / "approximately equal" |
+| **Unix shells** | `~` | Home directory |
+
+### Critical Confusability Risk: Lua
+
+Lua — a widely-used embeddable scripting language — uses `~=` as its **inequality operator** (equivalent to `!=` in C-family languages). This is core Lua syntax used in every codebase:
+
+```lua
+if x ~= nil then    -- "if x is not equal to nil"
+if status ~= "ok" then   -- "if status is not equal to 'ok'"
+```
+
+Any developer with Lua experience will read Precept's `~=` as "not equal," which is the **exact opposite** of the intended "approximately equal / case-insensitive equal" semantics.
+
+### PostgreSQL's `~*` Precedent
+
+PostgreSQL is the **only surveyed system** that uses tilde for case-insensitive matching, and it uses `~*` (not `~=`) specifically for CI regex matching:
+
+```sql
+SELECT 'FooBar' ~ 'foo';    -- false (CS regex match)
+SELECT 'FooBar' ~* 'foo';   -- true  (CI regex match)
+SELECT 'FooBar' !~* 'foo';  -- false (CI regex not-match)
+```
+
+This is regex matching, not equality comparison.
+
+---
+
+## 6. Cascade Analysis
+
+If Precept adds `~=` as a case-insensitive equality operator, **users will immediately expect case-insensitive variants of every string operator**:
+
+| Current Operator | Expected CI Variant | Cascade Pressure |
+|---|---|---|
+| `==` | `~=` | The initial proposal |
+| `!=` | `~!=` or `!~=` | Immediate — negation of CI equality |
+| `contains` | `~contains` | High — common validation pattern |
+| `startsWith` | `~startsWith` | High — common validation pattern |
+| `endsWith` | `~endsWith` | High — common validation pattern |
+
+### No Precedent for Prefix-Modifier Pattern
+
+No surveyed system uses a `~` prefix modifier to create CI variants of existing operators. The pattern `~` + `operator` = "case-insensitive version of operator" is **novel and unattested**.
+
+### How Other Systems Handle the Cascade
+
+Systems that need CI for multiple operations use one of these strategies:
+
+1. **Function-based normalization** (OPA, FEEL): `lower(x) == lower(y)`, `lower(x).contains(lower(y))` — one function covers ALL operators.
+2. **Parameter-based approach** (FluentValidation): Each method takes a comparer argument — `StringComparer.OrdinalIgnoreCase`.
+3. **Regex with CI flag** (Drools, FEEL, SpEL, PostgreSQL): `matches(input, pattern, "i")` — a single mechanism for all pattern operations.
+
+All three strategies avoid the cascade problem by providing a **single mechanism** that composes with existing operators rather than duplicating the operator set.
+
+### Parser and Grammar Impact
+
+A `~` prefix modifier would require:
+- New token recognition for `~=`, `~!=`, `~contains`, `~startsWith`, `~endsWith` (each as a distinct operator).
+- TextMate grammar additions for each CI operator variant.
+- Completion provider entries for each variant.
+- MCP documentation for each new operator.
+- A parser rule for `~` + `operator` composition (or individual hard-coded recognition).
+
+A function-based approach (`lower()`) requires: one new built-in function, no grammar changes, no new operators, no cascade.
+
+---
+
+## 7. Summary of Findings
+
+### The Dominant Pattern
+
+Across **all 16+ systems surveyed**, the universal finding is:
+
+> **No constraint, rule, or expression language provides a dedicated case-insensitive comparison operator.**
+
+Every system uses one of three strategies:
+
+| Strategy | Systems | Mechanism |
+|---|---|---|
+| **Function normalization** | OPA/Rego, FEEL, Zod, Valibot | `lower(x) == lower(y)` |
+| **Parameter / comparer** | FluentValidation, NRules, .NET ecosystem | `.Equal(x, StringComparer.OrdinalIgnoreCase)` |
+| **Regex with CI flag** | Drools, FEEL, SpEL, Casbin, PostgreSQL | `matches(x, "pattern", "i")` |
+
+Some systems (Cedar, JSON Schema) deliberately provide **no CI comparison at all**.
+
+### `~=` Is Not Established
+
+The `~=` token for case-insensitive comparison has **zero precedent** in any surveyed language or framework. Its only established meaning is **inequality** (Lua), making it actively confusing.
+
+### The Tilde Confusability Risk Is Real
+
+Lua's `~=` (NOT EQUAL) is the most direct conflict. Developers familiar with Lua, AWK (`~` = regex match), Perl (`=~` = regex bind), or C-family languages (`~` = bitwise NOT) will all bring incorrect expectations. The mathematical "approximately equal" reading (≈) is plausible but not established in any programming language's operator syntax.
+
+### Function-Based Approach Avoids Cascade
+
+A `lower()` function in Precept's built-in function library would:
+- Provide CI comparison (`lower(name) == lower("John")`) with zero new operators.
+- Compose naturally with all existing operators (`lower(x) != lower(y)`, `lower(x).contains(lower(y))` patterns).
+- Avoid the cascade problem entirely.
+- Follow the dominant pattern established by OPA, FEEL, Zod, and every other surveyed system.
+- Require no parser, grammar, completion, or MCP changes beyond the function itself.

--- a/research/language/expressiveness/constraint-language-function-survey.md
+++ b/research/language/expressiveness/constraint-language-function-survey.md
@@ -1,0 +1,349 @@
+# Constraint/DSL Language Function Library Survey
+
+**Date:** 2026-04-11
+**Author:** Frank (Lead/Architect, Language Designer)
+**Request:** Shane — validate Issue #16 function library against comparable systems
+**Issue:** #16 — Built-in Functions
+
+---
+
+## Context
+
+Precept's Issue #16 proposes 23 function signatures across three numeric types and string:
+
+| Category | Functions |
+|----------|-----------|
+| **Number** | `abs`, `floor`, `ceil`, `round(1)`, `truncate`, `min(variadic)`, `max(variadic)` |
+| **Integer** | `abs`, `min(variadic)`, `max(variadic)` |
+| **Decimal** | `abs`, `floor`, `ceil`, `round(1→int)`, `round(2,N)`, `truncate`, `min(variadic)`, `max(variadic)` |
+| **String** | `toLower`, `toUpper`, `startsWith`, `endsWith`, `trim` |
+
+This survey evaluates five comparable systems: FEEL (DMN), Cedar, Drools/NRules, Zod/Valibot, and FluentValidation. The goal is to determine whether the proposal is sufficient, and whether any functions should be added, deferred, or excluded.
+
+Governing principle: *"The expression surface must be complete enough that every domain-relevant constraint is expressible, while remaining closed and decidable."*
+
+### Methodology Note
+
+**The sample corpus (`.precept` files in `samples/`) is not valid evidence for inclusion or exclusion of functions.** The samples were authored without the functions under evaluation — they cannot exercise capabilities that don't exist yet. Additionally, the corpus is incomplete: it covers ~24 verticals from a universe of hundreds.
+
+Each function is evaluated on:
+1. **Domain relevance** — does the function serve real constraint needs across business verticals (insurance, loans, hiring, hospitality, logistics, maintenance, billing, subscriptions, healthcare, government)?
+2. **System consensus** — how many of the 5 surveyed systems include it?
+3. **Precept principles** — is the function pure, total, and deterministic?
+4. **Expressibility gap** — does its absence force authors to omit constraints the domain genuinely needs, or use verbose workarounds that obscure intent?
+
+Sample files may be referenced as *illustrations* of a domain need, but "no sample uses this" is never evidence against inclusion.
+
+---
+
+## 1. FEEL Comparison (DMN — Friendly Enough Expression Language)
+
+FEEL is the closest comparable to Precept: it's the expression language for DMN decision tables, used to express business constraints and decision logic.
+
+### 1.1 Numeric Functions
+
+| FEEL Function | Precept Equivalent | Notes |
+|---|---|---|
+| `abs(n)` | `abs(x)` | ✅ Direct match |
+| `floor(n)` | `floor(x)` | ✅ Direct match |
+| `floor(n, scale)` | — | FEEL allows floor-to-N-places. Precept has `round(x, N)` but not floor/ceil with scale. |
+| `ceiling(n)` | `ceil(x)` | ✅ Direct match (different name) |
+| `ceiling(n, scale)` | — | Same gap as floor(n, scale). |
+| `decimal(n, scale)` | `round(x, N)` | ✅ Functionally equivalent (FEEL's `decimal` is round-to-scale) |
+| `round up(n, scale)` | — | Specific rounding mode. Precept uses banker's rounding only. |
+| `round down(n, scale)` | `truncate(x)` | `truncate` is round-toward-zero to integer. FEEL's is to arbitrary scale. |
+| `round half up(n, scale)` | — | FEEL offers 4 rounding modes; Precept offers 1 (banker's). |
+| `round half down(n, scale)` | — | Same. |
+| `modulo(a, b)` | `%` operator | ✅ Precept has `%` operator — no function needed |
+| `sqrt(n)` | — | Mathematical function. Not domain-relevant for business constraints. |
+| `log(n)` | — | Mathematical function. Exclude. |
+| `exp(n)` | — | Mathematical function. Exclude. |
+| `odd(n)` | — | Parity check. Expressible as `n % 2 != 0`. |
+| `even(n)` | — | Parity check. Expressible as `n % 2 == 0`. |
+| `random number()` | — | Non-deterministic. Violates Precept's determinism guarantee. Exclude permanently. |
+
+### 1.2 String Functions
+
+| FEEL Function | Precept Equivalent | Notes |
+|---|---|---|
+| `upper case(s)` | `toUpper(s)` | ✅ Direct match |
+| `lower case(s)` | `toLower(s)` | ✅ Direct match |
+| `starts with(s, match)` | `startsWith(s, match)` | ✅ Direct match |
+| `ends with(s, match)` | `endsWith(s, match)` | ✅ Direct match |
+| `contains(s, match)` | `contains` operator | ✅ Precept's `contains` is an operator, not a function. Works on strings and collections. |
+| `trim(s)` | `trim(s)` | ✅ Direct match |
+| `string length(s)` | `.length` accessor | ✅ Precept exposes `.length` on strings — no function needed |
+| `substring(s, start)` | — | String slicing. See recommendations below. |
+| `substring(s, start, len)` | — | String slicing. See recommendations below. |
+| `substring before(s, m)` | — | String extraction before a delimiter. |
+| `substring after(s, m)` | — | String extraction after a delimiter. |
+| `matches(s, regex)` | — | Regex matching. See recommendations below. |
+| `replace(s, regex, rep)` | — | Regex replacement. Mutating-ish. |
+| `split(s, delim)` | — | String-to-list. Precept has no list-of-string type. |
+| `is blank(s)` | — | Equivalent to `trim(s) == ""` or combined with `notempty` constraint. |
+| `uuid()` | — | Non-deterministic. Violates determinism. Exclude permanently. |
+
+### 1.3 List Functions
+
+| FEEL Function | Precept Equivalent | Notes |
+|---|---|---|
+| `count(list)` | `.count` accessor | ✅ Already covered |
+| `min(list)` | `.min` accessor | ✅ Already covered |
+| `max(list)` | `.max` accessor | ✅ Already covered |
+| `sum(list)` | `.sum` accessor | ✅ Already covered |
+| `list contains(list, e)` | `contains` operator | ✅ Already covered |
+| `mean(list)` | — | Average. See recommendations. |
+| `median(list)` | — | Statistical. Likely v2+ at best. |
+| `stddev(list)` | — | Statistical. Exclude for v1. |
+| `all(list)` / `any(list)` | `all` / `any` keywords | ✅ Precept has these as guard quantifiers |
+| `is empty(list)` | `.count == 0` or `notempty` constraint | ✅ Already expressible |
+| `sort`, `append`, `concatenate`, `flatten`, `reverse`, etc. | — | List mutation/construction. Precept collections are action-mutated, not expression-constructed. Exclude. |
+
+### 1.4 FEEL Summary
+
+**Precept covers 15 of FEEL's ~20 domain-relevant functions.** The gaps are:
+- `substring` / string slicing — domain-relevant for extracting prefixes from structured identifiers (policy numbers, claim IDs, permit codes). Candidate for v2.
+- `matches` (regex) — strongest v2 candidate; 4-system consensus (see consensus matrix)
+- `contains` for strings — already an operator in Precept
+- Statistical aggregates (mean, median) — domain-relevant for threshold constraints (average claim amounts, average spend tiers). Candidate for v2.
+- Rounding mode variants — Precept's single banker's rounding is sufficient for financial domains
+
+---
+
+## 2. Cedar Comparison (AWS Authorization Policy Language)
+
+Cedar is a **pure constraint language** — policies evaluate to permit/forbid with no mutation. This makes it the most philosophically aligned comparison.
+
+### 2.1 What Cedar Provides
+
+Cedar is deliberately minimal in its function surface:
+
+| Cedar Feature | Precept Equivalent | Notes |
+|---|---|---|
+| `==`, `!=`, `<`, `<=`, `>`, `>=` | Same operators | ✅ Identical |
+| `&&`, `\|\|`, `!` | `and`, `or`, `not` | ✅ Keyword equivalents |
+| `+`, `-`, `*` (long only) | `+`, `-`, `*`, `/`, `%` | ✅ Precept has more (division, modulo) |
+| `like` (wildcard match) | — | Simpler than regex. Interesting but narrow. |
+| `decimal()` (string→decimal) | N/A (Precept has native decimal type) | Not needed |
+| `datetime()`, `duration()` | N/A (Precept has no date/time types) | Not applicable currently |
+| `.contains()`, `.containsAll()`, `.containsAny()` | `contains` operator | Partial — Precept's `contains` is single-element. No `containsAll`/`containsAny`. |
+| `.isEmpty()` | `.count == 0` | ✅ Expressible |
+| `if/then/else` | `if/else` guard branches | ✅ Covered |
+| `has` (attribute presence) | Nullable + `!= null` | ✅ Covered differently |
+
+### 2.2 What Cedar Excludes
+
+Cedar has **no**:
+- `abs`, `floor`, `ceil`, `round`, `min`, `max` — no numeric functions at all
+- `toLower`, `toUpper`, `trim`, `startsWith`, `endsWith` — no string functions
+- No division operator, no modulo
+- No aggregate functions
+
+### 2.3 Cedar Takeaway
+
+Cedar validates Precept's overall approach — **keep the function library small** — but Cedar is so minimal it doesn't help validate specific function choices. Cedar does confirm that a constraint language can be fully useful with a very small expression surface. The one interesting Cedar feature Precept lacks is **`containsAll` / `containsAny`** for set operations, which Precept could express as collection accessors in a later version.
+
+---
+
+## 3. Drools/NRules Comparison
+
+Drools DRL and NRules are rule-engine expression languages. They sit closer to general-purpose programming than Precept.
+
+### 3.1 Drools DRL Built-in Functions
+
+Drools primarily delegates to the host language (Java) for functions, but DRL MVEL/FEEL-mode provides:
+
+| Drools/NRules Feature | Precept Equivalent | Notes |
+|---|---|---|
+| `Math.abs()`, `Math.min()`, `Math.max()` | `abs`, `min`, `max` | ✅ Match |
+| `Math.floor()`, `Math.ceil()`, `Math.round()` | `floor`, `ceil`, `round` | ✅ Match |
+| `String.toLowerCase()`, `toUpperCase()` | `toLower`, `toUpper` | ✅ Match |
+| `String.startsWith()`, `endsWith()`, `contains()` | `startsWith`, `endsWith`, `contains` | ✅ Match |
+| `String.trim()` | `trim` | ✅ Match |
+| `String.length()` | `.length` accessor | ✅ Match |
+| `String.matches(regex)` | — | Regex. Same gap as FEEL. |
+| `String.substring(start, end)` | — | Same gap as FEEL. |
+| `String.replace()` | — | String mutation. |
+| Collection `size()`, `contains()`, `isEmpty()` | `.count`, `contains`, `.count == 0` | ✅ Match |
+| `accumulate` (sum, avg, min, max, count) | Collection accessors | ✅ Partially covered |
+| Type coercion functions | N/A | Precept is statically typed — not needed |
+
+### 3.2 NRules (.NET)
+
+NRules delegates entirely to C# — no built-in function library of its own. It uses LINQ and .NET BCL methods directly. This confirms that .NET rule engines don't need a custom function library beyond what the host language provides. For Precept, which *is* the language, the proposed functions fill this role.
+
+### 3.3 Drools/NRules Takeaway
+
+**Full alignment.** Every function in Precept's proposal has a Drools equivalent. The main gap is `matches` (regex), which Drools inherits from Java. Drools also confirms that `abs`, `min`, `max`, `floor`, `ceil`, `round` are the core numeric functions rule authors actually use.
+
+---
+
+## 4. Zod/Valibot Comparison
+
+Zod and Valibot are schema validation libraries. Their "functions" are validation methods (constraints), not expression-level functions. This distinction matters for Precept.
+
+### 4.1 String Operations
+
+| Zod/Valibot | Is it a function or constraint? | Precept Coverage |
+|---|---|---|
+| `.min(n)`, `.max(n)`, `.length(n)` | Constraint (string length) | ✅ `minlength`, `maxlength` constraints |
+| `.regex(pattern)` | Constraint (pattern match) | ⚠️ Gap — no regex in Precept |
+| `.startsWith(s)`, `.endsWith(s)` | Constraint (prefix/suffix check) | ✅ `startsWith`, `endsWith` functions |
+| `.includes(s)` | Constraint (substring check) | ✅ `contains` operator |
+| `.trim()` | Transform (whitespace removal) | ✅ `trim` function |
+| `.toLowerCase()`, `.toUpperCase()` | Transform (case conversion) | ✅ `toLower`, `toUpper` functions |
+| `.uppercase()`, `.lowercase()` | Constraint (must be all-upper/all-lower) | ⚠️ No constraint equivalent, but `toLower(x) == x` is expressible |
+| `.email()` | Format validator | ❌ Precept doesn't validate email format — correct for its domain |
+| `.uuid()` | Format validator | ❌ Same — format validation is a validation-library concern |
+| `.url()`, `.ipv4()`, `.ipv6()` | Format validators | ❌ Infrastructure/network domain, not Precept's domain |
+| `.datetime()`, `.date()`, `.time()` | Format validators | ❌ Precept has no date/time types yet |
+
+### 4.2 Numeric Operations
+
+| Zod/Valibot | Is it a function or constraint? | Precept Coverage |
+|---|---|---|
+| `.min(n)`, `.max(n)` | Constraint (range bounds) | ✅ `min`, `max` constraint keywords |
+| `.positive()`, `.nonnegative()` | Constraint | ✅ `positive`, `nonnegative` constraint keywords |
+| `.negative()`, `.nonpositive()` | Constraint | ⚠️ Not in Precept. Expressible as `max 0` or invariant. |
+| `.multipleOf(n)` / `.step(n)` | Constraint | ⚠️ Not in Precept. Expressible as `x % n == 0`. |
+| `.int()` | Constraint (integer check) | ✅ Separate `integer` type in Precept |
+| `.finite()` | Constraint | ✅ Precept numbers are always finite (no Infinity/NaN) |
+
+### 4.3 Zod/Valibot Takeaway
+
+**Most Zod/Valibot operations map to Precept's constraint keywords, not functions.** The main gaps are:
+- **`regex` / `matches`**: The only cross-system gap that consistently appears
+- Format validators (email, UUID, URL): Not relevant to Precept's domain — these are infrastructure/identity concerns, not business-entity integrity constraints
+
+---
+
+## 5. FluentValidation Comparison
+
+FluentValidation is .NET's dominant validation library. Its validators are closest to Precept's constraint model.
+
+| FluentValidation Validator | Is it a function or constraint? | Precept Coverage |
+|---|---|---|
+| `NotNull()` | Constraint (non-null) | ✅ `nullable` / `!= null` invariant |
+| `NotEmpty()` | Constraint (non-empty) | ✅ `notempty` constraint keyword |
+| `Equal()`, `NotEqual()` | Constraint (equality) | ✅ `==`, `!=` operators |
+| `Length(min, max)` | Constraint (string length range) | ✅ `minlength`, `maxlength` constraint keywords |
+| `MinimumLength(n)`, `MaximumLength(n)` | Constraint | ✅ Same |
+| `LessThan(n)`, `GreaterThan(n)` | Constraint (comparison) | ✅ `<`, `>` operators |
+| `LessThanOrEqualTo(n)`, `GreaterThanOrEqualTo(n)` | Constraint | ✅ `<=`, `>=` operators |
+| `InclusiveBetween(a, b)` | Constraint (range) | ✅ Expressible as `x >= a and x <= b` |
+| `ExclusiveBetween(a, b)` | Constraint (range) | ✅ Expressible as `x > a and x < b` |
+| `Matches(regex)` | Constraint (pattern match) | ⚠️ Gap — no regex in Precept |
+| `EmailAddress()` | Format validator | ❌ Domain-specific. Not Precept's concern. |
+| `CreditCard()` | Format validator (Luhn) | ❌ Domain-specific. Not Precept's concern. |
+| `PrecisionScale(p, s)` | Constraint (decimal precision) | ✅ `maxplaces` constraint keyword |
+| `IsInEnum()` | Constraint (valid enum value) | ✅ `choice` type in Precept |
+| `Must(predicate)` | Custom predicate | N/A — Precept invariants serve this role |
+
+### 5.1 FluentValidation Takeaway
+
+**Near-complete coverage.** Precept's constraint keywords handle almost everything FluentValidation provides as built-in validators. The only recurring gap is `Matches(regex)` — regex-based pattern validation.
+
+---
+
+## 6. Consensus Matrix
+
+Functions/operations that appear in **3 or more** surveyed systems, rated for Precept relevance:
+
+| Function | FEEL | Cedar | Drools | Zod | FV | Count | Precept Status | Recommendation |
+|---|---|---|---|---|---|---|---|---|
+| `abs` | ✅ | — | ✅ | — | — | 2 | ✅ Proposed | **Ship as proposed** |
+| `floor` | ✅ | — | ✅ | — | — | 2 | ✅ Proposed | **Ship as proposed** |
+| `ceil` | ✅ | — | ✅ | — | — | 2 | ✅ Proposed | **Ship as proposed** |
+| `round` | ✅ | — | ✅ | — | — | 2 | ✅ Proposed | **Ship as proposed** |
+| `truncate` | ✅ | — | ✅ | — | — | 2 | ✅ Proposed | **Ship as proposed** |
+| `min` (variadic) | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `max` (variadic) | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `toLower` | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `toUpper` | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `startsWith` | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `endsWith` | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `trim` | ✅ | — | ✅ | ✅ | — | 3 | ✅ Proposed | **Ship as proposed** |
+| `contains` (string) | ✅ | ✅ | ✅ | ✅ | — | 4 | ✅ `contains` operator | **Already covered** |
+| `length` (string) | ✅ | — | ✅ | ✅ | ✅ | 4 | ✅ `.length` accessor | **Already covered** |
+| `regex/matches` | ✅ | — | ✅ | ✅ | ✅ | 4 | ❌ Gap | **Consider for v2** |
+| `isEmpty` (collection) | ✅ | ✅ | ✅ | — | ✅ | 4 | ✅ `.count == 0` | **Already expressible** |
+| `count` (collection) | ✅ | — | ✅ | — | — | 2 | ✅ `.count` accessor | **Already covered** |
+| `sum` (collection) | ✅ | — | ✅ | — | — | 2 | ✅ `.sum` accessor | **Already covered** |
+| `between` (range) | — | — | — | — | ✅ | 1 | Expressible via `>=`/`<=` | **Already expressible** |
+| `email` (format) | — | — | — | ✅ | ✅ | 2 | ❌ Not proposed | **Exclude permanently** |
+| `substring` | ✅ | — | ✅ | — | — | 2 | ❌ Not proposed | **Consider for v2** |
+| `mean/average` | ✅ | — | ✅ | — | — | 2 | ❌ Not proposed | **Consider for v2** |
+
+---
+
+## 7. Recommendations
+
+### 7.1 Ship as Proposed (No Changes Needed)
+
+All 23 signatures in the Issue #16 proposal are validated by this survey. Every proposed function appears in at least 2 surveyed systems, and the core set (`abs`, `floor`, `ceil`, `round`, `min`, `max`, `toLower`, `toUpper`, `startsWith`, `endsWith`, `trim`) appears in 3+. The proposal is well-scoped and well-grounded.
+
+### 7.2 Include Now — Additional Functions
+
+**None.** The current proposal covers all domain-relevant, pure, total, deterministic functions needed for v1. No surveyed system revealed a function that (a) appears in 3+ systems, (b) is pure/total/deterministic, (c) serves a domain need Precept can't already express, AND (d) isn't already in the proposal.
+
+The strongest "near-miss" is `contains` for string substring testing, but Precept already has the `contains` operator that works on strings. No addition needed.
+
+### 7.3 Consider for v2
+
+| Function | Consensus | Domain Example | Rationale | Pure/Total? |
+|---|---|---|---|---|
+| **`matches(s, pattern)`** (regex) | 4/5 systems | Insurance: policy/claim number formats; Loans: SSN, account number patterns; Healthcare: patient IDs, NPI numbers; Government: case/permit ID formats; Logistics: tracking number patterns; Billing: invoice reference codes | Strongest v2 candidate — highest consensus of any non-proposed function. Deferred from v1 because: (a) regex is a sub-language — adds irreducible complexity to the DSL grammar, parser, and tooling, (b) needs design work on whether pattern is a string literal or a new type. `choice` covers enumerated-value constraints but does NOT cover format validation of structured identifiers, which is a distinct and widespread domain need. | Pure: yes. Total: yes (always returns boolean). Deterministic: yes. |
+| **`substring(s, start, len?)`** | 2/5 systems (FEEL, Drools) | Insurance: extract claim category prefixes; Government: parse jurisdiction codes from permit IDs; Logistics: extract carrier codes from tracking numbers; Billing: extract department codes from invoice references | Operationally useful for decomposing structured identifiers. Tension with Precept's constraint-not-transformation principle, though reading a substring for comparison purposes IS a constraint operation. OOB index behavior needs design. | Pure: yes. Total: debatable (OOB indices). Deterministic: yes. |
+| **`mean(collection)`** / **`.avg` accessor** | 2/5 systems (FEEL, Drools) | Insurance: average claim amount thresholds for fraud flags; Subscriptions: average monthly usage for tier classification; Healthcare: average wait time constraints; Billing: average spend thresholds for discount eligibility; Hiring: average interview score minimums | Genuine domain need across verticals where threshold constraints reference central tendency. Natural fit as `.avg` accessor alongside `.min`, `.max`, `.sum`. Workaround (`.sum / .count`) is clean but obscures intent. | Pure: yes. Total: yes if non-empty is preconditioned (same as `.min`/`.max`). Deterministic: yes. |
+| **`containsAll(set, set)`** / **`containsAny(set, set)`** | 2/5 systems (FEEL, Cedar) | Government: all required documents submitted; Healthcare: all mandatory screenings completed; Hiring: all required interview stages passed; Insurance: all required coverage types present; Compliance: any of listed certifications held | Set-completeness and set-overlap checks. Currently expressible only through multiple `contains` conjunctions, which is verbose and error-prone for larger required sets. Strong candidate as operators or collection methods. | Pure: yes. Total: yes. Deterministic: yes. |
+
+### 7.4 Exclude Permanently
+
+| Function | Reason | Precept Principle Violated |
+|---|---|---|
+| `random()` / `uuid()` | Non-deterministic | Determinism guarantee — fire/inspect must produce the same result for the same inputs |
+| `sqrt`, `log`, `exp` | Mathematical/scientific functions | Not domain-relevant for business entity integrity constraints |
+| `email()`, `creditCard()`, `url()`, `ipv4()` | Format validators | Infrastructure/identity concerns, not business-entity lifecycle constraints. A Precept governs *how an entity evolves*, not *what format a string is in*. Format validation belongs in the ingestion layer, not the domain integrity layer. |
+| `replace(s, pattern, rep)` | String mutation/transformation | Precept functions are for constraint expressions, not data transformation. `set` actions handle mutation. |
+| `split(s, delim)` | String-to-list construction | Precept has no dynamically-constructed collections. Collections are declared fields mutated by actions. |
+| `sort`, `reverse`, `append`, `flatten` | List construction/mutation | Same — collections are action-mutated, not expression-constructed. |
+| `odd()`, `even()` | Parity checks | Trivially expressible as `x % 2 == 0` / `x % 2 != 0`. Adding dedicated functions violates minimal ceremony. |
+
+---
+
+## 8. Cross-Cutting Observations
+
+### 8.1 Precept's Constraint Keywords Cover What Other Systems Implement as Functions
+
+A key finding: many things other systems expose as functions (range checks, non-null, non-empty, length bounds, positivity) are already first-class **constraint keywords** in Precept (`nonnegative`, `positive`, `min`, `max`, `notempty`, `minlength`, `maxlength`, `mincount`, `maxcount`, `maxplaces`). This means Precept needs *fewer* functions than comparable systems — the constraint surface absorbs validation that other systems must encode as function calls.
+
+### 8.2 Collection Accessors Cover What Other Systems Implement as Functions
+
+Similarly, FEEL's `count()`, `min()`, `max()`, `sum()` are functions; Precept's `.count`, `.min`, `.max`, `.sum` are **accessors** on collection types. Same information, different mechanism. No function duplication needed.
+
+### 8.3 Cedar Confirms the "Small Is Correct" Thesis
+
+Cedar — the most constraint-oriented system surveyed — has the smallest function surface of all: no numeric functions, no string functions, no aggregates. It proves that a constraint language can be complete and useful with an extremely small expression surface. Precept's 23 functions is already significantly more than what the most similar system provides.
+
+### 8.4 The Regex Gap Is Real and Domain-Significant
+
+`matches` / regex is the only function with 4-system consensus that Precept doesn't cover. Every surveyed business vertical has structured identifiers with format constraints that `choice` cannot express — policy numbers, claim IDs, SSNs, permit codes, tracking numbers, invoice references, patient IDs. Format validation of structured identifiers is a fundamental constraint need, distinct from enumerated-value validation.
+
+The deferral to v2 rests on principled design cost, not absence of need:
+- Adding regex embeds a **sub-language** in Precept — irreducible complexity in grammar, parser, type checker, and tooling
+- Design decisions are needed: string literal patterns vs. a dedicated pattern type, supported regex subset, error reporting for invalid patterns
+- **Recommendation:** Strongest v2 candidate. Design a constrained subset (literal patterns only, no backreferences, no dynamic construction) and ship early in the v2 cycle.
+
+---
+
+## 9. Final Assessment
+
+**The Issue #16 proposal is well-calibrated for v1.** It covers every pure, total, deterministic function that appears in 2+ surveyed systems and serves domain-relevant constraint expression. No function meets ALL of these criteria simultaneously: (a) 3+ system consensus, (b) pure/total/deterministic, (c) addresses an expressibility gap not already covered by Precept's constraint keywords or collection accessors, AND (d) doesn't introduce irreducible design complexity (like a sub-language).
+
+The proposal's restraint is validated by principled analysis: Cedar proves constraint languages work with far less, while FEEL shows Precept has already covered the domain-critical subset of a much larger function library. Precept's constraint keywords and collection accessors cover significant ground that other systems must handle via functions, keeping the function count appropriately minimal.
+
+**The v2 pipeline is stronger than previously assessed.** After removing sample-corpus bias from the evaluation:
+- **`matches` (regex)** has the strongest case — 4/5 consensus, domain-critical across every surveyed vertical, pure/total/deterministic. Deferred solely for sub-language design complexity.
+- **`.avg` accessor** has genuine cross-vertical need for threshold constraints referencing central tendency.
+- **`containsAll` / `containsAny`** address real verbosity pain for multi-element set checks in compliance and workflow domains.
+- **`substring`** serves structured-identifier decomposition needs, though it sits in tension with the constraint-not-transformation principle.

--- a/research/language/expressiveness/function-library-comparison.md
+++ b/research/language/expressiveness/function-library-comparison.md
@@ -1,0 +1,283 @@
+# Function Library Comparison — Excel, SQL, .NET
+
+External research grounding for [#16 — Built-in function library](https://github.com/sfalik/Precept/issues/16). This document maps relevant functions from Excel, SQL, and .NET `System.Math` against Precept's proposed 23-signature library to identify gaps, validate coverage, and recommend additions or exclusions.
+
+**Evaluation filter:** Precept is a constraint language governing business entity lifecycle integrity. Every function must be pure, total, deterministic, and free of side effects. General-purpose computation, formatting, and data transformation functions are out of scope.
+
+> **Methodology correction (2025-04-11):** An earlier version of this document used "no sample demonstrates the need" as evidence to exclude functions. This is circular reasoning — the sample `.precept` files cannot use functions that don't exist yet, and the sample corpus is not complete. This revision eliminates sample-corpus-based reasoning from all evaluations.
+>
+> **Corrected evaluation criteria:**
+> - **Domain relevance:** Would real business entities (insurance, loans, hiring, hospitality, logistics, maintenance, billing, subscriptions, healthcare, government, legal) use this function in lifecycle constraints?
+> - **Design principle fit:** Is the function pure, total, deterministic?
+> - **Consensus across systems:** How many surveyed systems (Excel, SQL, .NET) include it?
+> - **Prevention gap:** Does the absence of this function prevent authors from expressing a constraint the domain needs?
+>
+> Every function previously dismissed with sample-based reasoning has been re-evaluated against these criteria.
+
+---
+
+## 1. Excel Comparison Table
+
+### Math / Numeric
+
+| Excel Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `ABS(n)` | number → number | `abs(n)` (proposed) | No | Symmetric range checks. `maintenance-work-order`: `abs(ActualHours - EstimatedHours) <= 4` replaces one-sided guard. | ✅ Covered |
+| `FLOOR(n, sig)` | number × number → number | `floor(n)` (proposed, 0-arg floor-to-integer) | No | Rounding allocation quantities down. `event-registration`: integer seat counts from computed decimals. | ✅ Covered |
+| `CEILING(n, sig)` | number × number → number | `ceil(n)` (proposed, 0-arg ceil-to-integer) | No | Rounding up for minimum allocations. `apartment-rental`: ceil of income ratios. | ✅ Covered |
+| `ROUND(n, d)` | number × number → number | `round(n, N)` (implemented) | No | Already in production: `travel-reimbursement`, `event-registration` use `round(expr, 2)`. | ✅ Covered |
+| `ROUNDUP(n, d)` | number × number → number | None | Partial | Always rounds away from zero. For positive numbers, equivalent to `ceil`. For Precept's domain (non-negative financial amounts), `ceil` suffices. Away-from-zero rounding on negative values has no domain-relevant lifecycle use. | ❌ Exclude |
+| `ROUNDDOWN(n, d)` | number × number → number | `truncate(n)` (proposed) | Partial | For positive numbers, same as `truncate`/`floor`. Multi-decimal-place round-down is covered by `round` with appropriate precision; a dedicated function adds no constraint capability beyond what `round` and `truncate` provide. | ❌ Exclude |
+| `TRUNC(n, d)` | number × number → number | `truncate(n)` (proposed) | No | Dropping fractional parts. `fee-schedule`: truncating intermediate fee calculations. | ✅ Covered |
+| `MIN(a, b, ...)` | variadic → number | `min(a, b, ...)` (proposed) | No | Capping values: `insurance-claim` approved ≤ claimed. `hiring-pipeline`: min of score thresholds. | ✅ Covered |
+| `MAX(a, b, ...)` | variadic → number | `max(a, b, ...)` (proposed) | No | Floor values: `loan-application` minimum credit score enforcement via computed values. | ✅ Covered |
+| `MOD(n, d)` | number × number → number | `%` operator | No | Modulo already available as infix. Same semantics. | ✅ Covered (operator) |
+| `SIGN(n)` | number → number | None | Minimal | Returns -1/0/1. Direction-of-change constraints ("adjustment must be positive", "balance must not change sign") are expressible with comparison operators: `x > 0`, `x < 0`, `x == 0`. The composed form `(a > 0 and b > 0) or (a < 0 and b < 0)` covers "same sign" checks. The integer result provides no additional constraint power beyond what comparisons already offer. Present in 3/3 surveyed systems, but for general math — not constraint-specific use. | ❌ Exclude |
+| `INT(n)` | number → number | `floor(n)` | No | `INT` rounds toward negative infinity, same as `floor`. Covered. | ✅ Covered |
+| `POWER(b, e)` | number × number → number | `pow(base, exponent)` (proposed) | Gap — Include | Exponentiation. Domain uses: compound interest ceilings in loan and insurance constraints (`principal * pow(1 + rate, periods)`), penalty escalation that doubles each overdue period (billing, government), declining-balance depreciation thresholds (maintenance, asset management). Present in 3/3 surveyed systems. With exponent restricted to non-negative integers, the function is total. Without `pow`, these constraints are inexpressible — manual expansion (`rate * rate * rate * ...`) is neither general nor practical. | ✅ Include now |
+| `SQRT(n)` | number → number | None | No gap | Square root. Partial for negative inputs — violates totality. No business-entity lifecycle constraint in any domain (insurance, loans, healthcare, etc.) requires computing square roots; statistical calculations are host-application concerns. | ❌ Exclude |
+| `LOG(n, b)` | number × number → number | None | No gap | Logarithms. Partial for non-positive inputs — violates totality. No domain-relevant lifecycle constraint requires logarithmic computation. | ❌ Exclude |
+| `LN(n)` | number → number | None | No gap | Natural log. Same reasoning as `LOG` — partial function, no domain need. | ❌ Exclude |
+
+### String / Text
+
+| Excel Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `LOWER(s)` | string → string | `toLower(s)` (proposed) | No | Case-insensitive guards. `customer-profile`: comparing contact methods regardless of case. | ✅ Covered |
+| `UPPER(s)` | string → string | `toUpper(s)` (proposed) | No | Normalizing comparisons. `payment-method`: normalizing currency codes. | ✅ Covered |
+| `TRIM(s)` | string → string | `trim(s)` (proposed) | No | Input sanitization in constraints. `hiring-pipeline`: ensuring trimmed names aren't empty. | ✅ Covered |
+| `LEFT(s, n)` | string × number → string | None | Minimal | Extract first N characters. Prefix matching in business constraints (account number prefixes, policy type codes) is a real domain need, but `startsWith(s, prefix)` already covers the boolean constraint case. `left` returns a string value, which is a transformation operation — Precept governs what data must satisfy, and prefix-presence is testable without extraction. | ❌ Exclude |
+| `RIGHT(s, n)` | string × number → string | None | Minimal | Extract last N characters. Suffix matching (file extensions, trailing codes) is a real domain pattern, but `endsWith(s, suffix)` covers the boolean constraint case. Same design-principle reasoning as `LEFT` — extraction is transformation, not constraint validation. | ❌ Exclude |
+| `MID(s, start, len)` | string × number × number → string | None | Gap | Positional substring extraction. Domain need: embedded format codes within identifiers — insurance policy numbers with embedded state codes at positions 3-4, account numbers with embedded branch codes, serial numbers with embedded manufacturer codes. `startsWith`/`endsWith` only cover prefix/suffix; mid-string positional validation requires extraction. Without `substring`, authors cannot express "characters 3-5 of PolicyNumber must be a valid state code." Prevention gap exists for mid-string format validation. | ⏳ Consider v2 |
+| `LEN(s)` | string → number | `.length` accessor (issue #10) | No | String length validation. `insurance-claim`: `DecisionNote.length <= 500`. `building-access-badge`: `AccessReason.length <= 200`. Already in use in samples. | ✅ Covered (accessor) |
+| `FIND(find, within)` | string × string → number | None | Minimal | Returns position index. The constraint use case is "does it contain?" not "where?" — `contains` operator (issue #15) covers the boolean case. The integer position has no constraint utility in business-entity lifecycle rules. | ❌ Exclude |
+| `SEARCH(find, within)` | string × string → number | None | Minimal | Case-insensitive FIND. Same analysis — the integer position is not useful for constraint logic. The boolean presence test is the domain need, covered by `contains`. | ❌ Exclude |
+| `SUBSTITUTE(s, old, new)` | string × string × string → string | None | Minimal | String mutation. Domain uses exist — normalizing formats (stripping hyphens from SSNs, normalizing phone numbers) for comparison. However, Precept's design principle is to govern what data *must look like*, not to transform it. Normalization is a host-application responsibility: the host normalizes, Precept validates the normalized result. This is a design-principle exclusion — substitution is transformation, not constraint validation. | ❌ Exclude |
+| `REPLACE(s, start, n, new)` | string × number × number × string → string | None | Minimal | Positional string mutation. Same design-principle reasoning as SUBSTITUTE — transformation belongs in the host application. Precept validates; it does not rewrite. | ❌ Exclude |
+| `TEXT(n, fmt)` | value × string → string | None | No gap | Number-to-string formatting. Display formatting is a presentation concern, not a constraint concern. No domain-relevant lifecycle constraint requires format-rendering a number into a string. | ❌ Exclude |
+| `CONCAT(a, b, ...)` | variadic → string | None | Small gap | String concatenation. Computed string values in `set` actions are a real domain pattern: display names from components, formatted references, combined identifiers. However, this is better addressed as a `+` operator overload on strings (separate proposal) rather than a function. | ⏳ Consider v2 |
+| `EXACT(a, b)` | string × string → boolean | `==` operator | No | Case-sensitive comparison. Precept `==` on strings is already case-sensitive. | ✅ Covered (operator) |
+| `REPT(s, n)` | string × number → string | None | No gap | String repetition. No domain-relevant lifecycle constraint requires repeating a string. | ❌ Exclude |
+
+### Logical
+
+| Excel Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `IF(cond, t, f)` | bool × T × T → T | Conditional expression (issue #9) | No | Covered by the conditional expression proposal, not the function library. | ✅ Covered (separate proposal) |
+| `AND(a, b, ...)` | variadic bool → bool | `and` operator (issue #31) | No | Logical conjunction. Already an operator. | ✅ Covered (operator) |
+| `OR(a, b, ...)` | variadic bool → bool | `or` operator (issue #31) | No | Logical disjunction. Already an operator. | ✅ Covered (operator) |
+| `NOT(b)` | bool → bool | `not` operator (issue #31) | No | Logical negation. Already an operator. | ✅ Covered (operator) |
+| `IFS(c1,v1,c2,v2,...)` | paired → T | Conditional expression chaining | No | Multi-branch conditional covered by chained conditionals when #9 ships. | ✅ Covered (separate proposal) |
+| `SWITCH(expr, v1,r1,...)` | matched → T | Conditional expression chaining | No | Same as IFS for constraint purposes. | ✅ Covered (separate proposal) |
+
+### Type Checking
+
+| Excel Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `ISNUMBER(v)` | any → bool | Static typing | No | Precept fields are statically typed. A `number` field is always a number. Type checking is structurally unnecessary. | ❌ Exclude |
+| `ISTEXT(v)` | any → bool | Static typing | No | Same reasoning — static typing eliminates the need. | ❌ Exclude |
+| `ISBLANK(v)` | any → bool | `== null` | No | Nullable fields use `== null` / `!= null`. | ✅ Covered (syntax) |
+| `ISERROR(v)` | any → bool | Totality guarantee | No | All Precept functions are total — they cannot produce errors. Error checking is structurally unnecessary. | ❌ Exclude |
+
+---
+
+## 2. SQL Comparison Table
+
+### Math
+
+| SQL Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `ABS(n)` | number → number | `abs(n)` (proposed) | No | Same as Excel analysis. | ✅ Covered |
+| `CEILING(n)` | number → number | `ceil(n)` (proposed) | No | Same as Excel analysis. | ✅ Covered |
+| `FLOOR(n)` | number → number | `floor(n)` (proposed) | No | Same as Excel analysis. | ✅ Covered |
+| `ROUND(n, d)` | number × int → number | `round(n, N)` (implemented) | No | Same as Excel analysis. | ✅ Covered |
+| `TRUNCATE(n, d)` | number × int → number | `truncate(n)` (proposed) | No | SQL TRUNCATE takes optional decimal places; Precept truncate is to-integer. For multi-place truncation, `round` with mode could cover it, but the proposal's to-integer `truncate` matches the most common domain need (drop all decimals). | ✅ Covered |
+| `MOD(n, d)` | number × number → number | `%` operator | No | Covered by operator. | ✅ Covered (operator) |
+| `POWER(b, e)` | number × number → number | `pow(base, exponent)` (proposed) | Gap — Include | Same as Excel analysis. Domain patterns across insurance, loans, and billing. With integer exponent restriction, total. | ✅ Include now |
+| `SIGN(n)` | number → int | None | Minimal | Same as Excel analysis. Comparison operators cover the constraint need; the integer result adds no constraint power. | ❌ Exclude |
+| `SQRT(n)` | number → number | None | No gap | Same as Excel analysis. Partial function; no domain need in business lifecycle constraints. | ❌ Exclude |
+| `GREATEST(a, b, ...)` | variadic → number | `max(a, b, ...)` (proposed) | No | SQL's `GREATEST` is Precept's variadic `max`. Direct mapping. | ✅ Covered |
+| `LEAST(a, b, ...)` | variadic → number | `min(a, b, ...)` (proposed) | No | SQL's `LEAST` is Precept's variadic `min`. Direct mapping. | ✅ Covered |
+
+### String
+
+| SQL Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `LOWER(s)` | string → string | `toLower(s)` (proposed) | No | Covered. | ✅ Covered |
+| `UPPER(s)` | string → string | `toUpper(s)` (proposed) | No | Covered. | ✅ Covered |
+| `TRIM(s)` | string → string | `trim(s)` (proposed) | No | Covered. | ✅ Covered |
+| `LTRIM(s)` | string → string | None | Minimal | Left-only trim. Domain need for asymmetric whitespace handling is negligible across business domains — full `trim` covers the common case. No business-entity lifecycle constraint requires selectively preserving trailing whitespace while stripping leading whitespace. | ❌ Exclude |
+| `RTRIM(s)` | string → string | None | Minimal | Right-only trim. Same design-principle reasoning as LTRIM — full `trim` covers the domain need. | ❌ Exclude |
+| `SUBSTRING(s, start, len)` | string × int × int → string | None | Gap | Positional format validation is a real domain need: embedded codes within structured identifiers (insurance policy numbers, account numbers, serial codes). `startsWith`/`endsWith` cover prefix/suffix but not mid-string extraction. Same analysis as Excel `MID`. | ⏳ Consider v2 |
+| `LEFT(s, n)` | string × int → string | None | Minimal | Same as Excel analysis. `startsWith` covers the boolean constraint case; extraction is transformation. | ❌ Exclude |
+| `RIGHT(s, n)` | string × int → string | None | Minimal | Same as Excel analysis. `endsWith` covers the boolean constraint case; extraction is transformation. | ❌ Exclude |
+| `LENGTH(s)` / `LEN(s)` | string → int | `.length` accessor (issue #10) | No | Covered. | ✅ Covered (accessor) |
+| `REPLACE(s, old, new)` | string × string × string → string | None | Minimal | String mutation. Same design-principle reasoning as Excel SUBSTITUTE — transformation is a host-application responsibility. Precept validates; it does not rewrite. | ❌ Exclude |
+| `CONCAT(a, b, ...)` | variadic → string | None | Small gap | Same as Excel analysis. | ⏳ Consider v2 |
+| `REVERSE(s)` | string → string | None | No gap | No domain-relevant lifecycle constraint requires reversing strings. | ❌ Exclude |
+| `LPAD(s, len, pad)` | string × int × string → string | None | No gap | Padding is a display/formatting concern — not a lifecycle constraint operation. | ❌ Exclude |
+| `RPAD(s, len, pad)` | string × int × string → string | None | No gap | Same as LPAD. | ❌ Exclude |
+| `POSITION(sub IN s)` / `CHARINDEX(sub, s)` | string × string → int | None | Minimal | Position finding. The integer position is not useful for lifecycle constraints. `contains` covers the boolean presence test, which is the domain need. | ❌ Exclude |
+
+### Type / Null
+
+| SQL Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `COALESCE(a, b, ...)` | variadic nullable → T | Conditional expression (issue #9) | No | Null-coalescing is a specific case of conditional: `x == null ? default : x`. The expression audit flags this as L7 (significant gap), but it is addressed by the conditional expression proposal, not the function library. A dedicated `??` operator could be considered separately. | ✅ Covered (separate proposal) |
+| `NULLIF(a, b)` | T × T → T? | None | No gap | Returns null if a == b. Extremely niche even in SQL; primary use case (avoiding division by zero) is handled by Precept's totality guarantees. No domain-relevant lifecycle constraint requires conditionally nulling a value based on equality. | ❌ Exclude |
+| `CAST(expr AS type)` / `CONVERT` | any → T | None | Design question | Type conversion between `integer`, `decimal`, and `number`. This is a type system design decision (how do types coerce in mixed expressions), not a function library question. The type checker already handles `integer` + `decimal` promotion. | ❌ Exclude (type system concern) |
+
+### Conditional
+
+| SQL Function | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `CASE WHEN c THEN v ... END` | conditional → T | Conditional expression (issue #9) | No | Core conditional expression. Covered by separate proposal. | ✅ Covered (separate proposal) |
+| `IIF(cond, t, f)` | bool × T × T → T | Conditional expression (issue #9) | No | Same. | ✅ Covered (separate proposal) |
+| `GREATEST(a, b, ...)` | variadic → T | `max(a, b, ...)` (proposed) | No | Already covered above. | ✅ Covered |
+| `LEAST(a, b, ...)` | variadic → T | `min(a, b, ...)` (proposed) | No | Already covered above. | ✅ Covered |
+
+---
+
+## 3. .NET `System.Math` Comparison
+
+| .NET Method | Signature | Precept Equivalent | Gap? | Domain Relevance | Verdict |
+|---|---|---|---|---|---|
+| `Math.Abs(n)` | number → number | `abs(n)` (proposed) | No | Covered. | ✅ Covered |
+| `Math.Floor(n)` | double → double | `floor(n)` (proposed) | No | Covered. | ✅ Covered |
+| `Math.Ceiling(n)` | double → double | `ceil(n)` (proposed) | No | Covered. | ✅ Covered |
+| `Math.Round(n, d)` | double × int → double | `round(n, N)` (implemented) | No | Covered. Uses MidpointRounding.ToEven (banker's rounding), matching Precept's semantics. | ✅ Covered |
+| `Math.Truncate(n)` | double → double | `truncate(n)` (proposed) | No | Covered. | ✅ Covered |
+| `Math.Min(a, b)` | T × T → T | `min(a, b, ...)` (proposed, variadic) | No | Precept's variadic version is a superset. | ✅ Covered |
+| `Math.Max(a, b)` | T × T → T | `max(a, b, ...)` (proposed, variadic) | No | Same. | ✅ Covered |
+| `Math.Sign(n)` | number → int | None | Minimal | Returns -1/0/1. Comparison operators (`> 0`, `< 0`, `== 0`) cover the constraint use case. The integer result adds no constraint power — direction checks are inherently boolean predicates in lifecycle rules. | ❌ Exclude |
+| `Math.Pow(b, e)` | double × double → double | `pow(base, exponent)` (proposed) | Gap — Include | Exponentiation. Domain patterns: compound interest ceilings (loans, insurance), penalty escalation (billing, government), declining-balance depreciation (maintenance). (1) With exponent restricted to non-negative integers, the function is total. (2) Compound interest constraints are real — a loan precept may need to enforce `TotalObligation <= Principal * pow(1 + Rate, MaxPeriods)` as an invariant. (3) Without `pow`, these constraints are inexpressible. | ✅ Include now |
+| `Math.Sqrt(n)` | double → double | None | No gap | Partial for negative inputs. No domain-relevant lifecycle constraint requires square roots — statistical/scientific computation is a host-application concern. | ❌ Exclude |
+| `Math.Log(n)` | double → double | None | No gap | Partial for non-positive inputs. No domain-relevant lifecycle constraint requires logarithms. | ❌ Exclude |
+| `Math.Log10(n)` | double → double | None | No gap | Same reasoning as `Math.Log`. | ❌ Exclude |
+| `Math.Log2(n)` | double → double | None | No gap | Same reasoning as `Math.Log`. | ❌ Exclude |
+| `Math.Clamp(v, min, max)` | T × T × T → T | `clamp(value, low, high)` (proposed) | Gap — Include | Clamp a value within a range. Domain uses are universal: capping approved insurance amounts, bounding discount percentages (0–100), enforcing dosage limits in healthcare, bounding benefit amounts in government programs, capping penalty amounts in billing. While composable as `max(low, min(high, v))`, the DSL readability improvement is significant — `clamp(Score, 0, 100)` is immediately clear to non-programmer domain experts; `min(max(Score, 0), 100)` requires mental unpacking. For a constraint language designed for business authors, readability of range-bounding — one of the most common constraint patterns — justifies a dedicated function. | ✅ Include now |
+| `Math.BitOperations.*` | various | None | No gap | Bitwise operations. No domain-relevant lifecycle constraint requires bitwise operations. | ❌ Exclude |
+| `Math.IEEERemainder` | double × double → double | `%` operator | No | Covered by modulo operator (different semantics, but `%` is the appropriate constraint-language version). | ✅ Covered (operator) |
+| `MathF.*` (float variants) | various | N/A | N/A | `MathF` mirrors `Math` for `float`. Precept uses `decimal`/`number`/`integer` — no need for float-specific variants. | N/A |
+
+---
+
+## 4. Recommendations
+
+### Include Now — Add to Proposal
+
+The corrected methodology reveals two functions that should be added to the current proposal, plus one that requires a cross-cutting design decision:
+
+| Function | Signature | Domain Evidence | Totality | Consensus |
+|---|---|---|---|---|
+| `pow(base, exponent)` | number × integer → number | Compound interest ceilings (loans, insurance), penalty escalation that doubles per period (billing, government, legal), declining-balance depreciation thresholds (maintenance, asset management). Without `pow`, these constraints are inexpressible — manual expansion is neither general nor practical. | **Total if exponent is restricted to non-negative integers.** `pow(x, 0)` = 1 for all x (including x=0, by convention). No undefined inputs. Fractional exponents of negative bases are avoided by type restriction. | 3/3 systems (Excel POWER, SQL POWER, .NET Math.Pow) |
+| `clamp(value, low, high)` | number × number × number → number | Range-bounding is one of the most common constraint patterns across all business domains: capping approved insurance amounts, bounding discount percentages (0–100), enforcing dosage limits (healthcare), bounding benefit amounts (government), capping penalties (billing), constraining scores and ratings. While composable as `max(low, min(high, v))`, the readability improvement is significant for a DSL targeting business authors. `clamp(Score, 0, 100)` is immediately clear; `min(max(Score, 0), 100)` requires mental unpacking. | **Total.** Defined for all numeric inputs. When low > high, returns high (same as .NET `Math.Clamp`). | 1/3 systems (.NET Math.Clamp), but the conceptual pattern is universal — Excel/SQL users compose it from MIN/MAX |
+
+**String contains (design decision needed):** The `contains` operator (issue #15) currently covers collection membership (`MySet contains "value"`). There is a real domain gap for **string containment** — testing whether a string contains a substring. Domain uses: email format validation (`Email contains "@"`), forbidden character detection, substring presence in free-text fields, domain checks in URLs/emails. This is pure, total, deterministic, and present in virtually every programming system. **Recommendation:** Extend `contains` to support string operands (issue #15 scope) or add a dedicated `strContains(haystack, needle)` function. This is a design decision, not a function-library question, but it represents a real prevention gap that this analysis surfaced.
+
+### Consider for v2
+
+| Function | Rationale | Domain Evidence | Blocker |
+|---|---|---|---|
+| `substring(s, start, length)` | Positional format validation: extracting embedded codes from structured identifiers. Insurance policy numbers with embedded state codes, account numbers with embedded branch identifiers, serial numbers with embedded manufacturer codes. `startsWith`/`endsWith` cover prefix/suffix but not mid-string positions. | Moderate — positional format validation is real but less common than prefix/suffix validation. Most format validation can be expressed with `startsWith`, `endsWith`, `.length`, and collection constraints. | Design question: Is positional substring extraction a constraint operation or a transformation? It returns a value for comparison, which straddles the line. |
+| String concatenation (as `+` operator overload, not a function) | Building computed string values in `set` actions: display names from components, formatted references, combined identifiers. | Moderate — computed string values are a real pattern in lifecycle management (composing display fields, building reference strings). | Not a function library question — this is an operator overload on string type. Separate proposal. |
+
+### Exclude
+
+| Category | Functions | Reason |
+|---|---|---|
+| **Partial functions** | `sqrt`, `log`, `ln`, `log10`, `log2` | Undefined for negative/zero inputs. Violates totality. No domain-relevant lifecycle constraint requires these mathematical operations — statistical and scientific computation belongs in the host application. |
+| **Sign/direction** | `sign` | Comparison operators (`> 0`, `< 0`, `== 0`) express direction-of-change constraints directly. The composed form `(a > 0 and b > 0) or (a < 0 and b < 0)` covers "same sign" checks. The integer result (-1/0/1) provides no additional constraint power beyond what comparisons already offer. |
+| **Substring extraction** | `left`, `right` | Boolean test functions (`startsWith`, `endsWith`) cover the constraint use case for prefix/suffix validation. Extracting substrings as values is a transformation operation — Precept validates, it does not extract. (`substring` for mid-string positional validation is considered for v2 separately.) |
+| **String mutation** | `substitute`, `replace`, `reverse` | Precept governs what data must look like, not how to transform it. String replacement and normalization are host-application responsibilities — the host normalizes, Precept validates the normalized result. This is a design-principle exclusion: transformation ≠ constraint. |
+| **String formatting** | `text`, `rept`, `lpad`, `rpad` | Display formatting is a presentation concern, not a lifecycle constraint operation. |
+| **Position finding** | `find`, `search`, `position`, `charindex` | The integer position has no constraint utility — the domain need is boolean presence testing, covered by `contains`. |
+| **Directional trim** | `ltrim`, `rtrim` | Standard `trim` covers the domain need. No business-entity lifecycle constraint requires selectively preserving whitespace on one side. |
+| **Type checking** | `isnumber`, `istext`, `isblank`, `iserror` | Static typing eliminates type checks. `== null` covers blank tests. Totality eliminates error checks. These are structurally unnecessary in Precept. |
+| **Type conversion** | `cast`, `convert`, `nullif` | Type coercion is a type system design question, not a function. `nullif` is SQL-specific (avoid division-by-zero) and unnecessary given Precept's totality guarantee. |
+| **Bitwise operations** | `Math.BitOperations.*` | No domain-relevant lifecycle constraint requires bitwise operations. |
+
+---
+
+## 5. Domain Evidence — Cross-Domain Gap Analysis
+
+> **Methodology note:** This section evaluates gaps by domain relevance across business verticals, not by sample coverage. The question is: "Would a precept author in this domain need this function?" — not "Does a sample file use it?"
+
+### `pow(base, exponent)` — Prevention gap: YES
+
+| Domain | Constraint Pattern | Why `pow` is required |
+|---|---|---|
+| **Loans / Lending** | Compound interest ceilings: `TotalObligation <= Principal * pow(1 + MonthlyRate, Periods)` | Loan lifecycle constraints must cap total obligation including compound interest. Without `pow`, the compound growth formula is inexpressible. |
+| **Insurance** | Reserve accumulation: `ReserveTarget >= BasePremium * pow(1 + GrowthRate, YearsActive)` | Insurance reserves grow exponentially. Lifecycle rules enforcing minimum reserves need exponentiation. |
+| **Billing / Penalties** | Penalty escalation: `LateFee <= BaseLateFee * pow(2, OverduePeriods)` | "Penalty doubles each period" is a real billing pattern. Without `pow`, authors must hard-code period-specific caps. |
+| **Government** | Inflation adjustment: `BenefitCap >= BaseAmount * pow(1 + InflationRate, YearsSinceBase)` | Government benefit programs adjust for inflation over time, requiring exponential growth invariants. |
+
+**Design constraint:** Exponent must be restricted to non-negative integers for totality. `pow(x, 0) = 1` for all x. `pow(0, n) = 0` for n > 0. No undefined inputs.
+
+### `clamp(value, low, high)` — Prevention gap: NO (but readability gap: YES)
+
+| Domain | Constraint Pattern | `clamp` vs. composed form |
+|---|---|---|
+| **Insurance** | `set ApprovedAmount = clamp(RequestedAmount, 0, PolicyLimit)` | vs. `set ApprovedAmount = min(max(RequestedAmount, 0), PolicyLimit)` |
+| **Billing / Subscriptions** | `set RetentionDiscount = clamp(ComputedDiscount, 0, 100)` | vs. `set RetentionDiscount = min(max(ComputedDiscount, 0), 100)` |
+| **Healthcare** | `set DosageAmount = clamp(CalculatedDose, MinDose, MaxDose)` | vs. `set DosageAmount = min(max(CalculatedDose, MinDose), MaxDose)` |
+| **Government** | `set BenefitAmount = clamp(EligibleAmount, 0, AnnualCap)` | vs. `set BenefitAmount = min(max(EligibleAmount, 0), AnnualCap)` |
+| **Any scored entity** | `set FinalScore = clamp(RawScore, 0, 100)` | vs. `set FinalScore = min(max(RawScore, 0), 100)` |
+
+Range-bounding is universal. The `clamp` form communicates intent directly ("bound this value to a range") while the composed form requires the reader to mentally reconstruct the range semantics. For a DSL targeting business authors, this readability difference justifies a dedicated function.
+
+### `sign(number)` — Prevention gap: NO
+
+Direction-of-change constraints are real (e.g., "adjustment must be positive", "balance must not change sign"). But these are inherently boolean predicates: `Adjustment > 0`, `(OldBalance > 0 and NewBalance > 0) or (OldBalance < 0 and NewBalance < 0)`. The integer result of `sign` (-1/0/1) provides no additional constraint power. Comparison operators are both sufficient and more readable in constraint expressions. Excludes on design-principle grounds.
+
+### `substring(s, start, length)` — Prevention gap: MODERATE
+
+Positional format validation exists in real domains: insurance policy numbers with embedded state codes at positions 3–4, account numbers with embedded branch identifiers, serial numbers with embedded manufacturer codes, government form numbers with embedded year codes. `startsWith`/`endsWith` cover prefix and suffix but cannot test mid-string positions. Without `substring`, a precept author cannot express "characters 3–5 of PolicyNumber must match StateCode" as a constraint.
+
+However, this need is less common than prefix/suffix validation, and the strongest version of this use case (complex format parsing) may be better served by regex support (out of scope for Precept). Mid-string positional extraction straddles the line between constraint validation and data transformation. Consider for v2.
+
+### `replace` / `substitute` — Prevention gap: WEAK
+
+String normalization use cases exist: comparing differently-formatted versions of phone numbers, stripping hyphens from identifiers for comparison. But this is fundamentally a transformation operation. Precept's design principle is that the host application normalizes data before lifecycle rules evaluate it. If a precept needs to compare `"555-1234"` and `"5551234"`, the host should normalize before submission, and the precept should validate the normalized form. This is a design-principle exclusion, not a capability gap — the prevention gap is real but the correct resolution is host-side normalization, not in-language string mutation.
+
+### String `contains` — Prevention gap: YES
+
+The `contains` operator currently covers collection membership. String containment — "does this string include this substring?" — is a distinct domain need:
+
+| Domain | Constraint Pattern |
+|---|---|
+| **Any entity with email** | `Email contains "@"` (basic format validation) |
+| **Insurance / Legal** | `ClaimDescription contains "fraud"` triggers review workflow |
+| **HR / Hiring** | `Resume contains RequiredCertification` |
+| **Government** | `ApplicationNotes contains "expedite"` flags priority processing |
+
+This is pure, total, deterministic, and present in virtually every surveyed system. The gap is real. Recommendation: address via `contains` operator overload for strings (issue #15 scope) or as a new function. This is a design decision that should be tracked.
+
+---
+
+## Summary
+
+> **Methodology correction applied.** This revision eliminates sample-corpus-based reasoning. All evaluations now use domain relevance, design-principle fit, cross-system consensus, and prevention-gap analysis.
+
+The corrected analysis recommends expanding the proposal from 23 to 25 signatures by adding **`pow(base, exponent)`** and **`clamp(value, low, high)`**:
+
+- **`pow`** closes a real prevention gap — compound interest, penalty escalation, and exponential growth constraints are inexpressible without it. With exponent restricted to non-negative integers, the function is total. All 3 surveyed systems include it.
+- **`clamp`** closes a readability gap — range-bounding is one of the most common constraint patterns across all business domains, and `clamp(x, lo, hi)` is dramatically clearer than `min(max(x, lo), hi)` for a DSL targeting business authors. Total for all inputs.
+- **String `contains`** is flagged as a real prevention gap that needs a design decision — extend the `contains` operator to strings (issue #15) or add a dedicated function. This is not a function-library question per se, but the gap is surfaced here because the analysis uncovered it.
+- **`substring`** moves from "Exclude" to "Consider v2" — mid-string positional format validation is a real domain need, though less common than prefix/suffix validation.
+- **`sign`**, **`left`/`right`**, **`replace`/`substitute`** remain excluded but with corrected reasoning — design-principle and domain-based exclusion, not sample-based.
+
+The numeric core (`abs`, `floor`, `ceil`, `round`, `truncate`, `min`, `max`, **`pow`**, **`clamp`**) now covers the complete set of business-grade numeric operations that are pure, total, and domain-relevant. The string functions (`toLower`, `toUpper`, `startsWith`, `endsWith`, `trim`) remain well-calibrated for constraint-relevant string operations.
+
+### Verdict Changes from Previous Version
+
+| Function | Previous Verdict | Revised Verdict | Reason for Change |
+|---|---|---|---|
+| `pow(base, exponent)` | ⏳ Consider v2 | ✅ **Include now** | Compound interest, penalty escalation, exponential growth are real domain patterns. Previous exclusion relied on "no sample expresses this" — circular reasoning. With integer exponent, total. |
+| `clamp(value, low, high)` | ⏳ Consider v2 (convenience) | ✅ **Include now** | Range-bounding is universal across domains. DSL readability improvement justifies dedicated function despite composability from min/max. |
+| `substring(s, start, len)` | ❌ Exclude permanently | ⏳ **Consider v2** | Mid-string positional format validation is a real domain need. Previous exclusion relied on "no sample needs substring values" — circular reasoning. |
+| String `contains` | Not assessed | 🔍 **Design decision needed** | Real prevention gap for string containment testing. Recommend addressing in issue #15 scope. |
+| `sign(number)` | ❌ Exclude permanently | ❌ Exclude | Verdict unchanged. Reasoning corrected from sample-based to domain-based (comparisons cover the constraint need). |
+| `left` / `right` | ❌ Exclude permanently | ❌ Exclude | Verdict unchanged. Reasoning corrected: `startsWith`/`endsWith` cover the boolean constraint case; extraction is transformation. |
+| `replace` / `substitute` | ❌ Exclude permanently | ❌ Exclude | Verdict unchanged. Reasoning corrected: design-principle exclusion (transformation ≠ constraint), not sample-based. |
+| `concat` (as function) | ❌ Exclude permanently | ❌ Exclude (function form) | Function form excluded; `+` operator overload on strings remains ⏳ Consider v2 as a separate proposal. |

--- a/research/language/expressiveness/superpower-keyword-function-disambiguation.md
+++ b/research/language/expressiveness/superpower-keyword-function-disambiguation.md
@@ -1,0 +1,438 @@
+# Superpower Keyword/Function Token Disambiguation Research
+
+**Date:** 2026-04-12
+**Author:** George (Runtime Dev)
+**Requested by:** Shane
+**Issue:** #16 — Built-in Functions
+**Problem:** `min` and `max` are tokenized as constraint keywords but need to also work as function names in expression position.
+
+---
+
+## 1. Superpower Capabilities for Token Matching
+
+Superpower 3.1.0 provides several mechanisms for matching tokens in the parser combinator layer:
+
+### 1.1 `Token.EqualTo(kind)`
+
+Matches a single token of exactly the specified kind. Returns the matched `Token<TKind>`:
+
+```csharp
+Token.EqualTo(PreceptToken.Min)  // matches a Min keyword token
+```
+
+### 1.2 `Token.EqualToValue(kind, value)`
+
+Matches a token of a given kind AND whose underlying text span equals a specific string:
+
+```csharp
+// Source: datalust/superpower src/Superpower/Parsers/Token.cs:66-79
+public static TokenListParser<TKind, Token<TKind>> EqualToValue<TKind>(TKind kind, string value)
+{
+    return EqualTo(kind).Where(t => t.Span.EqualsValue(value)).Named(Presentation.FormatLiteral(value));
+}
+```
+
+Useful when a single token kind covers multiple text values (e.g. matching a specific identifier).
+
+### 1.3 `Token.Matching(predicate, name)`
+
+Matches a token whose kind satisfies an arbitrary predicate:
+
+```csharp
+// Source: datalust/superpower src/Superpower/Parsers/Token.cs:94-109
+public static TokenListParser<TKind, Token<TKind>> Matching<TKind>(Func<TKind, bool> predicate, string name)
+```
+
+This enables matching *any of several* token kinds in a single combinator:
+
+```csharp
+Token.Matching<PreceptToken>(k => k == PreceptToken.Identifier || k == PreceptToken.Min || k == PreceptToken.Max, "function name")
+```
+
+### 1.4 `.Or()` chaining
+
+Standard alternative combinator. Multiple `Token.EqualTo()` calls chained:
+
+```csharp
+Token.EqualTo(PreceptToken.Identifier)
+    .Try().Or(Token.EqualTo(PreceptToken.Min))
+    .Try().Or(Token.EqualTo(PreceptToken.Max))
+```
+
+### 1.5 `.Try()` for backtracking
+
+When `.Try()` wraps a parser, a failed match resets the input position. **This is the standard Superpower mechanism for disambiguation** — try the more specific parse first, backtrack on failure. No allocation overhead when it succeeds:
+
+```csharp
+// Source: datalust/superpower src/Superpower/Combinators.cs:968-990
+public static TokenListParser<TKind, T> Try<TKind, T>(this TokenListParser<TKind, T> parser)
+{
+    return input =>
+    {
+        var rt = parser(input);
+        if (rt.HasValue)
+            return rt;
+        rt.Backtrack = true;
+        return rt;
+    };
+}
+```
+
+### 1.6 `Parse.Not()` for negative lookahead
+
+Tests that a parser does NOT match, without consuming input. Used by Serilog to distinguish property references from function calls:
+
+```csharp
+// Serilog pattern: "this is NOT a function call, so it's a property"
+from notFunction in Parse.Not(Token.EqualTo(Identifier).IgnoreThen(Token.EqualTo(LParen)))
+from p in Token.EqualTo(Identifier).Select(...)
+select p
+```
+
+### 1.7 `TokenizerBuilder.requireDelimiters`
+
+The `requireDelimiters: true` flag ensures keywords like `min` don't match inside longer identifiers like `minimum`. Precept already uses this for all keyword registrations. **This is tokenizer-level only** — it doesn't help with parser-level disambiguation.
+
+### 1.8 Key Limitation
+
+Superpower's `TokenizerBuilder` assigns **one token kind per matched text**. When the tokenizer sees `min`, it produces `PreceptToken.Min` — always. There is no built-in mechanism for context-sensitive tokenization in `TokenizerBuilder`. Disambiguation between keyword and function usage **must happen at the parser level**.
+
+---
+
+## 2. How Existing Projects Solve It
+
+### 2.1 Serilog Expressions — The Gold Standard
+
+Serilog Expressions (built by the same author as Superpower) uses a **hand-written tokenizer** that classifies all alphabetic words then resolves them in the parser.
+
+**Tokenizer strategy:** All letter-sequences are checked against a keyword list. Matches become keyword tokens; non-matches become `Identifier`:
+
+```csharp
+// Source: serilog/serilog-expressions ExpressionTokenizer.cs:21-42
+readonly ExpressionKeyword[] _keywords =
+[
+    new("and", ExpressionToken.And),
+    new("in", ExpressionToken.In),
+    new("not", ExpressionToken.Not),
+    new("or", ExpressionToken.Or),
+    new("true", ExpressionToken.True),
+    new("false", ExpressionToken.False),
+    new("null", ExpressionToken.Null),
+    new("if", ExpressionToken.If),
+    new("then", ExpressionToken.Then),
+    new("else", ExpressionToken.Else),
+    // ...
+];
+```
+
+**Critical design choice:** Serilog **does not tokenize function names as keywords**. All function names tokenize as `Identifier`:
+
+```csharp
+// Source: serilog/serilog-expressions ExpressionTokenParsers.cs:83-89
+static readonly TokenListParser<ExpressionToken, Expression> Function =
+    (from name in Token.EqualTo(ExpressionToken.Identifier)
+        from lparen in Token.EqualTo(ExpressionToken.LParen)
+        from expr in Parse.Ref(() => Expr!).ManyDelimitedBy(Token.EqualTo(ExpressionToken.Comma))
+        from rparen in Token.EqualTo(ExpressionToken.RParen)
+        from ci in Token.EqualTo(ExpressionToken.CI).Value(true).OptionalOrDefault()
+        select (Expression)new CallExpression(ci, name.ToStringValue(), expr)).Named("function");
+```
+
+**How property vs. function is distinguished:** Serilog uses `Parse.Not()` as a negative lookahead to ensure that `identifier(` is NOT matched as a property reference:
+
+```csharp
+// Source: serilog/serilog-expressions ExpressionTokenParsers.cs:136-140
+static readonly TokenListParser<ExpressionToken, Expression> RootProperty =
+    (from notFunction in Parse.Not(Token.EqualTo(ExpressionToken.Identifier)
+                                       .IgnoreThen(Token.EqualTo(ExpressionToken.LParen)))
+        from p in Token.EqualTo(ExpressionToken.Identifier).Select(t => ...)
+        select p).Named("property");
+```
+
+**Serilog avoids the collision entirely** because function names like `Contains`, `Substring`, `Length` are never keywords — they're just identifiers followed by `(`.
+
+### 2.2 Superpower's JSON Sample
+
+The JSON parser sample tokenizes `true`, `false`, and `null` as a generic `Identifier` token, then distinguishes them at the parser level via `Token.EqualToValue()`:
+
+```csharp
+// Source: datalust/superpower sample/JsonParser/Program.cs:62-68
+// "it's useful for the tokenizer to be very permissive - it's more
+// informative to generate an error later at the parsing stage"
+Identifier,
+```
+
+This reinforces the Superpower idiom: **tokenize broadly, disambiguate narrowly in the parser**.
+
+### 2.3 `requireDelimiters` Test
+
+Superpower's own test suite demonstrates that `requireDelimiters: true` handles prefix/suffix overlap at the tokenizer level:
+
+```csharp
+// Source: datalust/superpower test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs:27-41
+var tokenizer = new TokenizerBuilder<bool>()
+    .Ignore(Span.WhiteSpace)
+    .Match(Span.EqualTo("is"), true, requireDelimiters: true)
+    .Match(Character.Letter.AtLeastOnce(), false, requireDelimiters: true)
+    .Build();
+
+// "is isnot is notis ins not is" → 7 tokens, 3 of which are `true` (keyword)
+```
+
+But this only solves "is" vs "isnot" — it doesn't help when the *same word* appears in two grammatical roles.
+
+---
+
+## 3. How Precept Already Handles `round`
+
+This is the **key finding** of the research.
+
+### `round` is NOT a keyword token
+
+Despite being a built-in function, `round` does **not** appear in the `PreceptToken` enum with a `[TokenSymbol]` attribute. It tokenizes as `PreceptToken.Identifier`. The parser matches it by checking the text value:
+
+```csharp
+// Source: PreceptParser.cs:315-332
+// round(expr, N) — built-in rounding function; recognized by identifier name, not a keyword
+private static readonly TokenListParser<PreceptToken, PreceptExpression> RoundAtom =
+    (from kw in Token.EqualTo(PreceptToken.Identifier).Where(t => t.ToStringValue() == "round")
+     from _lp in Token.EqualTo(PreceptToken.LeftParen)
+     from val in Superpower.Parse.Ref(BoolExprRef)
+     from _c in Token.EqualTo(PreceptToken.Comma)
+     from n in Token.EqualTo(PreceptToken.NumberLiteral)
+     from _rp in Token.EqualTo(PreceptToken.RightParen)
+     let raw = n.ToNumericLiteralValue()
+     let places = raw is long l ? (int)l : (int)(double)raw
+     select (PreceptExpression)new PreceptRoundExpression(val, places))
+    .Try();
+```
+
+**Why this works for `round`:** The word `round` is never used as a keyword in any other grammar position — it only appears in expression position as `round(...)`. So there's no collision.
+
+### `min`/`max` are different
+
+Unlike `round`, `min` and `max` ARE keyword tokens (`PreceptToken.Min`, `PreceptToken.Max`) because they serve a distinct grammatical role in constraint position:
+
+```precept
+field Score as number min 0 max 100
+```
+
+The tokenizer will always produce `PreceptToken.Min` for the text "min" — it cannot also produce `PreceptToken.Identifier`. This is the collision.
+
+### The existing `AnyMemberToken` pattern
+
+Precept **already handles** the `min`/`max` dual-role problem in one place — dotted member access for collection accessors like `Tags.min`, `Tags.max`:
+
+```csharp
+// Source: PreceptParser.cs:273-278
+// Member tokens: identifiers plus 'min'/'max' which are keywords but also valid
+// dotted member names (e.g. Tags.min, Tags.max on set fields).
+private static readonly TokenListParser<PreceptToken, Token<PreceptToken>> AnyMemberToken =
+    Token.EqualTo(PreceptToken.Identifier)
+        .Try().Or(Token.EqualTo(PreceptToken.Min))
+        .Try().Or(Token.EqualTo(PreceptToken.Max));
+```
+
+**This is exactly the same pattern we need for function names.** The parser explicitly accepts keyword tokens in a non-keyword position.
+
+### The `Atom` precedence chain
+
+The expression atom parser has a defined priority order:
+
+```csharp
+// Source: PreceptParser.cs:334-343
+private static readonly TokenListParser<PreceptToken, PreceptExpression> Atom =
+    NumberAtom
+        .Try().Or(StringAtom)
+        .Try().Or(TrueAtom)
+        .Try().Or(FalseAtom)
+        .Try().Or(NullAtom)
+        .Try().Or(ParenExpr)
+        .Try().Or(RoundAtom)       // ← function call, tried BEFORE identifier
+        .Or(DottedIdentifier);      // ← catch-all identifier
+```
+
+`RoundAtom` appears **before** `DottedIdentifier` so the function-call pattern is attempted first. The `.Try()` ensures backtracking on failure.
+
+---
+
+## 4. Option Analysis
+
+### Option A: Parser-Only Disambiguation (keyword tokens, match in parser)
+
+**Approach:** Keep `min`/`max` as `PreceptToken.Min`/`PreceptToken.Max` keyword tokens. Create function-call combinators that match these keyword tokens followed by `(`:
+
+```csharp
+private static readonly TokenListParser<PreceptToken, PreceptExpression> MinFunctionAtom =
+    (from kw in Token.EqualTo(PreceptToken.Min)
+     from _lp in Token.EqualTo(PreceptToken.LeftParen)
+     from args in Superpower.Parse.Ref(BoolExprRef)
+         .AtLeastOnceDelimitedBy(Token.EqualTo(PreceptToken.Comma))
+     from _rp in Token.EqualTo(PreceptToken.RightParen)
+     select (PreceptExpression)new PreceptFunctionCallExpression("min", args))
+    .Try();
+```
+
+**Pros:**
+- Zero tokenizer changes — lowest risk of breaking existing behavior
+- Constraint parsing (`min 0`) is unaffected because it matches `Min` followed by `NumberLiteral`, not `(`
+- Proven in Precept: `AnyMemberToken` already successfully matches keyword tokens in non-keyword positions
+
+**Cons:**
+- Each keyword-that-is-also-a-function needs a separate function-call combinator (or a shared `AnyFunctionName` combinator — see Option B)
+- Adding future functions that collide with keywords requires manually adding them to the combinator
+
+**Risk:** Low. The constraint parser matches `min <NumberLiteral>` and the function parser matches `min(`. These are unambiguous with one token of lookahead.
+
+**Superpower idiomaticness:** Good. `.Try().Or()` chains are the standard Superpower pattern.
+
+### Option B: Unified `AnyFunctionName` Token Set (recommended)
+
+**Approach:** Keep `min`/`max` as keyword tokens. Create a single combinator that matches any token eligible to be a function name, then use it in one generic function-call atom:
+
+```csharp
+// Generalization of the existing AnyMemberToken pattern
+static readonly TokenListParser<PreceptToken, string> AnyFunctionName =
+    Token.EqualTo(PreceptToken.Identifier).Select(t => t.ToStringValue())
+        .Try().Or(Token.EqualTo(PreceptToken.Min).Value("min"))
+        .Try().Or(Token.EqualTo(PreceptToken.Max).Value("max"));
+    // Future: .Try().Or(Token.EqualTo(PreceptToken.SomeKeyword).Value("name"))
+
+// Single generic function-call atom replaces RoundAtom + individual function atoms
+static readonly TokenListParser<PreceptToken, PreceptExpression> FunctionCallAtom =
+    (from name in AnyFunctionName
+     from _lp in Token.EqualTo(PreceptToken.LeftParen)
+     from args in Superpower.Parse.Ref(BoolExprRef)
+         .AtLeastOnceDelimitedBy(Token.EqualTo(PreceptToken.Comma))
+     from _rp in Token.EqualTo(PreceptToken.RightParen)
+     select (PreceptExpression)new PreceptFunctionCallExpression(name, args))
+    .Try();
+```
+
+**Pros:**
+- Zero tokenizer changes — same low risk as Option A
+- One function-call combinator handles ALL functions (identifiers + keyword-name functions)
+- Natural generalization of the existing `AnyMemberToken` pattern (lines 273-278)
+- Extensible: adding a new keyword-that-is-also-a-function = one `.Or()` line
+- `round` can be migrated into this same combinator (currently special-cased via `Identifier.Where`)
+- Matches Serilog's approach (single `Function` parser) adapted for Precept's token collision
+
+**Cons:**
+- `AnyFunctionName` must be maintained when new keyword/function collisions arise — but this is a one-line change per collision
+- Slightly less explicit than individual atoms — all function dispatch happens at evaluation time, not parse time
+
+**Risk:** Low. Same disambiguation logic as Option A — the `(` lookahead separates function calls from constraint keywords.
+
+**Superpower idiomaticness:** Excellent. This is the exact pattern `AnyMemberToken` already uses, and matches how Serilog structures its parser.
+
+### Option C: Retokenize `min`/`max` as Identifiers
+
+**Approach:** Remove `Min` and `Max` from keyword registration. They tokenize as `PreceptToken.Identifier`. The constraint parser matches them via `Token.EqualToValue(PreceptToken.Identifier, "min")`:
+
+```csharp
+// Constraint parsing would change from:
+Token.EqualTo(PreceptToken.Min)
+// To:
+Token.EqualToValue(PreceptToken.Identifier, "min")
+```
+
+**Pros:**
+- Cleanest conceptual model — `min`/`max` are always identifiers
+- No `AnyFunctionName` combinator needed — everything is an identifier
+
+**Cons:**
+- **Breaking change to constraint parsing:** Every `Token.EqualTo(PreceptToken.Min)` and `Token.EqualTo(PreceptToken.Max)` call must be replaced (found in `ConstraintSuffix`, `AnyMemberToken`, and possibly tests)
+- **Syntax highlighting regression:** `min`/`max` are currently highlighted as constraint keywords. Demoting them to identifiers degrades the editing experience — authors lose visual distinction between `field X as number min 0` (constraint keyword) and `min(A, B)` (function name)
+- **Semantic token regression:** `min`/`max` carry `[TokenCategory(Constraint)]` which drives semantic token classification. Removing the token means losing this classification
+- **MCP language tool regression:** `precept_language` reports constraint keywords from the token enum. Removing `Min`/`Max` tokens would drop them from the constraint keyword list
+- **Error messages degrade:** Superpower reports "expected keyword `min`" for constraint errors. With identifiers, it would report "expected identifier" — less helpful
+
+**Risk:** High. Touches tokenizer, parser, syntax highlighting, semantic tokens, MCP output, and error messages. Multiple integration test failures likely.
+
+**Superpower idiomaticness:** Acceptable in isolation, but goes against the Superpower ethos of "more specific tokens for better error messages" (README: "unexpected identifier `frm`, expected keyword `from`").
+
+---
+
+## 5. Recommendation: Option B — Unified `AnyFunctionName` Token Set
+
+**Option B is the right choice.** Here's why:
+
+### It's the existing Precept pattern
+
+Precept already does this. `AnyMemberToken` (line 273-278) exists specifically to accept `Min`/`Max` keyword tokens in non-keyword (dotted member) position. Option B applies the same pattern to function-call position. It's not novel — it's generalization.
+
+### It matches how `round` already works, but better
+
+`round` currently uses `Identifier.Where(t == "round")` — a name-check on a generic identifier token. This works because `round` isn't a keyword. For `min`/`max` (which ARE keywords), `AnyFunctionName` handles the same intent through token-kind matching rather than string comparison. Both patterns can coexist, and eventually `round` can be migrated into `AnyFunctionName` for consistency.
+
+### Zero tokenizer risk
+
+The tokenizer is unchanged. `min` and `max` remain keyword tokens. Constraint parsing (`min 0`, `max 100`) is completely unaffected. Dotted member access (`Tags.min`, `Tags.max`) via `AnyMemberToken` is unaffected. The only change is adding a new parser combinator in expression-atom position.
+
+### Disambiguation is trivially unambiguous
+
+| Pattern | What follows `min` | Parser that matches |
+|---------|-------------------|-------------------|
+| Constraint | `min 0` — number literal | `ConstraintSuffix` |
+| Function call | `min(A, B)` — left paren | `FunctionCallAtom` |
+| Dotted member | `Tags.min` — preceded by dot | `AnyMemberToken` |
+
+One token of lookahead (`NumberLiteral` vs `LeftParen`) is sufficient. No deep backtracking needed.
+
+### Implementation sketch
+
+```csharp
+// 1. AnyFunctionName combinator (alongside AnyMemberToken)
+static readonly TokenListParser<PreceptToken, string> AnyFunctionName =
+    Token.EqualTo(PreceptToken.Identifier).Select(t => t.ToStringValue())
+        .Try().Or(Token.EqualTo(PreceptToken.Min).Value("min"))
+        .Try().Or(Token.EqualTo(PreceptToken.Max).Value("max"));
+
+// 2. Generic function-call atom
+static readonly TokenListParser<PreceptToken, PreceptExpression> FunctionCallAtom =
+    (from name in AnyFunctionName
+     from _lp in Token.EqualTo(PreceptToken.LeftParen)
+     from args in Superpower.Parse.Ref(BoolExprRef)
+         .AtLeastOnceDelimitedBy(Token.EqualTo(PreceptToken.Comma))
+     from _rp in Token.EqualTo(PreceptToken.RightParen)
+     select (PreceptExpression)new PreceptFunctionCallExpression(name, args))
+    .Try()
+    .Register(/* construct catalog info */);
+
+// 3. Update Atom to include FunctionCallAtom before DottedIdentifier
+private static readonly TokenListParser<PreceptToken, PreceptExpression> Atom =
+    NumberAtom
+        .Try().Or(StringAtom)
+        .Try().Or(TrueAtom)
+        .Try().Or(FalseAtom)
+        .Try().Or(NullAtom)
+        .Try().Or(ParenExpr)
+        .Try().Or(FunctionCallAtom)    // ← replaces/subsumes RoundAtom
+        .Or(DottedIdentifier);
+```
+
+### Migration path for `round`
+
+`round` can optionally be migrated into `FunctionCallAtom`:
+- Add `"round"` to a validation set in the function evaluator
+- Remove `RoundAtom` as a separate combinator
+- `round(x, 2)` would parse as `FunctionCallExpression("round", [x, 2])` instead of `PreceptRoundExpression`
+
+This is a separate decision, but the infrastructure supports it naturally.
+
+---
+
+## Summary
+
+| Criterion | Option A | Option B | Option C |
+|-----------|----------|----------|----------|
+| Tokenizer changes | None | None | Significant |
+| Parser changes | Per-function atoms | One generic atom | Constraint parser rewrite |
+| Breaking risk | Low | Low | High |
+| Matches existing pattern | Partial (AnyMemberToken) | Direct generalization | New pattern |
+| Extensibility | Manual per-collision | One-line per collision | Automatic |
+| Syntax highlighting | Preserved | Preserved | Degraded |
+| Error messages | Preserved | Preserved | Degraded |
+| Superpower idiom | Good | Excellent | Acceptable |
+
+**Recommendation: Option B.** It generalizes Precept's existing `AnyMemberToken` pattern, requires zero tokenizer changes, subsumes the current `RoundAtom` special case, and scales cleanly to future keyword/function collisions.

--- a/samples/insurance-claim.precept
+++ b/samples/insurance-claim.precept
@@ -2,6 +2,7 @@ precept InsuranceClaim
 
 # Claims often bounce between missing-document collection and adjuster review.
 # This example keeps that back-and-forth in one readable file.
+# Built-in functions (min, trim) keep the logic clear.
 
 field ClaimantName as string nullable
 field ClaimAmount as decimal default 0 maxplaces 2
@@ -57,7 +58,7 @@ event PayClaim
 from Draft on Submit -> set ClaimantName = Submit.Claimant -> set ClaimAmount = Submit.Amount -> set PoliceReportRequired = Submit.RequiresPoliceReport -> transition Submitted
 
 from Submitted on RequestDocument -> add MissingDocuments RequestDocument.Name -> no transition
-from Submitted on AssignAdjuster -> set AdjusterName = AssignAdjuster.Name -> transition UnderReview
+from Submitted on AssignAdjuster -> set AdjusterName = trim(AssignAdjuster.Name) -> transition UnderReview
 
 from UnderReview on RequestDocument -> add MissingDocuments RequestDocument.Name -> no transition
 from UnderReview on ReceiveDocument when MissingDocuments contains ReceiveDocument.Name -> remove MissingDocuments ReceiveDocument.Name -> no transition

--- a/samples/loan-application.precept
+++ b/samples/loan-application.precept
@@ -2,6 +2,7 @@ precept LoanApplication
 
 # This sample keeps underwriting rules in the workflow itself instead of spreading them across services.
 # The approval guard combines document verification, credit policy, and affordability checks.
+# Built-in functions (min, round, clamp) keep the logic readable without external helpers.
 
 field ApplicantName as string nullable
 field RequestedAmount as number default 0
@@ -53,7 +54,7 @@ from Draft on Submit -> set ApplicantName = Submit.Applicant -> set RequestedAmo
 
 from UnderReview on VerifyDocuments -> set DocumentsVerified = true -> no transition
 
-from UnderReview on Approve when DocumentsVerified and CreditScore >= 680 and AnnualIncome >= ExistingDebt * 2 and RequestedAmount < AnnualIncome / 2 and Approve.Amount <= RequestedAmount -> set ApprovedAmount = Approve.Amount -> set DecisionNote = Approve.Note -> transition Approved
+from UnderReview on Approve when DocumentsVerified and CreditScore >= 680 and AnnualIncome >= ExistingDebt * 2 and RequestedAmount < AnnualIncome / 2 and Approve.Amount <= RequestedAmount -> set ApprovedAmount = min(Approve.Amount, RequestedAmount) -> set DecisionNote = Approve.Note -> transition Approved
 from UnderReview on Approve -> reject "Approval requires verified documents, strong credit, and affordable debt load"
 
 from UnderReview on Decline -> set DecisionNote = Decline.Note -> transition Declined

--- a/samples/travel-reimbursement.precept
+++ b/samples/travel-reimbursement.precept
@@ -2,6 +2,7 @@ precept TravelReimbursement
 
 # Finance reviews a reimbursement request by checking both totals and policy ratios.
 # This sample brings in multiplication and division without making the domain obscure.
+# Built-in functions (round, min, clamp) keep arithmetic readable.
 
 field EmployeeName as string nullable
 field TripDays as number default 1
@@ -47,7 +48,7 @@ event Pay
 from Draft on Submit when Submit.Lodging / Submit.Days <= 350 -> set EmployeeName = Submit.Employee -> set TripDays = Submit.Days -> set LodgingTotal = Submit.Lodging -> set MealsTotal = Submit.Meals -> set MileageTotal = round(Submit.Miles * Submit.Rate, 2) -> set MileageRate = Submit.Rate -> set RequestedTotal = Submit.Lodging + Submit.Meals + (Submit.Miles * Submit.Rate) -> transition Submitted
 from Draft on Submit -> reject "Average lodging per day exceeds the policy cap"
 
-from Submitted on Approve when Approve.Amount <= RequestedTotal -> set ApprovedTotal = Approve.Amount -> set FinanceNote = Approve.Note -> transition Approved
+from Submitted on Approve when Approve.Amount <= RequestedTotal -> set ApprovedTotal = min(Approve.Amount, RequestedTotal) -> set FinanceNote = Approve.Note -> transition Approved
 from Submitted on Approve -> reject "Finance cannot approve more than the requested total"
 from Submitted on Reject -> set FinanceNote = Reject.Note -> transition Rejected
 

--- a/src/Precept/Dsl/ConstraintViolation.cs
+++ b/src/Precept/Dsl/ConstraintViolation.cs
@@ -133,6 +133,10 @@ public sealed record ExpressionSubjects(
             case PreceptParenthesizedExpression paren:
                 Walk(paren.Inner, fields, args);
                 break;
+            case PreceptFunctionCallExpression fn:
+                foreach (var arg in fn.Arguments)
+                    Walk(arg, fields, args);
+                break;
             case PreceptLiteralExpression:
                 break;
         }

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -576,7 +576,7 @@ public static class DiagnosticCatalog
     public static readonly LanguageConstraint C73 = Register(
         "C73", "compile",
         "Function argument type mismatch.",
-        "{name}() {param} argument expects {expected} but got {actual}.");
+        "{name}() no matching overload: {param} argument expects {expected} but got {actual}.");
 
     /// <summary>round() precision argument must be a non-negative integer literal.</summary>
     public static readonly LanguageConstraint C74 = Register(

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -555,4 +555,50 @@ public static class DiagnosticCatalog
         "C70", "parse",
         "Duplicate modifier on field or event argument declaration.",
         "Duplicate modifier '{modifier}' on '{name}'. Each modifier may appear at most once per declaration.");
+
+    // ═══════════════════════════════════════════════════════════════
+    // Function diagnostics (C71–C77)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>Unknown function name in expression.</summary>
+    public static readonly LanguageConstraint C71 = Register(
+        "C71", "compile",
+        "Unknown function name in expression.",
+        "Unknown function '{name}'.");
+
+    /// <summary>Function called with incorrect number of arguments.</summary>
+    public static readonly LanguageConstraint C72 = Register(
+        "C72", "compile",
+        "Function called with incorrect number of arguments.",
+        "{name}() called with {count} argument(s), but no matching overload found.");
+
+    /// <summary>Function argument type mismatch.</summary>
+    public static readonly LanguageConstraint C73 = Register(
+        "C73", "compile",
+        "Function argument type mismatch.",
+        "{name}() {param} argument expects {expected} but got {actual}.");
+
+    /// <summary>round() precision argument must be a non-negative integer literal.</summary>
+    public static readonly LanguageConstraint C74 = Register(
+        "C74", "compile",
+        "round() precision argument must be a non-negative integer literal.",
+        "round() precision argument must be a non-negative integer literal.");
+
+    /// <summary>pow() exponent must be integer type.</summary>
+    public static readonly LanguageConstraint C75 = Register(
+        "C75", "compile",
+        "pow() exponent must be integer type.",
+        "pow() exponent must be integer type, but got {actual}.");
+
+    /// <summary>sqrt() requires a non-negative argument proof.</summary>
+    public static readonly LanguageConstraint C76 = Register(
+        "C76", "compile",
+        "sqrt() requires a non-negative argument. Add a 'nonnegative' constraint or guard with '>= 0'.",
+        "sqrt() requires a non-negative argument. '{arg}' may be negative. Add a 'nonnegative' constraint or guard with '{arg} >= 0 and ...'.");
+
+    /// <summary>Function does not accept nullable arguments.</summary>
+    public static readonly LanguageConstraint C77 = Register(
+        "C77", "compile",
+        "Function does not accept nullable arguments.",
+        "Function '{name}' does not accept nullable arguments. '{arg}' may be null. Add a null check.");
 }

--- a/src/Precept/Dsl/FunctionRegistry.cs
+++ b/src/Precept/Dsl/FunctionRegistry.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+
+namespace Precept;
+
+/// <summary>
+/// Constraint on a function argument beyond its type.
+/// </summary>
+internal enum FunctionArgConstraint
+{
+    None,
+    MustBeIntegerLiteral
+}
+
+/// <summary>
+/// Describes a single parameter of a function overload.
+/// </summary>
+internal sealed record FunctionParameter(
+    string Name,
+    StaticValueKind AcceptedTypes,
+    FunctionArgConstraint Constraint = FunctionArgConstraint.None);
+
+/// <summary>
+/// Describes one overload of a built-in function.
+/// </summary>
+internal sealed record FunctionOverload(
+    FunctionParameter[] Parameters,
+    StaticValueKind ReturnType,
+    int? MinArity = null);
+
+/// <summary>
+/// Describes a built-in function with all its overloads.
+/// </summary>
+internal sealed record FunctionDefinition(
+    string Name,
+    FunctionOverload[] Overloads);
+
+/// <summary>
+/// Registry of all built-in functions available in the Precept DSL.
+/// Designed for multiple overloads, variable arity, return-type lookup,
+/// argument-type validation, and special argument constraints.
+/// </summary>
+internal static class FunctionRegistry
+{
+    private static readonly Dictionary<string, FunctionDefinition> Functions = new(System.StringComparer.Ordinal);
+
+    static FunctionRegistry()
+    {
+        Register(new FunctionDefinition("round",
+        [
+            // round(numeric) → decimal  (1-arg, banker's rounding to nearest integer)
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal)],
+                StaticValueKind.Decimal),
+            // round(numeric, places) → decimal  (2-arg, precision rounding)
+            new FunctionOverload(
+                [
+                    new FunctionParameter("value", StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal),
+                    new FunctionParameter("places", StaticValueKind.Number | StaticValueKind.Integer, FunctionArgConstraint.MustBeIntegerLiteral)
+                ],
+                StaticValueKind.Decimal)
+        ]));
+    }
+
+    public static bool IsFunction(string name) => Functions.ContainsKey(name);
+
+    public static bool TryGetFunction(string name, out FunctionDefinition definition)
+        => Functions.TryGetValue(name, out definition!);
+
+    public static IReadOnlyCollection<string> FunctionNames => Functions.Keys;
+
+    private static void Register(FunctionDefinition definition)
+        => Functions[definition.Name] = definition;
+}

--- a/src/Precept/Dsl/FunctionRegistry.cs
+++ b/src/Precept/Dsl/FunctionRegistry.cs
@@ -32,6 +32,7 @@ internal sealed record FunctionOverload(
 /// </summary>
 internal sealed record FunctionDefinition(
     string Name,
+    string Description,
     FunctionOverload[] Overloads);
 
 /// <summary>
@@ -43,21 +44,141 @@ internal static class FunctionRegistry
 {
     private static readonly Dictionary<string, FunctionDefinition> Functions = new(System.StringComparer.Ordinal);
 
+    private static readonly StaticValueKind Numeric =
+        StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal;
+
     static FunctionRegistry()
     {
-        Register(new FunctionDefinition("round",
+        // ── Numeric: rounding / truncation ──────────────────────
+
+        Register(new FunctionDefinition("abs", "Returns the absolute value.",
+        [
+            new FunctionOverload([new FunctionParameter("value", Numeric)], Numeric)
+        ]));
+
+        Register(new FunctionDefinition("floor", "Rounds toward negative infinity, returning an integer.",
+        [
+            new FunctionOverload([new FunctionParameter("value", Numeric)], StaticValueKind.Integer)
+        ]));
+
+        Register(new FunctionDefinition("ceil", "Rounds toward positive infinity, returning an integer.",
+        [
+            new FunctionOverload([new FunctionParameter("value", Numeric)], StaticValueKind.Integer)
+        ]));
+
+        Register(new FunctionDefinition("round", "Rounds a numeric value. 1-arg: banker's rounding to nearest integer. 2-arg: rounds to specified decimal places.",
         [
             // round(numeric) → decimal  (1-arg, banker's rounding to nearest integer)
             new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal)],
+                [new FunctionParameter("value", Numeric)],
                 StaticValueKind.Decimal),
             // round(numeric, places) → decimal  (2-arg, precision rounding)
             new FunctionOverload(
                 [
-                    new FunctionParameter("value", StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal),
+                    new FunctionParameter("value", Numeric),
                     new FunctionParameter("places", StaticValueKind.Number | StaticValueKind.Integer, FunctionArgConstraint.MustBeIntegerLiteral)
                 ],
                 StaticValueKind.Decimal)
+        ]));
+
+        Register(new FunctionDefinition("truncate", "Truncates toward zero, returning an integer.",
+        [
+            new FunctionOverload([new FunctionParameter("value", Numeric)], StaticValueKind.Integer)
+        ]));
+
+        // ── Numeric: aggregation / comparison ───────────────────
+
+        Register(new FunctionDefinition("min", "Returns the smallest of two or more values.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("a", Numeric), new FunctionParameter("b", Numeric)],
+                Numeric, MinArity: 2)
+        ]));
+
+        Register(new FunctionDefinition("max", "Returns the largest of two or more values.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("a", Numeric), new FunctionParameter("b", Numeric)],
+                Numeric, MinArity: 2)
+        ]));
+
+        Register(new FunctionDefinition("clamp", "Constrains a value to a range [min, max].",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", Numeric), new FunctionParameter("min", Numeric), new FunctionParameter("max", Numeric)],
+                Numeric)
+        ]));
+
+        // ── Numeric: exponentiation ─────────────────────────────
+
+        Register(new FunctionDefinition("pow", "Raises a value to an integer power.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("base", Numeric), new FunctionParameter("exponent", StaticValueKind.Integer)],
+                Numeric)
+        ]));
+
+        Register(new FunctionDefinition("sqrt", "Returns the square root. Requires non-negative argument (compile-time proof).",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.Number | StaticValueKind.Decimal)],
+                StaticValueKind.Number | StaticValueKind.Decimal)
+        ]));
+
+        // ── String: case / whitespace ───────────────────────────
+
+        Register(new FunctionDefinition("toLower", "Converts to lowercase using invariant culture.",
+        [
+            new FunctionOverload([new FunctionParameter("value", StaticValueKind.String)], StaticValueKind.String)
+        ]));
+
+        Register(new FunctionDefinition("toUpper", "Converts to uppercase using invariant culture.",
+        [
+            new FunctionOverload([new FunctionParameter("value", StaticValueKind.String)], StaticValueKind.String)
+        ]));
+
+        Register(new FunctionDefinition("trim", "Removes leading and trailing whitespace.",
+        [
+            new FunctionOverload([new FunctionParameter("value", StaticValueKind.String)], StaticValueKind.String)
+        ]));
+
+        // ── String: prefix / suffix ─────────────────────────────
+
+        Register(new FunctionDefinition("startsWith", "Tests whether a string starts with a prefix. Case-sensitive.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("prefix", StaticValueKind.String)],
+                StaticValueKind.Boolean)
+        ]));
+
+        Register(new FunctionDefinition("endsWith", "Tests whether a string ends with a suffix. Case-sensitive.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("suffix", StaticValueKind.String)],
+                StaticValueKind.Boolean)
+        ]));
+
+        // ── String: extraction ──────────────────────────────────
+
+        Register(new FunctionDefinition("left", "Returns the leftmost N characters. 1-indexed, clamping.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("count", Numeric)],
+                StaticValueKind.String)
+        ]));
+
+        Register(new FunctionDefinition("right", "Returns the rightmost N characters. Clamping.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("count", Numeric)],
+                StaticValueKind.String)
+        ]));
+
+        Register(new FunctionDefinition("mid", "Returns a substring starting at position for a given length. 1-indexed, clamping.",
+        [
+            new FunctionOverload(
+                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("start", Numeric), new FunctionParameter("length", Numeric)],
+                StaticValueKind.String)
         ]));
     }
 
@@ -67,6 +188,8 @@ internal static class FunctionRegistry
         => Functions.TryGetValue(name, out definition!);
 
     public static IReadOnlyCollection<string> FunctionNames => Functions.Keys;
+
+    public static IReadOnlyCollection<FunctionDefinition> AllFunctions => Functions.Values;
 
     private static void Register(FunctionDefinition definition)
         => Functions[definition.Name] = definition;

--- a/src/Precept/Dsl/FunctionRegistry.cs
+++ b/src/Precept/Dsl/FunctionRegistry.cs
@@ -162,7 +162,7 @@ internal static class FunctionRegistry
 
         // ── String: extraction ──────────────────────────────────
 
-        Register(new FunctionDefinition("left", "Returns the leftmost N characters. 1-indexed, clamping.",
+        Register(new FunctionDefinition("left", "Returns the leftmost N characters. Clamping.",
         [
             new([new("value", StaticValueKind.String), new("count", StaticValueKind.Number | StaticValueKind.Integer)], StaticValueKind.String),
         ]));

--- a/src/Precept/Dsl/FunctionRegistry.cs
+++ b/src/Precept/Dsl/FunctionRegistry.cs
@@ -8,7 +8,8 @@ namespace Precept;
 internal enum FunctionArgConstraint
 {
     None,
-    MustBeIntegerLiteral
+    MustBeIntegerLiteral,
+    RequiresNonNegativeProof
 }
 
 /// <summary>
@@ -50,135 +51,135 @@ internal static class FunctionRegistry
     static FunctionRegistry()
     {
         // ── Numeric: rounding / truncation ──────────────────────
+        // Overloads ordered by specificity: integer → decimal → number.
+        // Resolution picks the first arity-and-type match.
 
         Register(new FunctionDefinition("abs", "Returns the absolute value.",
         [
-            new FunctionOverload([new FunctionParameter("value", Numeric)], Numeric)
+            new([new("value", StaticValueKind.Integer)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Decimal),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Number),
         ]));
 
         Register(new FunctionDefinition("floor", "Rounds toward negative infinity, returning an integer.",
         [
-            new FunctionOverload([new FunctionParameter("value", Numeric)], StaticValueKind.Integer)
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Integer),
         ]));
 
         Register(new FunctionDefinition("ceil", "Rounds toward positive infinity, returning an integer.",
         [
-            new FunctionOverload([new FunctionParameter("value", Numeric)], StaticValueKind.Integer)
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Integer),
         ]));
 
         Register(new FunctionDefinition("round", "Rounds a numeric value. 1-arg: banker's rounding to nearest integer. 2-arg: rounds to specified decimal places.",
         [
-            // round(numeric) → decimal  (1-arg, banker's rounding to nearest integer)
-            new FunctionOverload(
-                [new FunctionParameter("value", Numeric)],
-                StaticValueKind.Decimal),
-            // round(numeric, places) → decimal  (2-arg, precision rounding)
-            new FunctionOverload(
-                [
-                    new FunctionParameter("value", Numeric),
-                    new FunctionParameter("places", StaticValueKind.Number | StaticValueKind.Integer, FunctionArgConstraint.MustBeIntegerLiteral)
-                ],
-                StaticValueKind.Decimal)
+            // 1-arg: type-specific overloads
+            new([new("value", StaticValueKind.Integer)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Number),
+            // 2-arg: precision rounding (accepts any numeric, returns decimal)
+            new(
+            [
+                new("value", Numeric),
+                new("places", StaticValueKind.Number | StaticValueKind.Integer, FunctionArgConstraint.MustBeIntegerLiteral),
+            ], StaticValueKind.Decimal),
         ]));
 
         Register(new FunctionDefinition("truncate", "Truncates toward zero, returning an integer.",
         [
-            new FunctionOverload([new FunctionParameter("value", Numeric)], StaticValueKind.Integer)
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Integer),
         ]));
 
         // ── Numeric: aggregation / comparison ───────────────────
 
         Register(new FunctionDefinition("min", "Returns the smallest of two or more values.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("a", Numeric), new FunctionParameter("b", Numeric)],
-                Numeric, MinArity: 2)
+            new([new("value", StaticValueKind.Integer)], StaticValueKind.Integer, MinArity: 2),
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Decimal, MinArity: 2),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Number, MinArity: 2),
         ]));
 
         Register(new FunctionDefinition("max", "Returns the largest of two or more values.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("a", Numeric), new FunctionParameter("b", Numeric)],
-                Numeric, MinArity: 2)
+            new([new("value", StaticValueKind.Integer)], StaticValueKind.Integer, MinArity: 2),
+            new([new("value", StaticValueKind.Decimal)], StaticValueKind.Decimal, MinArity: 2),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Number, MinArity: 2),
         ]));
 
         Register(new FunctionDefinition("clamp", "Constrains a value to a range [min, max].",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", Numeric), new FunctionParameter("min", Numeric), new FunctionParameter("max", Numeric)],
-                Numeric)
+            new([new("value", StaticValueKind.Integer), new("min", StaticValueKind.Integer), new("max", StaticValueKind.Integer)], StaticValueKind.Integer),
+            new([new("value", StaticValueKind.Decimal), new("min", StaticValueKind.Decimal), new("max", StaticValueKind.Decimal)], StaticValueKind.Decimal),
+            new([new("value", StaticValueKind.Number), new("min", StaticValueKind.Number), new("max", StaticValueKind.Number)], StaticValueKind.Number),
         ]));
 
         // ── Numeric: exponentiation ─────────────────────────────
 
         Register(new FunctionDefinition("pow", "Raises a value to an integer power.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("base", Numeric), new FunctionParameter("exponent", StaticValueKind.Integer)],
-                Numeric)
+            new([new("base", StaticValueKind.Integer), new("exponent", StaticValueKind.Integer)], StaticValueKind.Integer),
+            new([new("base", StaticValueKind.Decimal), new("exponent", StaticValueKind.Integer)], StaticValueKind.Decimal),
+            new([new("base", StaticValueKind.Number), new("exponent", StaticValueKind.Integer)], StaticValueKind.Number),
         ]));
 
         Register(new FunctionDefinition("sqrt", "Returns the square root. Requires non-negative argument (compile-time proof).",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.Number | StaticValueKind.Decimal)],
-                StaticValueKind.Number | StaticValueKind.Decimal)
+            new([new("value", StaticValueKind.Decimal, FunctionArgConstraint.RequiresNonNegativeProof)], StaticValueKind.Decimal),
+            new([new("value", StaticValueKind.Number, FunctionArgConstraint.RequiresNonNegativeProof)], StaticValueKind.Number),
         ]));
 
         // ── String: case / whitespace ───────────────────────────
 
         Register(new FunctionDefinition("toLower", "Converts to lowercase using invariant culture.",
         [
-            new FunctionOverload([new FunctionParameter("value", StaticValueKind.String)], StaticValueKind.String)
+            new([new("value", StaticValueKind.String)], StaticValueKind.String),
         ]));
 
         Register(new FunctionDefinition("toUpper", "Converts to uppercase using invariant culture.",
         [
-            new FunctionOverload([new FunctionParameter("value", StaticValueKind.String)], StaticValueKind.String)
+            new([new("value", StaticValueKind.String)], StaticValueKind.String),
         ]));
 
         Register(new FunctionDefinition("trim", "Removes leading and trailing whitespace.",
         [
-            new FunctionOverload([new FunctionParameter("value", StaticValueKind.String)], StaticValueKind.String)
+            new([new("value", StaticValueKind.String)], StaticValueKind.String),
         ]));
 
         // ── String: prefix / suffix ─────────────────────────────
 
         Register(new FunctionDefinition("startsWith", "Tests whether a string starts with a prefix. Case-sensitive.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("prefix", StaticValueKind.String)],
-                StaticValueKind.Boolean)
+            new([new("value", StaticValueKind.String), new("prefix", StaticValueKind.String)], StaticValueKind.Boolean),
         ]));
 
         Register(new FunctionDefinition("endsWith", "Tests whether a string ends with a suffix. Case-sensitive.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("suffix", StaticValueKind.String)],
-                StaticValueKind.Boolean)
+            new([new("value", StaticValueKind.String), new("suffix", StaticValueKind.String)], StaticValueKind.Boolean),
         ]));
 
         // ── String: extraction ──────────────────────────────────
 
         Register(new FunctionDefinition("left", "Returns the leftmost N characters. 1-indexed, clamping.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("count", Numeric)],
-                StaticValueKind.String)
+            new([new("value", StaticValueKind.String), new("count", StaticValueKind.Number | StaticValueKind.Integer)], StaticValueKind.String),
         ]));
 
         Register(new FunctionDefinition("right", "Returns the rightmost N characters. Clamping.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("count", Numeric)],
-                StaticValueKind.String)
+            new([new("value", StaticValueKind.String), new("count", StaticValueKind.Number | StaticValueKind.Integer)], StaticValueKind.String),
         ]));
 
         Register(new FunctionDefinition("mid", "Returns a substring starting at position for a given length. 1-indexed, clamping.",
         [
-            new FunctionOverload(
-                [new FunctionParameter("value", StaticValueKind.String), new FunctionParameter("start", Numeric), new FunctionParameter("length", Numeric)],
-                StaticValueKind.String)
+            new(
+            [
+                new("value", StaticValueKind.String),
+                new("start", StaticValueKind.Number | StaticValueKind.Integer),
+                new("length", StaticValueKind.Number | StaticValueKind.Integer),
+            ], StaticValueKind.String),
         ]));
     }
 

--- a/src/Precept/Dsl/PreceptExpressionEvaluator.cs
+++ b/src/Precept/Dsl/PreceptExpressionEvaluator.cs
@@ -369,9 +369,287 @@ internal static class PreceptExpressionRuntimeEvaluator
     {
         return fn.Name switch
         {
+            "abs" => EvaluateAbs(fn, context),
+            "floor" => EvaluateFloor(fn, context),
+            "ceil" => EvaluateCeil(fn, context),
             "round" => EvaluateRound(fn, context),
+            "truncate" => EvaluateTruncate(fn, context),
+            "min" => EvaluateMin(fn, context),
+            "max" => EvaluateMax(fn, context),
+            "clamp" => EvaluateClamp(fn, context),
+            "pow" => EvaluatePow(fn, context),
+            "sqrt" => EvaluateSqrt(fn, context),
+            "toLower" => EvaluateToLower(fn, context),
+            "toUpper" => EvaluateToUpper(fn, context),
+            "trim" => EvaluateTrim(fn, context),
+            "startsWith" => EvaluateStartsWith(fn, context),
+            "endsWith" => EvaluateEndsWith(fn, context),
+            "left" => EvaluateLeft(fn, context),
+            "right" => EvaluateRight(fn, context),
+            "mid" => EvaluateMid(fn, context),
             _ => EvaluationResult.Fail($"unknown function '{fn.Name}'.")
         };
+    }
+
+    private static EvaluationResult EvaluateAbs(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        return r.Value switch
+        {
+            long l => EvaluationResult.Ok(Math.Abs(l)),
+            decimal d => EvaluationResult.Ok(Math.Abs(d)),
+            double dbl => EvaluationResult.Ok(Math.Abs(dbl)),
+            _ => EvaluationResult.Fail("abs() requires a numeric argument.")
+        };
+    }
+
+    private static EvaluationResult EvaluateFloor(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        return r.Value switch
+        {
+            long l => EvaluationResult.Ok(l),
+            decimal d => EvaluationResult.Ok((long)Math.Floor(d)),
+            double dbl => EvaluationResult.Ok((long)Math.Floor(dbl)),
+            _ => EvaluationResult.Fail("floor() requires a numeric argument.")
+        };
+    }
+
+    private static EvaluationResult EvaluateCeil(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        return r.Value switch
+        {
+            long l => EvaluationResult.Ok(l),
+            decimal d => EvaluationResult.Ok((long)Math.Ceiling(d)),
+            double dbl => EvaluationResult.Ok((long)Math.Ceiling(dbl)),
+            _ => EvaluationResult.Fail("ceil() requires a numeric argument.")
+        };
+    }
+
+    private static EvaluationResult EvaluateTruncate(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        return r.Value switch
+        {
+            long l => EvaluationResult.Ok(l),
+            decimal d => EvaluationResult.Ok((long)Math.Truncate(d)),
+            double dbl => EvaluationResult.Ok((long)Math.Truncate(dbl)),
+            _ => EvaluationResult.Fail("truncate() requires a numeric argument.")
+        };
+    }
+
+    private static EvaluationResult EvaluateMin(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var values = new List<object>();
+        foreach (var arg in fn.Arguments)
+        {
+            var r = Evaluate(arg, context);
+            if (!r.Success) return r;
+            values.Add(r.Value!);
+        }
+        return ReduceComparable(values, (a, b) => a < b, "min");
+    }
+
+    private static EvaluationResult EvaluateMax(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var values = new List<object>();
+        foreach (var arg in fn.Arguments)
+        {
+            var r = Evaluate(arg, context);
+            if (!r.Success) return r;
+            values.Add(r.Value!);
+        }
+        return ReduceComparable(values, (a, b) => a > b, "max");
+    }
+
+    private static EvaluationResult ReduceComparable(List<object> values, Func<double, double, bool> compare, string name)
+    {
+        object best = values[0];
+        if (!TryToNumber(best, out var bestNum))
+            return EvaluationResult.Fail($"{name}() requires numeric arguments.");
+
+        for (int i = 1; i < values.Count; i++)
+        {
+            if (!TryToNumber(values[i], out var current))
+                return EvaluationResult.Fail($"{name}() requires numeric arguments.");
+            if (compare(current, bestNum))
+            {
+                best = values[i];
+                bestNum = current;
+            }
+        }
+
+        return EvaluationResult.Ok(best);
+    }
+
+    private static EvaluationResult EvaluateClamp(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var vr = Evaluate(fn.Arguments[0], context);
+        if (!vr.Success) return vr;
+        var minr = Evaluate(fn.Arguments[1], context);
+        if (!minr.Success) return minr;
+        var maxr = Evaluate(fn.Arguments[2], context);
+        if (!maxr.Success) return maxr;
+
+        if (!TryToNumber(vr.Value, out var val) || !TryToNumber(minr.Value, out var min) || !TryToNumber(maxr.Value, out var max))
+            return EvaluationResult.Fail("clamp() requires numeric arguments.");
+
+        var clamped = Math.Clamp(val, min, max);
+
+        return vr.Value switch
+        {
+            long => EvaluationResult.Ok((long)clamped),
+            decimal => EvaluationResult.Ok((decimal)clamped),
+            _ => EvaluationResult.Ok(clamped)
+        };
+    }
+
+    private static EvaluationResult EvaluatePow(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var br = Evaluate(fn.Arguments[0], context);
+        if (!br.Success) return br;
+        var er = Evaluate(fn.Arguments[1], context);
+        if (!er.Success) return er;
+
+        if (er.Value is not long exp)
+            return EvaluationResult.Fail("pow() exponent must be integer.");
+
+        return br.Value switch
+        {
+            long lb => EvaluationResult.Ok(IntegerPow(lb, exp)),
+            decimal db => EvaluationResult.Ok(DecimalPow(db, exp)),
+            double dbl => EvaluationResult.Ok(Math.Pow(dbl, exp)),
+            _ => EvaluationResult.Fail("pow() requires a numeric base.")
+        };
+    }
+
+    private static long IntegerPow(long b, long exp)
+    {
+        if (exp < 0) return 0;
+        if (exp == 0) return 1;
+        long result = 1;
+        for (long i = 0; i < exp; i++) result *= b;
+        return result;
+    }
+
+    private static decimal DecimalPow(decimal b, long exp)
+    {
+        if (exp < 0) return 1m / DecimalPow(b, -exp);
+        if (exp == 0) return 1m;
+        decimal result = 1m;
+        for (long i = 0; i < exp; i++) result *= b;
+        return result;
+    }
+
+    private static EvaluationResult EvaluateSqrt(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+
+        return r.Value switch
+        {
+            decimal d => EvaluationResult.Ok((decimal)Math.Sqrt((double)d)),
+            double dbl => EvaluationResult.Ok(Math.Sqrt(dbl)),
+            long l => EvaluationResult.Ok(Math.Sqrt(l)),
+            _ => EvaluationResult.Fail("sqrt() requires a numeric argument.")
+        };
+    }
+
+    private static EvaluationResult EvaluateToLower(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        if (r.Value is not string s) return EvaluationResult.Fail("toLower() requires a string argument.");
+        return EvaluationResult.Ok(s.ToLowerInvariant());
+    }
+
+    private static EvaluationResult EvaluateToUpper(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        if (r.Value is not string s) return EvaluationResult.Fail("toUpper() requires a string argument.");
+        return EvaluationResult.Ok(s.ToUpperInvariant());
+    }
+
+    private static EvaluationResult EvaluateTrim(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        if (r.Value is not string s) return EvaluationResult.Fail("trim() requires a string argument.");
+        return EvaluationResult.Ok(s.Trim());
+    }
+
+    private static EvaluationResult EvaluateStartsWith(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        var pr = Evaluate(fn.Arguments[1], context);
+        if (!pr.Success) return pr;
+        if (r.Value is not string s || pr.Value is not string prefix)
+            return EvaluationResult.Fail("startsWith() requires string arguments.");
+        return EvaluationResult.Ok(s.StartsWith(prefix, StringComparison.Ordinal));
+    }
+
+    private static EvaluationResult EvaluateEndsWith(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        var sr = Evaluate(fn.Arguments[1], context);
+        if (!sr.Success) return sr;
+        if (r.Value is not string s || sr.Value is not string suffix)
+            return EvaluationResult.Fail("endsWith() requires string arguments.");
+        return EvaluationResult.Ok(s.EndsWith(suffix, StringComparison.Ordinal));
+    }
+
+    private static EvaluationResult EvaluateLeft(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        var cr = Evaluate(fn.Arguments[1], context);
+        if (!cr.Success) return cr;
+        if (r.Value is not string s) return EvaluationResult.Fail("left() requires a string first argument.");
+        if (!TryToNumber(cr.Value, out var countNum)) return EvaluationResult.Fail("left() count must be numeric.");
+        int count = Math.Max(0, (int)countNum);
+        count = Math.Min(count, s.Length);
+        return EvaluationResult.Ok(s[..count]);
+    }
+
+    private static EvaluationResult EvaluateRight(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        var cr = Evaluate(fn.Arguments[1], context);
+        if (!cr.Success) return cr;
+        if (r.Value is not string s) return EvaluationResult.Fail("right() requires a string first argument.");
+        if (!TryToNumber(cr.Value, out var countNum)) return EvaluationResult.Fail("right() count must be numeric.");
+        int count = Math.Max(0, (int)countNum);
+        count = Math.Min(count, s.Length);
+        return EvaluationResult.Ok(s[^count..]);
+    }
+
+    private static EvaluationResult EvaluateMid(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var r = Evaluate(fn.Arguments[0], context);
+        if (!r.Success) return r;
+        var sr = Evaluate(fn.Arguments[1], context);
+        if (!sr.Success) return sr;
+        var lr = Evaluate(fn.Arguments[2], context);
+        if (!lr.Success) return lr;
+        if (r.Value is not string s) return EvaluationResult.Fail("mid() requires a string first argument.");
+        if (!TryToNumber(sr.Value, out var startNum)) return EvaluationResult.Fail("mid() start must be numeric.");
+        if (!TryToNumber(lr.Value, out var lenNum)) return EvaluationResult.Fail("mid() length must be numeric.");
+
+        int start = Math.Max(0, (int)startNum - 1);
+        int length = Math.Max(0, (int)lenNum);
+
+        if (start >= s.Length) return EvaluationResult.Ok("");
+        length = Math.Min(length, s.Length - start);
+        return EvaluationResult.Ok(s.Substring(start, length));
     }
 
     private static EvaluationResult EvaluateRound(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
@@ -383,22 +661,32 @@ internal static class PreceptExpressionRuntimeEvaluator
         if (!TryToDecimal(valResult.Value, out var d))
             return EvaluationResult.Fail("round() requires a numeric argument.");
 
-        int places = 0;
+        // 2-arg: precision rounding → always returns decimal
         if (fn.Arguments.Length >= 2)
         {
             var placesResult = Evaluate(fn.Arguments[1], context);
             if (!placesResult.Success)
                 return placesResult;
+            int places;
             if (placesResult.Value is long lv)
                 places = (int)lv;
             else if (placesResult.Value is double dv)
                 places = (int)dv;
             else
                 return EvaluationResult.Fail("round() places argument must be numeric.");
+
+            return EvaluationResult.Ok(Math.Round(d, places, MidpointRounding.ToEven));
         }
 
-        var result = Math.Round(d, places, MidpointRounding.ToEven);
-        return EvaluationResult.Ok(result);
+        // 1-arg: type-preserving banker's rounding
+        var rounded = Math.Round(d, 0, MidpointRounding.ToEven);
+        return valResult.Value switch
+        {
+            long => EvaluationResult.Ok((long)rounded),
+            decimal => EvaluationResult.Ok((long)rounded),
+            double => EvaluationResult.Ok((double)rounded),
+            _ => EvaluationResult.Ok(rounded)
+        };
     }
 
     private static bool TryToDecimal(object? value, out decimal d)

--- a/src/Precept/Dsl/PreceptExpressionEvaluator.cs
+++ b/src/Precept/Dsl/PreceptExpressionEvaluator.cs
@@ -24,7 +24,7 @@ internal static class PreceptExpressionRuntimeEvaluator
             PreceptParenthesizedExpression parenthesized => Evaluate(parenthesized.Inner, context, fieldContracts),
             PreceptUnaryExpression unary => EvaluateUnary(unary, context),
             PreceptBinaryExpression binary => EvaluateBinary(binary, context, fieldContracts),
-            PreceptRoundExpression round => EvaluateRound(round, context),
+            PreceptFunctionCallExpression fn => EvaluateFunction(fn, context),
             _ => EvaluationResult.Fail("unsupported expression node.")
         };
     }
@@ -365,16 +365,39 @@ internal static class PreceptExpressionRuntimeEvaluator
         return EvaluationResult.Ok(collection.Contains(rightResult.Value));
     }
 
-    private static EvaluationResult EvaluateRound(PreceptRoundExpression round, IReadOnlyDictionary<string, object?> context)
+    private static EvaluationResult EvaluateFunction(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
     {
-        var valResult = Evaluate(round.Value, context);
+        return fn.Name switch
+        {
+            "round" => EvaluateRound(fn, context),
+            _ => EvaluationResult.Fail($"unknown function '{fn.Name}'.")
+        };
+    }
+
+    private static EvaluationResult EvaluateRound(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)
+    {
+        var valResult = Evaluate(fn.Arguments[0], context);
         if (!valResult.Success)
             return valResult;
 
         if (!TryToDecimal(valResult.Value, out var d))
             return EvaluationResult.Fail("round() requires a numeric argument.");
 
-        var result = Math.Round(d, round.Places, MidpointRounding.ToEven);
+        int places = 0;
+        if (fn.Arguments.Length >= 2)
+        {
+            var placesResult = Evaluate(fn.Arguments[1], context);
+            if (!placesResult.Success)
+                return placesResult;
+            if (placesResult.Value is long lv)
+                places = (int)lv;
+            else if (placesResult.Value is double dv)
+                places = (int)dv;
+            else
+                return EvaluationResult.Fail("round() places argument must be numeric.");
+        }
+
+        var result = Math.Round(d, places, MidpointRounding.ToEven);
         return EvaluationResult.Ok(result);
     }
 

--- a/src/Precept/Dsl/PreceptExpressionEvaluator.cs
+++ b/src/Precept/Dsl/PreceptExpressionEvaluator.cs
@@ -496,6 +496,9 @@ internal static class PreceptExpressionRuntimeEvaluator
         var maxr = Evaluate(fn.Arguments[2], context);
         if (!maxr.Success) return maxr;
 
+        if (vr.Value is decimal dv && minr.Value is decimal dmin && maxr.Value is decimal dmax)
+            return EvaluationResult.Ok(Math.Clamp(dv, dmin, dmax));
+
         if (!TryToNumber(vr.Value, out var val) || !TryToNumber(minr.Value, out var min) || !TryToNumber(maxr.Value, out var max))
             return EvaluationResult.Fail("clamp() requires numeric arguments.");
 
@@ -504,7 +507,6 @@ internal static class PreceptExpressionRuntimeEvaluator
         return vr.Value switch
         {
             long => EvaluationResult.Ok((long)clamped),
-            decimal => EvaluationResult.Ok((decimal)clamped),
             _ => EvaluationResult.Ok(clamped)
         };
     }

--- a/src/Precept/Dsl/PreceptModel.cs
+++ b/src/Precept/Dsl/PreceptModel.cs
@@ -131,8 +131,8 @@ public sealed record PreceptBinaryExpression(string Operator, PreceptExpression 
 
 public sealed record PreceptParenthesizedExpression(PreceptExpression Inner) : PreceptExpression;
 
-/// <summary>round(decimal, places) built-in function call.</summary>
-public sealed record PreceptRoundExpression(PreceptExpression Value, int Places) : PreceptExpression;
+/// <summary>General built-in function call: name(arg1, arg2, ...).</summary>
+public sealed record PreceptFunctionCallExpression(string Name, PreceptExpression[] Arguments) : PreceptExpression;
 
 public sealed record PreceptSetAssignment(
     string Key,

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -329,10 +329,10 @@ public static class PreceptParser
              new[] { firstArg }.Concat(restArgs).ToArray()))
         .Try()
         .Register(new ConstructInfo(
-            "round-function",
-            "round (<Expr>, <N>)",
+            "function-call",
+            "round (<Expr>, ...)",
             "expression",
-            "Calls a built-in function. Available: round(value, places) — rounds a decimal value to N decimal places (banker's rounding). Valid in set RHS and invariant/assert expressions.",
+            "Calls a built-in function. 18 functions available: abs, ceil, clamp, endsWith, floor, left, max, mid, min, pow, right, round, sqrt, startsWith, toLower, toUpper, trim, truncate. Valid in set RHS and invariant/assert expressions.",
             "from Idle on Apply -> set Rate = round(Apply.Amount, 2) -> no transition"));
 
     private static readonly TokenListParser<PreceptToken, PreceptExpression> Atom =

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -313,9 +313,16 @@ public static class PreceptParser
         select (PreceptExpression)new PreceptParenthesizedExpression(inner);
 
     // Built-in function call: FunctionName(expr, expr, ...)
-    // Function names are identifiers validated against the FunctionRegistry.
+    // Function names are identifiers validated against the FunctionRegistry,
+    // plus keyword tokens (min/max) that also serve as function names.
+    // This generalizes the AnyMemberToken pattern for function-call position.
+    private static readonly TokenListParser<PreceptToken, string> AnyFunctionName =
+        Token.EqualTo(PreceptToken.Identifier).Where(t => FunctionRegistry.IsFunction(t.ToStringValue())).Select(t => t.ToStringValue())
+            .Try().Or(Token.EqualTo(PreceptToken.Min).Value("min"))
+            .Try().Or(Token.EqualTo(PreceptToken.Max).Value("max"));
+
     private static readonly TokenListParser<PreceptToken, PreceptExpression> FunctionCallAtom =
-        (from name in Token.EqualTo(PreceptToken.Identifier).Where(t => FunctionRegistry.IsFunction(t.ToStringValue()))
+        (from name in AnyFunctionName
          from _lp in Token.EqualTo(PreceptToken.LeftParen)
          from firstArg in Superpower.Parse.Ref(BoolExprRef)
          from restArgs in (
@@ -325,7 +332,7 @@ public static class PreceptParser
          ).Many()
          from _rp in Token.EqualTo(PreceptToken.RightParen)
          select (PreceptExpression)new PreceptFunctionCallExpression(
-             name.ToStringValue(),
+             name,
              new[] { firstArg }.Concat(restArgs).ToArray()))
         .Try()
         .Register(new ConstructInfo(

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -312,23 +312,27 @@ public static class PreceptParser
         from _rp in Token.EqualTo(PreceptToken.RightParen)
         select (PreceptExpression)new PreceptParenthesizedExpression(inner);
 
-    // round(expr, N) — built-in rounding function; recognized by identifier name, not a keyword
-    private static readonly TokenListParser<PreceptToken, PreceptExpression> RoundAtom =
-        (from kw in Token.EqualTo(PreceptToken.Identifier).Where(t => t.ToStringValue() == "round")
+    // Built-in function call: FunctionName(expr, expr, ...)
+    // Function names are identifiers validated against the FunctionRegistry.
+    private static readonly TokenListParser<PreceptToken, PreceptExpression> FunctionCallAtom =
+        (from name in Token.EqualTo(PreceptToken.Identifier).Where(t => FunctionRegistry.IsFunction(t.ToStringValue()))
          from _lp in Token.EqualTo(PreceptToken.LeftParen)
-         from val in Superpower.Parse.Ref(BoolExprRef)
-         from _c in Token.EqualTo(PreceptToken.Comma)
-         from n in Token.EqualTo(PreceptToken.NumberLiteral)
+         from firstArg in Superpower.Parse.Ref(BoolExprRef)
+         from restArgs in (
+             from _c in Token.EqualTo(PreceptToken.Comma)
+             from arg in Superpower.Parse.Ref(BoolExprRef)
+             select arg
+         ).Many()
          from _rp in Token.EqualTo(PreceptToken.RightParen)
-         let raw = n.ToNumericLiteralValue()
-         let places = raw is long l ? (int)l : (int)(double)raw
-         select (PreceptExpression)new PreceptRoundExpression(val, places))
+         select (PreceptExpression)new PreceptFunctionCallExpression(
+             name.ToStringValue(),
+             new[] { firstArg }.Concat(restArgs).ToArray()))
         .Try()
         .Register(new ConstructInfo(
             "round-function",
             "round (<Expr>, <N>)",
             "expression",
-            "Rounds a decimal expression to N decimal places (banker's rounding). Valid in set RHS and invariant/assert expressions.",
+            "Calls a built-in function. Available: round(value, places) — rounds a decimal value to N decimal places (banker's rounding). Valid in set RHS and invariant/assert expressions.",
             "from Idle on Apply -> set Rate = round(Apply.Amount, 2) -> no transition"));
 
     private static readonly TokenListParser<PreceptToken, PreceptExpression> Atom =
@@ -338,7 +342,7 @@ public static class PreceptParser
             .Try().Or(FalseAtom)
             .Try().Or(NullAtom)
             .Try().Or(ParenExpr)
-            .Try().Or(RoundAtom)
+            .Try().Or(FunctionCallAtom)
             .Or(DottedIdentifier);
 
     // Level 4: Unary (! and unary -)
@@ -795,7 +799,7 @@ public static class PreceptParser
             PreceptUnaryExpression un => $"{un.Operator}{ReconstituteExpr(un.Operand)}",
             PreceptBinaryExpression bin => $"{ReconstituteExpr(bin.Left)} {bin.Operator} {ReconstituteExpr(bin.Right)}",
             PreceptParenthesizedExpression paren => $"({ReconstituteExpr(paren.Inner)})",
-            PreceptRoundExpression round => $"round({ReconstituteExpr(round.Value)}, {round.Places})",
+            PreceptFunctionCallExpression fn => $"{fn.Name}({string.Join(", ", fn.Arguments.Select(ReconstituteExpr))})",
             _ => expr.ToString() ?? ""
         };
 

--- a/src/Precept/Dsl/PreceptTypeChecker.cs
+++ b/src/Precept/Dsl/PreceptTypeChecker.cs
@@ -95,6 +95,15 @@ internal static class PreceptTypeChecker
             MapFieldContractKind,
             StringComparer.Ordinal);
 
+        // Inject non-negative proof markers for sqrt() compile-time checking.
+        // Fields with nonnegative, positive, or min >= 0 constraints are provably non-negative.
+        foreach (var field in model.Fields)
+        {
+            if (field.Constraints is not null &&
+                field.Constraints.Any(static c => c is FieldConstraint.Nonnegative or FieldConstraint.Positive or FieldConstraint.Min { Value: >= 0 }))
+                dataFieldKinds[$"$nonneg:{field.Name}"] = StaticValueKind.Boolean;
+        }
+
         var eventArgKinds = model.Events.ToDictionary(
             evt => evt.Name,
             evt => evt.Args.ToDictionary(
@@ -1268,63 +1277,190 @@ internal static class PreceptTypeChecker
         kind = StaticValueKind.None;
         diagnostic = null;
 
+        // SYNC:CONSTRAINT:C71 — unknown function name
         if (!FunctionRegistry.TryGetFunction(fn.Name, out var funcDef))
         {
             diagnostic = new PreceptValidationDiagnostic(
-                DiagnosticCatalog.C39,
-                $"unknown function '{fn.Name}'.",
+                DiagnosticCatalog.C71,
+                $"Unknown function '{fn.Name}'.",
                 0);
             return false;
         }
 
-        // Find overload matching arity (prefer exact match, then variadic)
-        var overload = funcDef.Overloads.FirstOrDefault(o =>
-            o.MinArity.HasValue
-                ? fn.Arguments.Length >= o.MinArity.Value
-                : fn.Arguments.Length == o.Parameters.Length);
-
-        if (overload is null)
+        // Infer all argument kinds before overload resolution.
+        var argKinds = new StaticValueKind[fn.Arguments.Length];
+        for (int i = 0; i < fn.Arguments.Length; i++)
         {
-            diagnostic = new PreceptValidationDiagnostic(
-                DiagnosticCatalog.C40,
-                $"{fn.Name}() called with {fn.Arguments.Length} argument(s), but no matching overload found.",
-                0);
-            return false;
-        }
-
-        // Validate each argument against the overload's parameter types
-        for (int i = 0; i < fn.Arguments.Length && i < overload.Parameters.Length; i++)
-        {
-            var param = overload.Parameters[i];
-
-            // Special constraint: must be a non-negative integer literal
-            if (param.Constraint == FunctionArgConstraint.MustBeIntegerLiteral)
-            {
-                if (fn.Arguments[i] is not PreceptLiteralExpression { Value: long lv } || lv < 0)
-                {
-                    diagnostic = new PreceptValidationDiagnostic(
-                        DiagnosticCatalog.C40,
-                        $"{fn.Name}() {param.Name} argument must be non-negative.",
-                        0);
-                    return false;
-                }
-                continue;
-            }
-
-            if (!TryInferKind(fn.Arguments[i], symbols, out var argKind, out diagnostic))
+            if (!TryInferKind(fn.Arguments[i], symbols, out argKinds[i], out diagnostic))
                 return false;
 
-            if (!IsNumericKind(argKind))
+            // SYNC:CONSTRAINT:C77 — nullable arguments
+            if ((argKinds[i] & StaticValueKind.Null) != 0)
             {
+                var argName = fn.Arguments[i] is PreceptIdentifierExpression id ? id.Name : $"argument {i + 1}";
                 diagnostic = new PreceptValidationDiagnostic(
-                    DiagnosticCatalog.C40,
-                    $"{fn.Name}() requires a numeric (integer, decimal, or number) argument.",
+                    DiagnosticCatalog.C77,
+                    $"Function '{fn.Name}' does not accept nullable arguments. '{argName}' may be null. Add a null check.",
                     0);
                 return false;
             }
         }
 
-        kind = overload.ReturnType;
+        // Find the best matching overload (arity + argument types).
+        FunctionOverload? matched = null;
+        foreach (var overload in funcDef.Overloads)
+        {
+            bool arityOk = overload.MinArity.HasValue
+                ? fn.Arguments.Length >= overload.MinArity.Value
+                : fn.Arguments.Length == overload.Parameters.Length;
+
+            if (!arityOk)
+                continue;
+
+            bool typesOk = true;
+            if (overload.MinArity.HasValue)
+            {
+                // Variadic: single parameter type applies to all arguments.
+                var paramType = overload.Parameters[0].AcceptedTypes;
+                for (int i = 0; i < fn.Arguments.Length; i++)
+                {
+                    if ((argKinds[i] & paramType) == 0)
+                    {
+                        typesOk = false;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < overload.Parameters.Length; i++)
+                {
+                    if ((argKinds[i] & overload.Parameters[i].AcceptedTypes) == 0)
+                    {
+                        typesOk = false;
+                        break;
+                    }
+                }
+            }
+
+            if (typesOk)
+            {
+                matched = overload;
+                break;
+            }
+        }
+
+        if (matched is null)
+        {
+            // SYNC:CONSTRAINT:C75 — pow exponent must be integer
+            if (fn.Name == "pow" && fn.Arguments.Length == 2 &&
+                IsNumericKind(argKinds[1]) && !IsExactly(argKinds[1], StaticValueKind.Integer))
+            {
+                diagnostic = new PreceptValidationDiagnostic(
+                    DiagnosticCatalog.C75,
+                    $"pow() exponent must be integer type, but got {KindLabel(argKinds[1])}.",
+                    0);
+                return false;
+            }
+
+            // Try to pinpoint a specific parameter type mismatch (C73).
+            var arityMatch = funcDef.Overloads.LastOrDefault(o =>
+                o.MinArity.HasValue
+                    ? fn.Arguments.Length >= o.MinArity.Value
+                    : fn.Arguments.Length == o.Parameters.Length);
+
+            if (arityMatch is not null)
+            {
+                // SYNC:CONSTRAINT:C73 — argument type mismatch
+                if (arityMatch.MinArity.HasValue)
+                {
+                    var param = arityMatch.Parameters[0];
+                    for (int i = 0; i < fn.Arguments.Length; i++)
+                    {
+                        if ((argKinds[i] & param.AcceptedTypes) == 0)
+                        {
+                            diagnostic = new PreceptValidationDiagnostic(
+                                DiagnosticCatalog.C73,
+                                $"{fn.Name}() no matching overload: {param.Name} argument expects {KindLabel(param.AcceptedTypes)} but got {KindLabel(argKinds[i])}.",
+                                0);
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int i = 0; i < arityMatch.Parameters.Length; i++)
+                    {
+                        var param = arityMatch.Parameters[i];
+                        if ((argKinds[i] & param.AcceptedTypes) == 0)
+                        {
+                            diagnostic = new PreceptValidationDiagnostic(
+                                DiagnosticCatalog.C73,
+                                $"{fn.Name}() no matching overload: {param.Name} argument expects {KindLabel(param.AcceptedTypes)} but got {KindLabel(argKinds[i])}.",
+                                0);
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            // SYNC:CONSTRAINT:C72 — no matching overload
+            diagnostic = new PreceptValidationDiagnostic(
+                DiagnosticCatalog.C72,
+                $"{fn.Name}() called with {fn.Arguments.Length} argument(s), but no matching overload found.",
+                0);
+            return false;
+        }
+
+        // Validate special parameter constraints on the matched overload.
+        var paramLoop = matched.MinArity.HasValue
+            ? Enumerable.Range(0, fn.Arguments.Length).Select(i => (ParamIndex: 0, ArgIndex: i))
+            : Enumerable.Range(0, matched.Parameters.Length).Select(i => (ParamIndex: i, ArgIndex: i));
+
+        foreach (var (paramIndex, argIndex) in paramLoop)
+        {
+            var param = matched.Parameters[paramIndex];
+
+            // SYNC:CONSTRAINT:C74 — round precision must be non-negative integer literal
+            if (param.Constraint == FunctionArgConstraint.MustBeIntegerLiteral)
+            {
+                if (fn.Arguments[argIndex] is not PreceptLiteralExpression { Value: long lv } || lv < 0)
+                {
+                    diagnostic = new PreceptValidationDiagnostic(
+                        DiagnosticCatalog.C74,
+                        "round() precision argument must be a non-negative integer literal.",
+                        0);
+                    return false;
+                }
+            }
+
+            // SYNC:CONSTRAINT:C76 — sqrt requires non-negative proof
+            if (param.Constraint == FunctionArgConstraint.RequiresNonNegativeProof)
+            {
+                var arg = fn.Arguments[argIndex];
+                bool isNonNeg = arg switch
+                {
+                    PreceptLiteralExpression { Value: long lval } => lval >= 0,
+                    PreceptLiteralExpression { Value: double dval } => dval >= 0,
+                    PreceptLiteralExpression { Value: decimal mval } => mval >= 0,
+                    PreceptFunctionCallExpression { Name: "abs" } => true,
+                    PreceptIdentifierExpression idArg => symbols.ContainsKey($"$nonneg:{idArg.Name}"),
+                    _ => false,
+                };
+
+                if (!isNonNeg)
+                {
+                    var argName = arg is PreceptIdentifierExpression nid ? nid.Name : "argument";
+                    diagnostic = new PreceptValidationDiagnostic(
+                        DiagnosticCatalog.C76,
+                        $"sqrt() requires a non-negative argument. '{argName}' may be negative. Add a 'nonnegative' constraint or guard with '{argName} >= 0 and ...'.",
+                        0);
+                    return false;
+                }
+            }
+        }
+
+        kind = matched.ReturnType;
         return true;
     }
 
@@ -1841,6 +1977,19 @@ internal static class PreceptTypeChecker
     /// <summary>Returns true when <paramref name="k"/> is a pure numeric kind (Number, Integer, or Decimal, non-nullable, no other flags).</summary>
     private static bool IsNumericKind(StaticValueKind k)
         => IsExactly(k, StaticValueKind.Number) || IsExactly(k, StaticValueKind.Integer) || IsExactly(k, StaticValueKind.Decimal);
+
+    /// <summary>Returns a human-readable label for a <see cref="StaticValueKind"/> (used in function diagnostic messages).</summary>
+    private static string KindLabel(StaticValueKind k) => (k & ~StaticValueKind.Null) switch
+    {
+        StaticValueKind.Integer => "integer",
+        StaticValueKind.Decimal => "decimal",
+        StaticValueKind.Number => "number",
+        StaticValueKind.String => "string",
+        StaticValueKind.Boolean => "boolean",
+        StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal => "numeric",
+        StaticValueKind.Number | StaticValueKind.Integer => "number or integer",
+        _ => k.ToString().ToLowerInvariant(),
+    };
 
     /// <summary>
     /// Resolves the result kind for a numeric binary operation.

--- a/src/Precept/Dsl/PreceptTypeChecker.cs
+++ b/src/Precept/Dsl/PreceptTypeChecker.cs
@@ -957,8 +957,9 @@ internal static class PreceptTypeChecker
                 CheckCrossScopeGuardIdentifiers(paren.Inner, allowedSymbols, sourceLine, diagnostics);
                 break;
 
-            case PreceptRoundExpression round:
-                CheckCrossScopeGuardIdentifiers(round.Value, allowedSymbols, sourceLine, diagnostics);
+            case PreceptFunctionCallExpression fn:
+                foreach (var arg in fn.Arguments)
+                    CheckCrossScopeGuardIdentifiers(arg, allowedSymbols, sourceLine, diagnostics);
                 break;
 
             case PreceptLiteralExpression:
@@ -1246,32 +1247,8 @@ internal static class PreceptTypeChecker
             case PreceptBinaryExpression binary:
                 return TryInferBinaryKind(binary, symbols, out kind, out diagnostic);
 
-            case PreceptRoundExpression round:
-            {
-                if (!TryInferKind(round.Value, symbols, out var innerKind, out diagnostic))
-                    return false;
-
-                if (!IsNumericKind(innerKind))
-                {
-                    diagnostic = new PreceptValidationDiagnostic(
-                        DiagnosticCatalog.C40,
-                        "round() requires a numeric (integer, decimal, or number) argument.",
-                        0);
-                    return false;
-                }
-
-                if (round.Places < 0)
-                {
-                    diagnostic = new PreceptValidationDiagnostic(
-                        DiagnosticCatalog.C40,
-                        "round() places argument must be non-negative.",
-                        0);
-                    return false;
-                }
-
-                kind = StaticValueKind.Decimal;
-                return true;
-            }
+            case PreceptFunctionCallExpression fn:
+                return TryInferFunctionCallKind(fn, symbols, out kind, out diagnostic);
 
             default:
                 diagnostic = new PreceptValidationDiagnostic(
@@ -1280,6 +1257,75 @@ internal static class PreceptTypeChecker
                     0);
                 return false;
         }
+    }
+
+    private static bool TryInferFunctionCallKind(
+        PreceptFunctionCallExpression fn,
+        IReadOnlyDictionary<string, StaticValueKind> symbols,
+        out StaticValueKind kind,
+        out PreceptValidationDiagnostic? diagnostic)
+    {
+        kind = StaticValueKind.None;
+        diagnostic = null;
+
+        if (!FunctionRegistry.TryGetFunction(fn.Name, out var funcDef))
+        {
+            diagnostic = new PreceptValidationDiagnostic(
+                DiagnosticCatalog.C39,
+                $"unknown function '{fn.Name}'.",
+                0);
+            return false;
+        }
+
+        // Find overload matching arity (prefer exact match, then variadic)
+        var overload = funcDef.Overloads.FirstOrDefault(o =>
+            o.MinArity.HasValue
+                ? fn.Arguments.Length >= o.MinArity.Value
+                : fn.Arguments.Length == o.Parameters.Length);
+
+        if (overload is null)
+        {
+            diagnostic = new PreceptValidationDiagnostic(
+                DiagnosticCatalog.C40,
+                $"{fn.Name}() called with {fn.Arguments.Length} argument(s), but no matching overload found.",
+                0);
+            return false;
+        }
+
+        // Validate each argument against the overload's parameter types
+        for (int i = 0; i < fn.Arguments.Length && i < overload.Parameters.Length; i++)
+        {
+            var param = overload.Parameters[i];
+
+            // Special constraint: must be a non-negative integer literal
+            if (param.Constraint == FunctionArgConstraint.MustBeIntegerLiteral)
+            {
+                if (fn.Arguments[i] is not PreceptLiteralExpression { Value: long lv } || lv < 0)
+                {
+                    diagnostic = new PreceptValidationDiagnostic(
+                        DiagnosticCatalog.C40,
+                        $"{fn.Name}() {param.Name} argument must be non-negative.",
+                        0);
+                    return false;
+                }
+                continue;
+            }
+
+            if (!TryInferKind(fn.Arguments[i], symbols, out var argKind, out diagnostic))
+                return false;
+
+            if (!IsNumericKind(argKind))
+            {
+                diagnostic = new PreceptValidationDiagnostic(
+                    DiagnosticCatalog.C40,
+                    $"{fn.Name}() requires a numeric (integer, decimal, or number) argument.",
+                    0);
+                return false;
+            }
+        }
+
+        kind = overload.ReturnType;
+        return true;
     }
 
     private static bool TryInferBinaryKind(

--- a/test/Precept.Mcp.Tests/LanguageToolTests.cs
+++ b/test/Precept.Mcp.Tests/LanguageToolTests.cs
@@ -145,8 +145,8 @@ public class LanguageToolTests
     {
         var result = LanguageTool.Run();
 
-        result.Constructs.Should().Contain(c => c.Form.StartsWith("round"),
-            "round() built-in must be registered in the construct catalog");
+        result.Constructs.Should().Contain(c => c.Description.Contains("built-in function"),
+            "function-call construct must be registered in the construct catalog");
     }
 
     [Fact]

--- a/test/Precept.Mcp.Tests/LanguageToolTests.cs
+++ b/test/Precept.Mcp.Tests/LanguageToolTests.cs
@@ -84,6 +84,15 @@ public class LanguageToolTests
     }
 
     [Fact]
+    public void ConstraintsIncludeBuiltInFunctionTypeCheckingRange()
+    {
+        var result = LanguageTool.Run();
+
+        result.Constraints.Select(constraint => constraint.Id)
+            .Should().Contain(["C71", "C72", "C73", "C74", "C75", "C76", "C77"]);
+    }
+
+    [Fact]
     public void ExpressionScopesHasFiveEntries()
     {
         var result = LanguageTool.Run();

--- a/test/Precept.Tests/CatalogDriftTests.cs
+++ b/test/Precept.Tests/CatalogDriftTests.cs
@@ -602,6 +602,57 @@ public class CatalogDriftTests
         ["C70"] = new(H + "field X as number default 0 default 1\n" + S2 +
             "event Go\nfrom A on Go -> no transition\n", "Duplicate modifier"),
 
+        // C71: unknown function name — parser rejects unknown names at parse time,
+        // so we construct a model with an unknown function call directly.
+        ["C71"] = new("_unused_", "Unknown function", DirectAction: () =>
+        {
+            var model = new PreceptDefinition(
+                "Test",
+                [new PreceptState("A", SourceLine: 2), new PreceptState("B", SourceLine: 3)],
+                new PreceptState("A", SourceLine: 2),
+                [new PreceptEvent("Go", [])],
+                [new PreceptField("X", PreceptScalarType.Number, false, true, 0L)],
+                [],
+                TransitionRows: [new PreceptTransitionRow(
+                    "A", "Go",
+                    new NoTransition(),
+                    [],
+                    WhenText: "unknownfn(X) > 0",
+                    WhenGuard: new PreceptBinaryExpression(
+                        ">",
+                        new PreceptFunctionCallExpression("unknownfn", [new PreceptIdentifierExpression("X")]),
+                        new PreceptLiteralExpression(0L)),
+                    SourceLine: 5)]);
+            var result = PreceptCompiler.Validate(model);
+            var diag = result.Diagnostics.FirstOrDefault(d => d.Constraint.Id == "C71");
+            if (diag is null) throw new InvalidOperationException("C71 not triggered");
+            throw new InvalidOperationException($"{diag.DiagnosticCode}: {diag.Message}");
+        }),
+
+        // C72: wrong number of arguments (parser requires ≥1 arg, so use 2-arg abs)
+        ["C72"] = new(H + "field X as number default 0\n" + S2 +
+            "event Go\nfrom A on Go when abs(X, X) > 0 -> no transition\n", "no matching overload"),
+
+        // C73: argument type mismatch
+        ["C73"] = new(H + "field Name as string default \"test\"\n" + S2 +
+            "event Go\nfrom A on Go when abs(Name) > 0 -> no transition\n", "no matching overload"),
+
+        // C74: round precision must be non-negative integer literal
+        ["C74"] = new(H + "field X as number default 0\n" + S2 +
+            "event Go\nfrom A on Go when round(X, X) > 0 -> no transition\n", "precision"),
+
+        // C75: pow exponent must be integer type
+        ["C75"] = new(H + "field X as number default 0\n" + S2 +
+            "event Go\nfrom A on Go when pow(X, X) > 0 -> no transition\n", "exponent"),
+
+        // C76: sqrt requires non-negative proof
+        ["C76"] = new(H + "field X as number default 0\n" + S2 +
+            "event Go\nfrom A on Go when sqrt(X) > 0 -> no transition\n", "non-negative"),
+
+        // C77: function does not accept nullable arguments
+        ["C77"] = new(H + "field X as number nullable default null\n" + S2 +
+            "event Go\nfrom A on Go when abs(X) > 0 -> no transition\n", "nullable"),
+
         // ── Runtime-phase (C33–C37) ───────────────────────────────────
 
         // C33: CreateInstance with empty initial state
@@ -1177,6 +1228,7 @@ public class CatalogDriftTests
         "C53",  // empty precept (no events) — legitimately points at precept header
         "C61",  // maxplaces on non-decimal — DirectAction
         "C62",  // choice with no values — DirectAction
+        "C71",  // unknown function name — DirectAction (parser rejects unknown names)
     };
 
     /// <summary>
@@ -1351,6 +1403,24 @@ public class CatalogDriftTests
 
         // C70: duplicate modifier — field on line 2
         ["C70"] = ("precept Test\nfield X as number default 0 default 1\nstate A initial\n", "parse", 2),
+
+        // C72: wrong arity — row on line 6
+        ["C72"] = ("precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(X, X) > 0 -> no transition\n", "compile", 6),
+
+        // C73: type mismatch — row on line 6
+        ["C73"] = ("precept Test\nfield Name as string default \"test\"\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(Name) > 0 -> no transition\n", "compile", 6),
+
+        // C74: round precision — row on line 6
+        ["C74"] = ("precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when round(X, X) > 0 -> no transition\n", "compile", 6),
+
+        // C75: pow exponent — row on line 6
+        ["C75"] = ("precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when pow(X, X) > 0 -> no transition\n", "compile", 6),
+
+        // C76: sqrt non-negative — row on line 6
+        ["C76"] = ("precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when sqrt(X) > 0 -> no transition\n", "compile", 6),
+
+        // C77: nullable arg — row on line 6
+        ["C77"] = ("precept Test\nfield X as number nullable default null\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(X) > 0 -> no transition\n", "compile", 6),
     };
 
     [Theory]

--- a/test/Precept.Tests/CatalogDriftTests.cs
+++ b/test/Precept.Tests/CatalogDriftTests.cs
@@ -94,8 +94,8 @@ public class CatalogDriftTests
             "transition-row" =>
                 $"{header}\n{string.Join("\n", states)}\nevent Submit\n{construct.Example}",
 
-            "round-function" =>
-                // round() needs a decimal field and an event to be valid in a transition context
+            "function-call" =>
+                // function call needs a decimal field and an event to be valid in a transition context
                 $"{header}\nfield Rate as decimal default 0.0\n{string.Join("\n", states)}\nevent Apply with Amount as number\n{construct.Example}",
 
             _ =>

--- a/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
+++ b/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
@@ -424,6 +424,71 @@ public class PreceptBuiltInFunctionTests
         validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C77");
     }
 
+    [Fact]
+    public void TypeChecker_C72_MinSingleArg()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when min(X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C72");
+    }
+
+    [Fact]
+    public void TypeChecker_C72_MaxSingleArg()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when max(X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C72");
+    }
+
+    [Fact]
+    public void TypeChecker_C76_SqrtWithAbsProof_NoDiagnostic()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when sqrt(abs(X)) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Where(d => d.Constraint.Id == "C76").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeChecker_C76_SqrtWithNonNegativeLiteral_NoDiagnostic()
+    {
+        var dsl = "precept Test\nstate A initial\nstate B\nevent Go\nfrom A on Go when sqrt(4.0) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Where(d => d.Constraint.Id == "C76").Should().BeEmpty();
+    }
+
+    // ─── Functions in invariant and assert contexts ─────────────────
+
+    [Fact]
+    public void Invariant_WithFunction_CompilesClean()
+    {
+        var dsl = "precept Test\nfield Balance as number nonnegative default 0\nstate Open initial\nstate Closed\nevent Go\nfrom Open on Go -> transition Closed\ninvariant sqrt(Balance) >= 0 because \"balance root must be non-negative\"\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StateAssert_WithFunction_CompilesClean()
+    {
+        var dsl = "precept Test\nfield Score as number default 10\nstate Active initial\nstate Done\nevent Go\nfrom Active on Go -> transition Done\nin Active assert floor(Score) >= 0 because \"floor score must be non-negative\"\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EventAssert_WithFunction_CompilesClean()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Submit with Amount as number default 1\non Submit assert abs(Amount) > 0 because \"amount must be non-zero\"\nfrom A on Submit -> transition B\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().BeEmpty();
+    }
+
     // ─── Evaluation: toLower ────────────────────────────────────────
 
     [Fact]

--- a/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
+++ b/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using Xunit;
 
@@ -32,6 +34,18 @@ public class PreceptBuiltInFunctionTests
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
         fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5L);
+    }
+
+    [Fact]
+    public void Eval_Abs_NegativeDecimal_ReturnsPositiveDecimal()
+    {
+        var fire = FireForSet(
+            "field Input as decimal default 0\nfield Output as decimal default 0",
+            "Output", "abs(Input)",
+            new Dictionary<string, object?> { ["Input"] = -5.5m, ["Output"] = 0m });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5.5m);
     }
 
     [Fact]
@@ -340,6 +354,18 @@ public class PreceptBuiltInFunctionTests
         fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3.0);
     }
 
+    [Fact]
+    public void Eval_Sqrt_ZeroInput_ReturnsZero()
+    {
+        var fire = FireForSet(
+            "field Input as number nonnegative default 0\nfield Output as number default 0",
+            "Output", "sqrt(Input)",
+            new Dictionary<string, object?> { ["Input"] = 0.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(0.0);
+    }
+
     // ─── Parse verification ─────────────────────────────────────────
 
     [Theory]
@@ -369,6 +395,40 @@ public class PreceptBuiltInFunctionTests
     }
 
     // ─── Type checker diagnostics ───────────────────────────────────
+
+    [Fact]
+    public void TypeChecker_C71_UnknownFunction()
+    {
+        // Parser rejects unknown function names, so construct a model directly
+        var model = new PreceptDefinition(
+            "Test",
+            [new PreceptState("A", SourceLine: 2), new PreceptState("B", SourceLine: 3)],
+            new PreceptState("A", SourceLine: 2),
+            [new PreceptEvent("Go", [])],
+            [new PreceptField("X", PreceptScalarType.Number, false, true, 0L)],
+            [],
+            TransitionRows: [new PreceptTransitionRow(
+                "A", "Go",
+                new NoTransition(),
+                [],
+                WhenText: "unknownfn(X) > 0",
+                WhenGuard: new PreceptBinaryExpression(
+                    ">",
+                    new PreceptFunctionCallExpression("unknownfn", [new PreceptIdentifierExpression("X")]),
+                    new PreceptLiteralExpression(0L)),
+                SourceLine: 5)]);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C71");
+    }
+
+    [Fact]
+    public void TypeChecker_C73_ArgTypeMismatch()
+    {
+        var dsl = "precept Test\nfield Name as string default \"\"\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(Name) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C73");
+    }
 
     [Fact]
     public void TypeChecker_C72_WrongArity_Abs()
@@ -525,6 +585,29 @@ public class PreceptBuiltInFunctionTests
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
         fire.UpdatedInstance!.InstanceData["Output"].Should().Be("");
+    }
+
+    [Fact]
+    public void Eval_ToLower_TurkishI_UsesInvariantCulture()
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+            var fire = FireForSet(
+                "field Input as string default \"\"\nfield Output as string default \"\"",
+                "Output", "toLower(Input)",
+                new Dictionary<string, object?> { ["Input"] = "TITLE", ["Output"] = "" });
+
+            fire.Outcome.Should().Be(TransitionOutcome.Transition);
+            var result = (string)fire.UpdatedInstance!.InstanceData["Output"]!;
+            result.Should().Be("title", "toLower should use invariant culture, not Turkish");
+            result.Should().NotContain("\u0131", "invariant culture should not produce dotless \u0131");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
     }
 
     // ─── Evaluation: toUpper ────────────────────────────────────────
@@ -700,6 +783,18 @@ public class PreceptBuiltInFunctionTests
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
         fire.UpdatedInstance!.InstanceData["Output"].Should().Be("Hi");
+    }
+
+    [Fact]
+    public void Eval_Right_ZeroCount_ReturnsEmpty()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "right(Input, 0)",
+            new Dictionary<string, object?> { ["Input"] = "Hello", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("");
     }
 
     // ─── Evaluation: mid ────────────────────────────────────────────

--- a/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
+++ b/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
@@ -1,0 +1,802 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Precept.Tests;
+
+public class PreceptBuiltInFunctionTests
+{
+    // ─── Evaluation: abs ────────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Abs_NegativeNumber_ReturnsPositive()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as number default 0",
+            "Output", "abs(Input)",
+            new Dictionary<string, object?> { ["Input"] = -5.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5.0);
+    }
+
+    [Fact]
+    public void Eval_Abs_NegativeInteger_ReturnsPositiveInteger()
+    {
+        var fire = FireForSet(
+            "field Input as integer default 0\nfield Output as integer default 0",
+            "Output", "abs(Input)",
+            new Dictionary<string, object?> { ["Input"] = -5L, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5L);
+    }
+
+    [Fact]
+    public void Eval_Abs_PositiveNumber_ReturnsSameValue()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as number default 0",
+            "Output", "abs(Input)",
+            new Dictionary<string, object?> { ["Input"] = 5.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5.0);
+    }
+
+    // ─── Evaluation: floor ──────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Floor_PositiveFraction_RoundsDown()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "floor(Input)",
+            new Dictionary<string, object?> { ["Input"] = 3.7, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3L);
+    }
+
+    [Fact]
+    public void Eval_Floor_NegativeFraction_RoundsTowardNegativeInfinity()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "floor(Input)",
+            new Dictionary<string, object?> { ["Input"] = -3.2, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(-4L);
+    }
+
+    [Fact]
+    public void Eval_Floor_WholeNumber_ReturnsSameValue()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "floor(Input)",
+            new Dictionary<string, object?> { ["Input"] = 5.0, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5L);
+    }
+
+    // ─── Evaluation: ceil ───────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Ceil_PositiveFraction_RoundsUp()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "ceil(Input)",
+            new Dictionary<string, object?> { ["Input"] = 3.2, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(4L);
+    }
+
+    [Fact]
+    public void Eval_Ceil_NegativeFraction_RoundsTowardPositiveInfinity()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "ceil(Input)",
+            new Dictionary<string, object?> { ["Input"] = -3.7, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(-3L);
+    }
+
+    // ─── Evaluation: truncate ───────────────────────────────────────
+
+    [Fact]
+    public void Eval_Truncate_PositiveFraction_TruncatesTowardZero()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "truncate(Input)",
+            new Dictionary<string, object?> { ["Input"] = 3.7, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3L);
+    }
+
+    [Fact]
+    public void Eval_Truncate_NegativeFraction_TruncatesTowardZero()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as integer default 0",
+            "Output", "truncate(Input)",
+            new Dictionary<string, object?> { ["Input"] = -3.7, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(-3L);
+    }
+
+    // ─── Evaluation: round ──────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Round_BankersRounding_HalfToEven_RoundsDown()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as number default 0",
+            "Output", "round(Input)",
+            new Dictionary<string, object?> { ["Input"] = 2.5, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2.0);
+    }
+
+    [Fact]
+    public void Eval_Round_BankersRounding_HalfToEven_RoundsUp()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as number default 0",
+            "Output", "round(Input)",
+            new Dictionary<string, object?> { ["Input"] = 3.5, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(4.0);
+    }
+
+    [Fact]
+    public void Eval_Round_BelowHalf_RoundsDown()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as number default 0",
+            "Output", "round(Input)",
+            new Dictionary<string, object?> { ["Input"] = 2.4, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2.0);
+    }
+
+    [Fact]
+    public void Eval_Round_AboveHalf_RoundsUp()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as number default 0",
+            "Output", "round(Input)",
+            new Dictionary<string, object?> { ["Input"] = 2.6, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3.0);
+    }
+
+    [Fact]
+    public void Eval_Round_WithPrecision_ReturnsDecimalResult()
+    {
+        var fire = FireForSet(
+            "field Input as number default 0\nfield Output as decimal default 0",
+            "Output", "round(Input, 2)",
+            new Dictionary<string, object?> { ["Input"] = 3.14159, ["Output"] = 0m });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3.14m);
+    }
+
+    // ─── Evaluation: min ────────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Min_TwoArgs_ReturnsSmallest()
+    {
+        var fire = FireForSet(
+            "field X as number default 0\nfield Output as number default 0",
+            "Output", "min(X, 7.0)",
+            new Dictionary<string, object?> { ["X"] = 3.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3.0);
+    }
+
+    [Fact]
+    public void Eval_Min_ThreeArgs_ReturnsSmallest()
+    {
+        var fire = FireForSet(
+            "field A as number default 0\nfield B as number default 0\nfield C as number default 0\nfield Output as number default 0",
+            "Output", "min(A, B, C)",
+            new Dictionary<string, object?> { ["A"] = 5.0, ["B"] = 2.0, ["C"] = 8.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2.0);
+    }
+
+    // ─── Evaluation: max ────────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Max_TwoArgs_ReturnsLargest()
+    {
+        var fire = FireForSet(
+            "field X as number default 0\nfield Output as number default 0",
+            "Output", "max(X, 7.0)",
+            new Dictionary<string, object?> { ["X"] = 3.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(7.0);
+    }
+
+    [Fact]
+    public void Eval_Max_ThreeArgs_ReturnsLargest()
+    {
+        var fire = FireForSet(
+            "field A as number default 0\nfield B as number default 0\nfield C as number default 0\nfield Output as number default 0",
+            "Output", "max(A, B, C)",
+            new Dictionary<string, object?> { ["A"] = 5.0, ["B"] = 2.0, ["C"] = 8.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(8.0);
+    }
+
+    // ─── Evaluation: clamp ──────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Clamp_InRange_ReturnsSameValue()
+    {
+        var fire = FireForSet(
+            "field X as number default 0\nfield Output as number default 0",
+            "Output", "clamp(X, 1.0, 10.0)",
+            new Dictionary<string, object?> { ["X"] = 5.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(5.0);
+    }
+
+    [Fact]
+    public void Eval_Clamp_BelowMin_ReturnsMin()
+    {
+        var fire = FireForSet(
+            "field X as number default 0\nfield Output as number default 0",
+            "Output", "clamp(X, 0.0, 10.0)",
+            new Dictionary<string, object?> { ["X"] = -5.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Eval_Clamp_AboveMax_ReturnsMax()
+    {
+        var fire = FireForSet(
+            "field X as number default 0\nfield Output as number default 0",
+            "Output", "clamp(X, 0.0, 10.0)",
+            new Dictionary<string, object?> { ["X"] = 15.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(10.0);
+    }
+
+    // ─── Evaluation: pow ────────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Pow_IntegerBase_ReturnsCorrectPower()
+    {
+        var fire = FireForSet(
+            "field X as integer default 0\nfield Output as integer default 0",
+            "Output", "pow(X, 3)",
+            new Dictionary<string, object?> { ["X"] = 2L, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(8L);
+    }
+
+    [Fact]
+    public void Eval_Pow_ZeroExponent_ReturnsOne()
+    {
+        var fire = FireForSet(
+            "field X as integer default 0\nfield Output as integer default 0",
+            "Output", "pow(X, 0)",
+            new Dictionary<string, object?> { ["X"] = 5L, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(1L);
+    }
+
+    [Fact]
+    public void Eval_Pow_ZeroBaseZeroExponent_ReturnsOne()
+    {
+        var fire = FireForSet(
+            "field X as integer default 0\nfield Output as integer default 0",
+            "Output", "pow(X, 0)",
+            new Dictionary<string, object?> { ["X"] = 0L, ["Output"] = 0L });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(1L);
+    }
+
+    // ─── Evaluation: sqrt ───────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Sqrt_ReturnsSquareRoot()
+    {
+        var fire = FireForSet(
+            "field Input as number nonnegative default 0\nfield Output as number default 0",
+            "Output", "sqrt(Input)",
+            new Dictionary<string, object?> { ["Input"] = 9.0, ["Output"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3.0);
+    }
+
+    // ─── Parse verification ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData("abs(X)")]
+    [InlineData("floor(X)")]
+    [InlineData("ceil(X)")]
+    [InlineData("round(X)")]
+    [InlineData("round(X, 2)")]
+    [InlineData("truncate(X)")]
+    [InlineData("min(X, 5)")]
+    [InlineData("max(X, 5)")]
+    [InlineData("clamp(X, 0, 10)")]
+    [InlineData("pow(X, 2)")]
+    public void Parse_NumericFunction_InGuard_Succeeds(string expr)
+    {
+        var dsl = $"precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when {expr} >= 0 -> transition B\n";
+        var model = PreceptParser.Parse(dsl);
+        model.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Parse_Min_DisambiguatesFromConstraintKeyword()
+    {
+        var dsl = "precept Test\nfield X as number min 0 default 5\nstate A initial\nstate B\nevent Go\nfrom A on Go when min(X, 3) > 0 -> transition B\n";
+        var model = PreceptParser.Parse(dsl);
+        model.Should().NotBeNull();
+    }
+
+    // ─── Type checker diagnostics ───────────────────────────────────
+
+    [Fact]
+    public void TypeChecker_C72_WrongArity_Abs()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(X, X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C72");
+    }
+
+    [Fact]
+    public void TypeChecker_C74_RoundPrecisionNotLiteral()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when round(X, X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C74");
+    }
+
+    [Fact]
+    public void TypeChecker_C75_PowExponentNotInteger()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when pow(X, X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C75");
+    }
+
+    [Fact]
+    public void TypeChecker_C76_SqrtWithoutProof()
+    {
+        var dsl = "precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when sqrt(X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C76");
+    }
+
+    [Fact]
+    public void TypeChecker_C76_SqrtWithNonneg_NoDiagnostic()
+    {
+        var dsl = "precept Test\nfield X as number nonnegative default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go when sqrt(X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Where(d => d.Constraint.Id == "C76").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeChecker_C77_NullableArg()
+    {
+        var dsl = "precept Test\nfield X as number nullable default null\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(X) > 0 -> no transition\n";
+        var model = PreceptParser.Parse(dsl);
+        var validation = PreceptCompiler.Validate(model);
+        validation.Diagnostics.Should().Contain(d => d.Constraint.Id == "C77");
+    }
+
+    // ─── Evaluation: toLower ────────────────────────────────────────
+
+    [Fact]
+    public void Eval_ToLower_MixedCase_ReturnsLowerCase()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "toLower(Input)",
+            new Dictionary<string, object?> { ["Input"] = "Hello", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("hello");
+    }
+
+    [Fact]
+    public void Eval_ToLower_AllUpperCase_ReturnsLowerCase()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "toLower(Input)",
+            new Dictionary<string, object?> { ["Input"] = "WORLD", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("world");
+    }
+
+    [Fact]
+    public void Eval_ToLower_EmptyString_ReturnsEmpty()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "toLower(Input)",
+            new Dictionary<string, object?> { ["Input"] = "", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("");
+    }
+
+    // ─── Evaluation: toUpper ────────────────────────────────────────
+
+    [Fact]
+    public void Eval_ToUpper_LowerCase_ReturnsUpperCase()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "toUpper(Input)",
+            new Dictionary<string, object?> { ["Input"] = "hello", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("HELLO");
+    }
+
+    [Fact]
+    public void Eval_ToUpper_EmptyString_ReturnsEmpty()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "toUpper(Input)",
+            new Dictionary<string, object?> { ["Input"] = "", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("");
+    }
+
+    // ─── Evaluation: trim ───────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Trim_LeadingAndTrailingWhitespace_ReturnsTrimmed()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "trim(Input)",
+            new Dictionary<string, object?> { ["Input"] = "  hello  ", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("hello");
+    }
+
+    [Fact]
+    public void Eval_Trim_NoWhitespace_ReturnsSameValue()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "trim(Input)",
+            new Dictionary<string, object?> { ["Input"] = "no_spaces", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("no_spaces");
+    }
+
+    // ─── Evaluation: startsWith ─────────────────────────────────────
+
+    [Fact]
+    public void Eval_StartsWith_MatchingPrefix_AllowsTransition()
+    {
+        var fire = FireForGuard(
+            "field Name as string default \"\"",
+            "startsWith(Name, \"Hello\")",
+            new Dictionary<string, object?> { ["Name"] = "Hello World" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+    }
+
+    [Fact]
+    public void Eval_StartsWith_NonMatchingPrefix_NoTransition()
+    {
+        var fire = FireForGuard(
+            "field Name as string default \"\"",
+            "startsWith(Name, \"World\")",
+            new Dictionary<string, object?> { ["Name"] = "Hello" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.NoTransition);
+    }
+
+    [Fact]
+    public void Eval_StartsWith_CaseSensitive_NoTransition()
+    {
+        var fire = FireForGuard(
+            "field Name as string default \"\"",
+            "startsWith(Name, \"hello\")",
+            new Dictionary<string, object?> { ["Name"] = "Hello" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.NoTransition);
+    }
+
+    // ─── Evaluation: endsWith ───────────────────────────────────────
+
+    [Fact]
+    public void Eval_EndsWith_MatchingSuffix_AllowsTransition()
+    {
+        var fire = FireForGuard(
+            "field Name as string default \"\"",
+            "endsWith(Name, \"World\")",
+            new Dictionary<string, object?> { ["Name"] = "Hello World" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+    }
+
+    [Fact]
+    public void Eval_EndsWith_NonMatchingSuffix_NoTransition()
+    {
+        var fire = FireForGuard(
+            "field Name as string default \"\"",
+            "endsWith(Name, \"World\")",
+            new Dictionary<string, object?> { ["Name"] = "Hello" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.NoTransition);
+    }
+
+    // ─── Evaluation: left ───────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Left_NormalLength_ReturnsPrefix()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "left(Input, 5)",
+            new Dictionary<string, object?> { ["Input"] = "Hello World", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Eval_Left_CountExceedsLength_ClampsToFullString()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "left(Input, 10)",
+            new Dictionary<string, object?> { ["Input"] = "Hi", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("Hi");
+    }
+
+    [Fact]
+    public void Eval_Left_ZeroCount_ReturnsEmpty()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "left(Input, 0)",
+            new Dictionary<string, object?> { ["Input"] = "Hello", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("");
+    }
+
+    // ─── Evaluation: right ──────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Right_NormalLength_ReturnsSuffix()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "right(Input, 5)",
+            new Dictionary<string, object?> { ["Input"] = "Hello World", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("World");
+    }
+
+    [Fact]
+    public void Eval_Right_CountExceedsLength_ClampsToFullString()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "right(Input, 10)",
+            new Dictionary<string, object?> { ["Input"] = "Hi", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("Hi");
+    }
+
+    // ─── Evaluation: mid ────────────────────────────────────────────
+
+    [Fact]
+    public void Eval_Mid_NormalRange_ReturnsSubstring()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "mid(Input, 7, 5)",
+            new Dictionary<string, object?> { ["Input"] = "Hello World", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("World");
+    }
+
+    [Fact]
+    public void Eval_Mid_FromStart_ReturnsPrefix()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "mid(Input, 1, 3)",
+            new Dictionary<string, object?> { ["Input"] = "Hello", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("Hel");
+    }
+
+    [Fact]
+    public void Eval_Mid_LengthExceedsRemaining_ClampsToEnd()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "mid(Input, 1, 10)",
+            new Dictionary<string, object?> { ["Input"] = "Hi", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("Hi");
+    }
+
+    [Fact]
+    public void Eval_Mid_StartBeyondLength_ReturnsEmpty()
+    {
+        var fire = FireForSet(
+            "field Input as string default \"\"\nfield Output as string default \"\"",
+            "Output", "mid(Input, 10, 3)",
+            new Dictionary<string, object?> { ["Input"] = "Hello", ["Output"] = "" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be("");
+    }
+
+    // ─── Parse verification: string functions ───────────────────────
+
+    [Theory]
+    [InlineData("toLower(Name)")]
+    [InlineData("toUpper(Name)")]
+    [InlineData("trim(Name)")]
+    [InlineData("startsWith(Name, \"prefix\")")]
+    [InlineData("endsWith(Name, \"suffix\")")]
+    [InlineData("left(Name, 3)")]
+    [InlineData("right(Name, 3)")]
+    [InlineData("mid(Name, 1, 5)")]
+    public void Parse_StringFunction_InExpression_Succeeds(string expr)
+    {
+        var dsl = $"precept Test\nfield Name as string default \"test\"\nfield Output as string default \"\"\nstate A initial\nstate B\nevent Go\n";
+        if (expr.StartsWith("startsWith") || expr.StartsWith("endsWith"))
+            dsl += $"from A on Go when {expr} -> transition B\n";
+        else
+            dsl += $"from A on Go -> set Output = {expr} -> transition B\n";
+        var model = PreceptParser.Parse(dsl);
+        model.Should().NotBeNull();
+    }
+
+    // ─── Integration tests ──────────────────────────────────────────
+
+    [Fact]
+    public void Integration_StringFunctions_ToLowerInGuard()
+    {
+        var fire = FireForGuard(
+            "field Email as string default \"\"",
+            "toLower(Email) == \"test@example.com\"",
+            new Dictionary<string, object?> { ["Email"] = "TEST@EXAMPLE.COM" });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+    }
+
+    [Fact]
+    public void Integration_NumericFunctions_AbsInGuard()
+    {
+        var dsl = $$"""
+            precept Calc
+            field Amount as number default 0
+            field AbsAmount as number default 0
+            state Active initial
+            state Done
+            event Process
+            from Active on Process when abs(Amount) > 10 -> set AbsAmount = abs(Amount) -> transition Done
+            from Active on Process -> no transition
+            """;
+        var workflow = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var instance = workflow.CreateInstance("Active",
+            new Dictionary<string, object?> { ["Amount"] = -15.0, ["AbsAmount"] = 0.0 });
+        var result = workflow.Fire(instance, "Process");
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["AbsAmount"].Should().Be(15.0);
+    }
+
+    [Fact]
+    public void Integration_ClampInSetExpression()
+    {
+        var fire = FireForSet(
+            "field Score as number default 0\nfield BoundedScore as number default 0",
+            "BoundedScore", "clamp(Score, 0.0, 100.0)",
+            new Dictionary<string, object?> { ["Score"] = 150.0, ["BoundedScore"] = 0.0 });
+
+        fire.Outcome.Should().Be(TransitionOutcome.Transition);
+        fire.UpdatedInstance!.InstanceData["BoundedScore"].Should().Be(100.0);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────
+
+    private static string BuildDslForSet(string declarations, string targetField, string expression)
+    {
+        return $$"""
+            precept Calc
+            {{declarations}}
+            state A initial
+            state B
+            event Go
+            from A on Go -> set {{targetField}} = {{expression}} -> transition B
+            """;
+    }
+
+    private static FireResult FireForSet(
+        string declarations,
+        string targetField,
+        string expression,
+        IReadOnlyDictionary<string, object?> instanceData)
+    {
+        var dsl = BuildDslForSet(declarations, targetField, expression);
+        var workflow = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var instance = workflow.CreateInstance("A", instanceData);
+        return workflow.Fire(instance, "Go");
+    }
+
+    private static FireResult FireForGuard(
+        string declarations,
+        string guardExpression,
+        IReadOnlyDictionary<string, object?> instanceData)
+    {
+        var dsl = $$"""
+            precept Calc
+            {{declarations}}
+            state A initial
+            state B
+            event Go
+            from A on Go when {{guardExpression}} -> transition B
+            from A on Go -> no transition
+            """;
+        var workflow = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var instance = workflow.CreateInstance("A", instanceData);
+        return workflow.Fire(instance, "Go");
+    }
+}

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -1125,7 +1125,7 @@ internal sealed class PreceptAnalyzer
         FunctionSnippetItem("startsWith(str, prefix)", "startsWith(${1:str}, ${2:prefix})", "Check if string starts with prefix"),
         FunctionSnippetItem("endsWith(str, suffix)", "endsWith(${1:str}, ${2:suffix})", "Check if string ends with suffix"),
         FunctionSnippetItem("trim(expr)", "trim(${1:expr})", "Remove leading/trailing whitespace"),
-        FunctionSnippetItem("left(str, count)", "left(${1:str}, ${2:count})", "First N characters (1-indexed)"),
+        FunctionSnippetItem("left(str, count)", "left(${1:str}, ${2:count})", "First N characters (clamping)"),
         FunctionSnippetItem("right(str, count)", "right(${1:str}, ${2:count})", "Last N characters"),
         FunctionSnippetItem("mid(str, start, count)", "mid(${1:str}, ${2:start}, ${3:count})", "Substring from position (1-indexed)")
     ];

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -1107,7 +1107,27 @@ internal sealed class PreceptAnalyzer
         new CompletionItem { Label = "or", Kind = CompletionItemKind.Keyword },
         new CompletionItem { Label = "not", Kind = CompletionItemKind.Keyword },
         new CompletionItem { Label = "contains", Kind = CompletionItemKind.Operator },
-        SnippetItem("round(expr, N)", "round(${1:expr}, ${2:2})", "Round a decimal value to N places")
+        // Numeric functions
+        FunctionSnippetItem("abs(expr)", "abs(${1:expr})", "Absolute value"),
+        FunctionSnippetItem("floor(expr)", "floor(${1:expr})", "Round down to nearest integer"),
+        FunctionSnippetItem("ceil(expr)", "ceil(${1:expr})", "Round up to nearest integer"),
+        FunctionSnippetItem("round(expr)", "round(${1:expr})", "Round to nearest integer"),
+        FunctionSnippetItem("round(expr, N)", "round(${1:expr}, ${2:2})", "Round a decimal value to N places"),
+        FunctionSnippetItem("truncate(expr)", "truncate(${1:expr})", "Truncate toward zero"),
+        FunctionSnippetItem("min(a, b)", "min(${1:a}, ${2:b})", "Minimum of two or more values"),
+        FunctionSnippetItem("max(a, b)", "max(${1:a}, ${2:b})", "Maximum of two or more values"),
+        FunctionSnippetItem("pow(base, exp)", "pow(${1:base}, ${2:exp})", "Raise to integer power"),
+        FunctionSnippetItem("sqrt(expr)", "sqrt(${1:expr})", "Square root (requires non-negative)"),
+        FunctionSnippetItem("clamp(value, lo, hi)", "clamp(${1:value}, ${2:lo}, ${3:hi})", "Clamp value to range [lo, hi]"),
+        // String functions
+        FunctionSnippetItem("toLower(expr)", "toLower(${1:expr})", "Convert string to lowercase"),
+        FunctionSnippetItem("toUpper(expr)", "toUpper(${1:expr})", "Convert string to uppercase"),
+        FunctionSnippetItem("startsWith(str, prefix)", "startsWith(${1:str}, ${2:prefix})", "Check if string starts with prefix"),
+        FunctionSnippetItem("endsWith(str, suffix)", "endsWith(${1:str}, ${2:suffix})", "Check if string ends with suffix"),
+        FunctionSnippetItem("trim(expr)", "trim(${1:expr})", "Remove leading/trailing whitespace"),
+        FunctionSnippetItem("left(str, count)", "left(${1:str}, ${2:count})", "First N characters (1-indexed)"),
+        FunctionSnippetItem("right(str, count)", "right(${1:str}, ${2:count})", "Last N characters"),
+        FunctionSnippetItem("mid(str, start, count)", "mid(${1:str}, ${2:start}, ${3:count})", "Substring from position (1-indexed)")
     ];
 
     internal static readonly IReadOnlyList<CompletionItem> LiteralItems =
@@ -1376,6 +1396,16 @@ internal sealed class PreceptAnalyzer
         {
             Label = label,
             Kind = CompletionItemKind.Snippet,
+            InsertText = snippet,
+            InsertTextFormat = InsertTextFormat.Snippet,
+            Detail = detail
+        };
+
+    private static CompletionItem FunctionSnippetItem(string label, string snippet, string detail)
+        => new()
+        {
+            Label = label,
+            Kind = CompletionItemKind.Function,
             InsertText = snippet,
             InsertTextFormat = InsertTextFormat.Snippet,
             Detail = detail

--- a/tools/Precept.LanguageServer/PreceptDocumentIntellisense.cs
+++ b/tools/Precept.LanguageServer/PreceptDocumentIntellisense.cs
@@ -29,6 +29,29 @@ internal static class PreceptDocumentIntellisense
     private static readonly Regex EventAssertRegex = new("^\\s*on\\s+(?<event>[A-Za-z_][A-Za-z0-9_]*)\\s+assert\\s+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex TransitionOutcomeRegex = new("\\btransition\\s+(?<state>[A-Za-z_][A-Za-z0-9_]*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    /// <summary>Hover content for built-in function names, keyed by function name.</summary>
+    private static readonly Dictionary<string, string> FunctionHoverContent = new(StringComparer.Ordinal)
+    {
+        ["abs"] = "```precept\nabs(value)\n```\n\nAbsolute value. Returns the non-negative magnitude.\n\nExample: `abs(-5)` → `5`",
+        ["floor"] = "```precept\nfloor(value)\n```\n\nRound down to the nearest integer.\n\nExample: `floor(3.7)` → `3`",
+        ["ceil"] = "```precept\nceil(value)\n```\n\nRound up to the nearest integer.\n\nExample: `ceil(3.2)` → `4`",
+        ["round"] = "```precept\nround(value)\nround(value, places)\n```\n\nRound to nearest integer (1-arg) or to N decimal places (2-arg).\n\nExample: `round(3.456, 2)` → `3.46`",
+        ["truncate"] = "```precept\ntruncate(value)\n```\n\nTruncate toward zero, removing the fractional part.\n\nExample: `truncate(3.9)` → `3`",
+        ["min"] = "```precept\nmin(a, b, ...)\n```\n\nMinimum of two or more values.\n\nExample: `min(Price, Limit)` → the smaller value",
+        ["max"] = "```precept\nmax(a, b, ...)\n```\n\nMaximum of two or more values.\n\nExample: `max(Score, Threshold)` → the larger value",
+        ["pow"] = "```precept\npow(base, exponent)\n```\n\nRaise to an integer power.\n\nExample: `pow(2, 3)` → `8`",
+        ["sqrt"] = "```precept\nsqrt(value)\n```\n\nSquare root. Requires non-negative argument (compile-time proof).\n\nExample: `sqrt(16)` → `4`",
+        ["clamp"] = "```precept\nclamp(value, lo, hi)\n```\n\nClamp value to range [lo, hi].\n\nExample: `clamp(Score, 0, 100)` → value bounded to 0–100",
+        ["toLower"] = "```precept\ntoLower(str)\n```\n\nConvert string to lowercase.\n\nExample: `toLower(Email)` → `\"user@example.com\"`",
+        ["toUpper"] = "```precept\ntoUpper(str)\n```\n\nConvert string to uppercase.\n\nExample: `toUpper(Code)` → `\"ABC\"`",
+        ["startsWith"] = "```precept\nstartsWith(str, prefix)\n```\n\nCheck if string starts with prefix. Returns boolean.\n\nExample: `startsWith(Email, \"admin@\")`",
+        ["endsWith"] = "```precept\nendsWith(str, suffix)\n```\n\nCheck if string ends with suffix. Returns boolean.\n\nExample: `endsWith(File, \".pdf\")`",
+        ["trim"] = "```precept\ntrim(str)\n```\n\nRemove leading and trailing whitespace.\n\nExample: `trim(Name)` → `\"Alice\"`",
+        ["left"] = "```precept\nleft(str, count)\n```\n\nFirst N characters (1-indexed, clamping).\n\nExample: `left(Code, 3)` → `\"ABC\"` from `\"ABCDEF\"`",
+        ["right"] = "```precept\nright(str, count)\n```\n\nLast N characters (clamping).\n\nExample: `right(Code, 3)` → `\"DEF\"` from `\"ABCDEF\"`",
+        ["mid"] = "```precept\nmid(str, start, count)\n```\n\nSubstring from position (1-indexed, clamping).\n\nExample: `mid(Code, 2, 3)` → `\"BCD\"` from `\"ABCDEF\"`",
+    };
+
     internal static PreceptDocumentInfo Analyze(string text)
     {
         var lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
@@ -169,6 +192,27 @@ internal static class PreceptDocumentIntellisense
                 }),
                 Range = CreateRange((int)position.Line, start, end)
             };
+        }
+
+        // Check if the word is a built-in function name followed by (
+        if (FunctionHoverContent.TryGetValue(word, out var functionHover))
+        {
+            // Verify it's actually a function call (followed by '(' on the line)
+            var afterEnd = end;
+            while (afterEnd < line.Length && char.IsWhiteSpace(line[afterEnd]))
+                afterEnd++;
+            if (afterEnd < line.Length && line[afterEnd] == '(')
+            {
+                return new Hover
+                {
+                    Contents = new MarkedStringsOrMarkupContent(new MarkupContent
+                    {
+                        Kind = MarkupKind.Markdown,
+                        Value = functionHover
+                    }),
+                    Range = CreateRange((int)position.Line, start, end)
+                };
+            }
         }
 
         // Fall back to token keyword description (Tier 1)

--- a/tools/Precept.Mcp/Tools/LanguageTool.cs
+++ b/tools/Precept.Mcp/Tools/LanguageTool.cs
@@ -19,8 +19,9 @@ public static class LanguageTool
         var constraints = DiagnosticCatalog.Constraints
             .Select(c => new ConstraintDto(c.Id, c.Phase, c.Rule))
             .ToList();
+        var functions = BuildFunctionCatalog();
 
-        return new LanguageResult(vocabulary, constructs, constraints, ExpressionScopes, FirePipeline, OutcomeKinds);
+        return new LanguageResult(vocabulary, constructs, constraints, ExpressionScopes, functions, FirePipeline, OutcomeKinds);
     }
 
     private static VocabularyDto BuildVocabulary()
@@ -91,6 +92,47 @@ public static class LanguageTool
                     operators);
     }
 
+    private static IReadOnlyList<FunctionDto> BuildFunctionCatalog()
+    {
+        return FunctionRegistry.AllFunctions
+            .OrderBy(f => f.Name, StringComparer.Ordinal)
+            .Select(f => new FunctionDto(
+                f.Name,
+                f.Description,
+                f.Overloads.Select(o => new FunctionSignatureDto(
+                    o.Parameters.Select(p => new FunctionParamDto(
+                        p.Name,
+                        FormatValueKind(p.AcceptedTypes),
+                        FormatArgConstraint(p.Constraint)
+                    )).ToList(),
+                    FormatValueKind(o.ReturnType),
+                    o.MinArity.HasValue
+                )).ToList()
+            ))
+            .ToList();
+    }
+
+    private static string FormatValueKind(StaticValueKind kind)
+    {
+        var allNumeric = StaticValueKind.Number | StaticValueKind.Integer | StaticValueKind.Decimal;
+        if ((kind & allNumeric) == allNumeric)
+            return "number";
+
+        var parts = new List<string>();
+        if (kind.HasFlag(StaticValueKind.Number)) parts.Add("number");
+        if (kind.HasFlag(StaticValueKind.Integer)) parts.Add("integer");
+        if (kind.HasFlag(StaticValueKind.Decimal)) parts.Add("decimal");
+        if (kind.HasFlag(StaticValueKind.String)) parts.Add("string");
+        if (kind.HasFlag(StaticValueKind.Boolean)) parts.Add("boolean");
+        return parts.Count > 0 ? string.Join(" | ", parts) : "unknown";
+    }
+
+    private static string? FormatArgConstraint(FunctionArgConstraint constraint) => constraint switch
+    {
+        FunctionArgConstraint.MustBeIntegerLiteral => "must be integer literal",
+        _ => null
+    };
+
     private static (int Precedence, string Arity) GetOperatorInfo(PreceptToken token) => token switch
     {
         PreceptToken.Or => (1, "binary"),
@@ -147,6 +189,7 @@ public sealed record LanguageResult(
     IReadOnlyList<ConstructDto> Constructs,
     IReadOnlyList<ConstraintDto> Constraints,
     IReadOnlyList<ExpressionScopeDto> ExpressionScopes,
+    IReadOnlyList<FunctionDto> Functions,
     IReadOnlyList<FirePipelineStageDto> FirePipeline,
     IReadOnlyList<OutcomeKindDto> OutcomeKinds);
 
@@ -165,5 +208,8 @@ public sealed record OperatorDto(string Symbol, int Precedence, string Arity, st
 public sealed record ConstructDto(string Form, string Context, string Description, string Example);
 public sealed record ConstraintDto(string Id, string Phase, string Rule);
 public sealed record ExpressionScopeDto(string Position, string Allowed);
+public sealed record FunctionDto(string Name, string Description, IReadOnlyList<FunctionSignatureDto> Signatures);
+public sealed record FunctionSignatureDto(IReadOnlyList<FunctionParamDto> Parameters, string ReturnType, bool IsVariadic);
+public sealed record FunctionParamDto(string Name, string Type, string? Constraint);
 public sealed record FirePipelineStageDto(int Stage, string Name, string Description);
 public sealed record OutcomeKindDto(string Kind, string Description, bool Mutated);

--- a/tools/Precept.Mcp/Tools/LanguageTool.cs
+++ b/tools/Precept.Mcp/Tools/LanguageTool.cs
@@ -130,6 +130,7 @@ public static class LanguageTool
     private static string? FormatArgConstraint(FunctionArgConstraint constraint) => constraint switch
     {
         FunctionArgConstraint.MustBeIntegerLiteral => "must be integer literal",
+        FunctionArgConstraint.RequiresNonNegativeProof => "requires non-negative proof",
         _ => null
     };
 

--- a/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
+++ b/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
@@ -20,6 +20,7 @@
     { "include": "#collectionMemberAccess" },
     { "include": "#stringMemberAccess" },
     { "include": "#rootEditDeclaration" },
+    { "include": "#functionCall" },
     { "include": "#controlKeywords" },
     { "include": "#declarationKeywords" },
     { "include": "#grammarKeywords" },
@@ -382,6 +383,18 @@
             "1": { "name": "variable.other.field.precept" },
             "2": { "name": "punctuation.accessor.precept" },
             "3": { "name": "variable.other.property.precept" }
+          }
+        }
+      ]
+    },
+
+    "functionCall": {
+      "comment": "Built-in function calls: function name followed by ( — must precede constraintKeywords so min(/max( match as functions, not constraints",
+      "patterns": [
+        {
+          "match": "\\b(abs|floor|ceil|round|truncate|min|max|pow|sqrt|clamp|toLower|toUpper|startsWith|endsWith|trim|left|right|mid)(?=\\s*\\()",
+          "captures": {
+            "1": { "name": "support.function.precept" }
           }
         }
       ]

--- a/tools/scripts/squad-review.js
+++ b/tools/scripts/squad-review.js
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+// squad-review.js — Post GitHub PR reviews as squad-reviewer[bot]
+//
+// Usage (initial review — inline comments on specific files/lines):
+//   node tools/scripts/squad-review.js <pr-number> <review-file.json>
+//   JSON: { "event": "REQUEST_CHANGES", "body": "...", "comments": [...] }
+//
+// Usage (reply — respond to existing threads, optionally resolve):
+//   node tools/scripts/squad-review.js <pr-number> <reply-file.json>
+//   JSON: { "event"?: "APPROVE", "body"?: "...", "replies": [...] }
+//
+// Usage (list threads — show existing review threads for mapping):
+//   node tools/scripts/squad-review.js <pr-number> threads [--unresolved]
+//
+// Usage (simple — markdown body only, legacy):
+//   node tools/scripts/squad-review.js <pr-number> <event> <body-file.md>
+//
+// Review JSON (initial review with inline comments):
+//   {
+//     "event": "REQUEST_CHANGES",
+//     "body": "## Overall review summary...",
+//     "comments": [
+//       { "path": "src/File.cs", "line": 42, "body": "**B1:** ..." }
+//     ]
+//   }
+//
+// Reply JSON (respond to existing threads):
+//   {
+//     "event": "APPROVE",              // optional — submit a review alongside replies
+//     "body": "## Re-review summary",  // optional — review body
+//     "replies": [
+//       { "commentId": 123456, "body": "Fixed in commit abc123.", "resolve": true }
+//     ]
+//   }
+//
+//   event/body are optional in reply mode. If present, a review is submitted.
+//   If only replies are present, just the replies are posted (no review event).
+//   resolve: true resolves the thread after replying (reviewer use only).
+//
+// Environment variables (optional overrides):
+//   SQUAD_REVIEWER_APP_ID          — GitHub App ID (default: from config)
+//   SQUAD_REVIEWER_INSTALLATION_ID — Installation ID (default: from config)
+//   SQUAD_REVIEWER_PEM_PATH        — Path to .pem file (default: ~/.squad-reviewer/private-key.pem)
+//   SQUAD_REVIEWER_OWNER           — Repo owner (default: sfalik)
+//   SQUAD_REVIEWER_REPO            — Repo name (default: Precept)
+
+import { createSign } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+// --- Config (override via env vars) ---
+const APP_ID = process.env.SQUAD_REVIEWER_APP_ID || "3355906";
+const INSTALLATION_ID = process.env.SQUAD_REVIEWER_INSTALLATION_ID || "123390393";
+const PEM_PATH = process.env.SQUAD_REVIEWER_PEM_PATH || resolve(homedir(), ".squad-reviewer", "private-key.pem");
+const OWNER = process.env.SQUAD_REVIEWER_OWNER || "sfalik";
+const REPO = process.env.SQUAD_REVIEWER_REPO || "Precept";
+
+// --- CLI args ---
+const args = process.argv.slice(2);
+
+let prNumber, reviewEvent, reviewBody, reviewComments, reviewReplies;
+let mode = "review"; // "review" | "threads" | "reply"
+
+if (args.length >= 2 && args[1] === "threads") {
+  // Threads mode: <pr-number> threads [--unresolved]
+  mode = "threads";
+  prNumber = args[0];
+  const unresolvedOnly = args.includes("--unresolved");
+
+  // Executed in main block below
+  var threadsUnresolvedOnly = unresolvedOnly;
+} else if (args.length === 2) {
+  // Structured mode: <pr-number> <file.json>
+  prNumber = args[0];
+  const filePath = args[1];
+  const content = readFileSync(resolve(filePath), "utf8");
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    console.error("Structured mode requires a valid JSON file. Got parse error.");
+    console.error("Usage: node squad-review.js <pr-number> <review-file.json>");
+    process.exit(1);
+  }
+
+  if (parsed.replies) {
+    // Reply mode — respond to existing threads, optionally with new comments
+    mode = "reply";
+    reviewReplies = parsed.replies;
+    reviewEvent = parsed.event?.toUpperCase() || null;
+    reviewBody = parsed.body || null;
+    reviewComments = parsed.comments || [];
+
+    // Validate replies
+    for (const [i, r] of reviewReplies.entries()) {
+      if (!r.commentId || !r.body) {
+        console.error(`Reply [${i}] missing required field (commentId, body).`);
+        process.exit(1);
+      }
+      if (typeof r.commentId !== "number" || r.commentId < 1) {
+        console.error(`Reply [${i}] commentId must be a positive integer. Got: ${r.commentId}`);
+        process.exit(1);
+      }
+    }
+
+    // Validate new comments (if any)
+    for (const [i, c] of reviewComments.entries()) {
+      if (!c.path || !c.line || !c.body) {
+        console.error(`Comment [${i}] missing required field (path, line, body).`);
+        process.exit(1);
+      }
+      if (typeof c.line !== "number" || c.line < 1) {
+        console.error(`Comment [${i}] line must be a positive integer. Got: ${c.line}`);
+        process.exit(1);
+      }
+    }
+  } else {
+    // Review mode — initial review with inline comments
+    if (!parsed.event || !parsed.body) {
+      console.error('JSON must contain "event" and "body" fields (for review) or "replies" array (for reply).');
+      process.exit(1);
+    }
+
+    reviewEvent = parsed.event.toUpperCase();
+    reviewBody = parsed.body;
+    reviewComments = parsed.comments || [];
+
+    // Validate comments
+    for (const [i, c] of reviewComments.entries()) {
+      if (!c.path || !c.line || !c.body) {
+        console.error(`Comment [${i}] missing required field (path, line, body).`);
+        process.exit(1);
+      }
+      if (typeof c.line !== "number" || c.line < 1) {
+        console.error(`Comment [${i}] line must be a positive integer. Got: ${c.line}`);
+        process.exit(1);
+      }
+    }
+  }
+} else if (args.length === 3) {
+  // Simple mode: <pr-number> <event> <body-file>
+  prNumber = args[0];
+  reviewEvent = args[1].toUpperCase();
+  reviewBody = readFileSync(resolve(args[2]), "utf8");
+  reviewComments = [];
+} else {
+  console.error("Usage:");
+  console.error("  Review:     node squad-review.js <pr-number> <review-file.json>");
+  console.error("  Reply:      node squad-review.js <pr-number> <reply-file.json>");
+  console.error("  Threads:    node squad-review.js <pr-number> threads [--unresolved]");
+  console.error("  Simple:     node squad-review.js <pr-number> <event> <body-file>");
+  process.exit(1);
+}
+
+const validEvents = ["APPROVE", "REQUEST_CHANGES", "COMMENT"];
+if (mode === "review" && !validEvents.includes(reviewEvent)) {
+  console.error(`Invalid event: ${reviewEvent}. Must be one of: ${validEvents.join(", ")}`);
+  process.exit(1);
+}
+if (mode === "reply" && reviewEvent && !validEvents.includes(reviewEvent)) {
+  console.error(`Invalid event: ${reviewEvent}. Must be one of: ${validEvents.join(", ")}`);
+  process.exit(1);
+}
+
+// --- JWT generation (RS256, no external deps) ---
+function base64url(buffer) {
+  return Buffer.from(buffer).toString("base64url");
+}
+
+function createJWT(appId, pemPath) {
+  const privateKey = readFileSync(pemPath, "utf8");
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64url(JSON.stringify({
+    iat: now - 30,        // issued 30s ago (clock skew)
+    exp: now + 5 * 60,    // expires in 5 minutes
+    iss: appId,
+  }));
+
+  const signable = `${header}.${payload}`;
+  const sign = createSign("RSA-SHA256");
+  sign.update(signable);
+  sign.end();
+  const signature = sign.sign(privateKey, "base64url");
+
+  return `${signable}.${signature}`;
+}
+
+// --- GitHub API helpers ---
+async function getInstallationToken(jwt, installationId) {
+  const res = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to get installation token (${res.status}): ${text}`);
+  }
+
+  const data = await res.json();
+  return data.token;
+}
+
+async function submitReview(token, owner, repo, pr, event, body, comments) {
+  const payload = {
+    event: event,
+    body: body,
+  };
+
+  if (comments && comments.length > 0) {
+    payload.comments = comments.map((c) => ({
+      path: c.path,
+      line: c.line,
+      side: "RIGHT",
+      body: c.body,
+    }));
+  }
+
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${pr}/reviews`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to submit review (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+async function replyToComment(token, owner, repo, pr, commentId, body) {
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to reply to comment ${commentId} (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+async function listReviewThreads(token, owner, repo, pr) {
+  const query = `
+    query($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              isResolved
+              comments(first: 1) {
+                nodes {
+                  databaseId
+                  path
+                  originalLine
+                  body
+                  author { login }
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query,
+      variables: { owner, repo, pr: parseInt(pr, 10) },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to list review threads (${res.status}): ${text}`);
+  }
+
+  const data = await res.json();
+  if (data.errors) {
+    throw new Error(`GraphQL errors: ${JSON.stringify(data.errors)}`);
+  }
+
+  const threads = data.data.repository.pullRequest.reviewThreads.nodes;
+  return threads.map((t) => {
+    const c = t.comments.nodes[0];
+    return {
+      threadId: t.id,
+      commentId: c.databaseId,
+      path: c.path,
+      line: c.originalLine,
+      body: c.body,
+      author: c.author?.login || "unknown",
+      createdAt: c.createdAt,
+      isResolved: t.isResolved,
+    };
+  });
+}
+
+async function resolveThread(token, threadId) {
+  const query = `
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread { isResolved }
+      }
+    }
+  `;
+
+  // Try via app token first
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables: { threadId } }),
+  });
+
+  if (res.ok) {
+    const data = await res.json();
+    if (!data.errors) {
+      return data.data.resolveReviewThread.thread.isResolved;
+    }
+    // FORBIDDEN — fall through to gh CLI fallback
+  }
+
+  // Fallback: use gh CLI (user's own auth can resolve threads)
+  try {
+    const ghQuery = `mutation { resolveReviewThread(input: {threadId: "${threadId}"}) { thread { isResolved } } }`;
+    const tmpFile = resolve(tmpdir(), `squad-resolve-${Date.now()}.graphql`);
+    writeFileSync(tmpFile, ghQuery, "utf8");
+    const proc = spawnSync("gh", ["api", "graphql", "-F", `query=@${tmpFile}`], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (proc.status !== 0) {
+      throw new Error(proc.stderr || "gh CLI failed");
+    }
+    const data = JSON.parse(proc.stdout);
+    return data.data.resolveReviewThread.thread.isResolved;
+  } catch (ghErr) {
+    throw new Error(`Failed to resolve thread ${threadId} — both app token and gh CLI failed. ${ghErr.message}`);
+  }
+}
+
+// --- Main ---
+try {
+  console.log(`Generating JWT for App ID ${APP_ID}...`);
+  const jwt = createJWT(APP_ID, PEM_PATH);
+
+  console.log(`Getting installation token for installation ${INSTALLATION_ID}...`);
+  const token = await getInstallationToken(jwt, INSTALLATION_ID);
+
+  if (mode === "threads") {
+    // --- Threads mode: list review threads ---
+    console.log(`Listing review threads on ${OWNER}/${REPO}#${prNumber}...`);
+    let threads = await listReviewThreads(token, OWNER, REPO, prNumber);
+
+    if (threadsUnresolvedOnly) {
+      threads = threads.filter((t) => !t.isResolved);
+    }
+
+    // Output as JSON for consumption by the coordinator
+    console.log(JSON.stringify(threads, null, 2));
+    console.log(`\n${threads.length} thread(s) found.`);
+
+  } else if (mode === "reply") {
+    // --- Reply mode: respond to existing threads, optionally resolve ---
+    const needsResolve = reviewReplies.some((r) => r.resolve);
+    let threadMap = null;
+
+    if (needsResolve) {
+      // Build commentId → threadId mapping for resolving
+      console.log(`Fetching thread metadata for resolve...`);
+      const threads = await listReviewThreads(token, OWNER, REPO, prNumber);
+      threadMap = new Map(threads.map((t) => [t.commentId, t.threadId]));
+    }
+
+    // Post replies
+    let replyCount = 0;
+    let resolveCount = 0;
+
+    for (const reply of reviewReplies) {
+      console.log(`Replying to comment ${reply.commentId}...`);
+      await replyToComment(token, OWNER, REPO, prNumber, reply.commentId, reply.body);
+      replyCount++;
+
+      if (reply.resolve && threadMap) {
+        const threadId = threadMap.get(reply.commentId);
+        if (threadId) {
+          console.log(`Resolving thread for comment ${reply.commentId}...`);
+          await resolveThread(token, threadId);
+          resolveCount++;
+        } else {
+          console.warn(`⚠️ Could not find thread for comment ${reply.commentId} — skipping resolve.`);
+        }
+      }
+    }
+
+    // Optionally submit a top-level review alongside the replies (with new comments if any)
+    if (reviewEvent && reviewBody) {
+      const newCommentCount = reviewComments.length;
+      const newLabel = newCommentCount > 0 ? ` with ${newCommentCount} new inline comment(s)` : "";
+      console.log(`Submitting ${reviewEvent} review on ${OWNER}/${REPO}#${prNumber}${newLabel}...`);
+      const review = await submitReview(token, OWNER, REPO, prNumber, reviewEvent, reviewBody, reviewComments);
+      console.log(`✅ Review posted: ${review.html_url}`);
+    }
+
+    const resolveLabel = resolveCount > 0 ? `, ${resolveCount} resolved` : "";
+    const newCommentLabel = reviewComments.length > 0 ? `, ${reviewComments.length} new comment(s)` : "";
+    console.log(`✅ ${replyCount} reply(s) posted${resolveLabel}${newCommentLabel}.`);
+
+  } else {
+    // --- Review mode: initial review with inline comments ---
+    const commentCount = reviewComments.length;
+    const commentLabel = commentCount > 0 ? ` with ${commentCount} inline comment(s)` : "";
+    console.log(`Submitting ${reviewEvent} review on ${OWNER}/${REPO}#${prNumber}${commentLabel}...`);
+    const review = await submitReview(token, OWNER, REPO, prNumber, reviewEvent, reviewBody, reviewComments);
+
+    console.log(`✅ Review posted: ${review.html_url}`);
+  }
+} catch (err) {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What this does

Implements a complete built-in function library across all data types (number, decimal, integer, string) with shared function-call infrastructure — 34 signatures across 18 function names. This closes the three expression-surface prevention gaps identified in the expression-language audit (L5: range constraints, L2: decimal rounding, L6: string validation). See [Issue #16](https://github.com/sfalik/Precept/issues/16) for full design rationale, locked decisions, and acceptance criteria.

Closes #16

## Implementation notes

Key technical risks and non-mechanical paths identified during design review:

- **`PreceptRoundExpression` migration** — The existing `round()` has its own AST node, parser path, type-checking logic, and evaluator dispatch. All four must be absorbed into the shared `PreceptFunctionCallExpression` infrastructure. This is the highest-risk change because it replaces working code with new infrastructure and must preserve exact existing behavior (banker&#39;s rounding, literal precision constraint). Migration must complete before any new function work begins — it validates the infrastructure.

- **`min`/`max` token collision** — `min` and `max` are already tokenized as constraint keywords (field constraint zone). The parser must accept them as function names when followed by `(`. Requires an `AnyFunctionNameToken` combinator that matches both identifier tokens and specific keyword tokens in function-name position. The tokenizer does NOT change — the parser handles the disambiguation.

- **`sqrt` compile-time non-negative proof** — The type checker must prove the argument is non-negative before allowing `sqrt`. Two satisfaction paths: (1) field has `nonnegative` constraint, (2) `&gt;= 0` guard in conjunction. This parallels C56 nullable narrowing but for a different safety property. The narrowing logic in `ApplyNarrowing()` / `TryInferKind()` will need a new proof category.

- **`pow` integer exponent restriction** — Exponent must be integer TYPE (not just integer-valued). This is a type-check-time restriction, not a runtime check. Non-integer exponent type → diagnostic. Expression arguments allowed (not literal-only) since exponent value doesn&#39;t affect result type.

- **`left`/`right`/`mid` 1-indexed + clamping totality** — These functions use 1-based indexing (Excel convention) with clamping rather than exceptions. Off-by-one risk in the evaluator: `mid(s, 1, 3)` must map to `s.Substring(0, 3)` internally (1-indexed to 0-indexed conversion). All boundary conditions must be exhaustively tested.

- **Variadic type checking for `min`/`max`** — All N arguments must be the same numeric type. The type checker validates each argument against the first argument&#39;s resolved type. Mixed numeric types (e.g., `min(integer, decimal)`) are rejected — no implicit promotion.

## Implementation checklist

### Slice 1: Infrastructure — Parser + Model + Core Type Checker

#### Parser
- [x] `PreceptToken` enum: add function name tokens (`Abs`, `Floor`, `Ceil`, `Round`, `Truncate`, `Pow`, `Sqrt`, `Clamp`, `Min`, `Max`, `ToLower`, `ToUpper`, `StartsWith`, `EndsWith`, `Trim`, `Left`, `Right`, `Mid`) with `[TokenCategory(Function)]` attribute
- [x] Tokenizer: register function name keywords (handle `min`/`max` collision — these tokens already exist as constraint keywords; need `AnyFunctionNameToken` combinator that accepts both identifier and constraint-keyword tokens in function-name position)
- [x] Parser: `FunctionCall` combinator — `AnyFunctionNameToken` + `(` + comma-separated expression list + `)` at atom level, before `DottedIdentifier`
- [x] Parser: `(` lookahead distinguishes function call from identifier reference
- [x] Parser: comma-separated argument list with `ExpressionParser.Lambda.ManyDelimitedBy(Token.EqualTo(PreceptToken.Comma))`
- [x] `PreceptModel.cs`: define `PreceptFunctionCallExpression(string Name, PreceptExpression[] Arguments)` record
- [x] `PreceptModel.cs`: integrate into `PreceptExpression` hierarchy
- [x] `ReconstituteExpr`: handle `PreceptFunctionCallExpression` reconstruction from token list

#### PreceptRoundExpression migration
- [x] Replace `PreceptRoundExpression` AST node usage with `PreceptFunctionCallExpression(Name: &#34;round&#34;, Arguments: [value])` for 1-arg round
- [x] Replace `PreceptRoundExpression` AST node usage with `PreceptFunctionCallExpression(Name: &#34;round&#34;, Arguments: [value, precision])` for 2-arg round
- [x] Remove `PreceptRoundExpression` parser combinator and route through shared `FunctionCall` combinator
- [x] Remove `PreceptRoundExpression` type-checker special case — route through function registry
- [x] Remove `PreceptRoundExpression` evaluator special case — route through function dispatch
- [x] Verify all existing `round()` tests still pass with zero behavior change
- [x] Verify that `round(decimal, N)` literal constraint is enforced through the registry path (not special-case code)

#### Type checker — function registry infrastructure
- [x] `DiagnosticCatalog.cs`: C71 — unknown function name (&#34;`Unknown function &#39;{name}&#39;. Built-in functions: abs, floor, ceil, ...`&#34;)
- [x] `DiagnosticCatalog.cs`: C72 — function arity mismatch (&#34;`Function &#39;{name}&#39; expects {expected} argument(s) but received {actual}`&#34;)
- [x] `DiagnosticCatalog.cs`: C73 — function argument type mismatch (&#34;`Function &#39;{name}&#39; expects {expectedType} but received {actualType}`&#34;)
- [x] `DiagnosticCatalog.cs`: C74 — round precision must be integer literal (&#34;`Function &#39;round&#39; requires the precision argument to be an integer literal`&#34;)
- [x] `DiagnosticCatalog.cs`: C75 — round precision must be non-negative (&#34;`Function &#39;round&#39; requires a non-negative precision. Received: {value}`&#34;)
- [x] `DiagnosticCatalog.cs`: C76 — pow exponent must be integer type (&#34;`Function &#39;pow&#39; requires an integer exponent. Received: {type}`&#34;)
- [x] `DiagnosticCatalog.cs`: C77 — sqrt requires non-negative proof (&#34;`Function &#39;sqrt&#39; requires a non-negative argument. &#39;{name}&#39; may be negative. Add a &#39;nonnegative&#39; constraint or guard with &#39;&gt;= 0&#39;`&#34;)
- [x] `// SYNC:CONSTRAINT:C71-C77` comments in type checker source
- [x] Static function registry data structure: maps function name → list of `FunctionSignature(string Name, PreceptExpressionKind[] ParamTypes, PreceptExpressionKind ReturnType, SignatureFlags Flags)`
- [x] Registry populated with all 34 signatures (10 number, 5 integer, 11 decimal, 8 string)
- [x] Function name lookup in `CollectCompileTimeDiagnostics` or equivalent — unknown name → C71
- [x] Arity validation — fixed-arity functions: wrong count → C72; variadic min/max: &lt; 2 → C72
- [x] Argument type resolution — resolve each argument expression&#39;s `PreceptExpressionKind`
- [x] Overload resolution — select most-specific matching signature by argument types
- [x] Type mismatch — no matching overload → C73 with actionable message
- [x] Return type propagation — `TryInferKind` resolves function call to the return type of the matched signature

#### Tests for Slice 1
- [x] Parser: `abs(X)` parses as `PreceptFunctionCallExpression`
- [x] Parser: `round(X, 2)` parses as `PreceptFunctionCallExpression` (not `PreceptRoundExpression`)
- [x] Parser: `min(A, B, C)` parses with 3 arguments
- [x] Parser: nested function call `abs(floor(X))` parses correctly
- [x] Parser: function call in expression `abs(X - Y) &lt;= 4` has correct precedence (atom level)
- [x] Parser: `min` and `max` parse as function names despite being constraint keywords
- [x] Type checker: unknown function `foo(X)` → C71 with full function list in message
- [x] Type checker: `abs(X, Y)` → C72 arity mismatch
- [x] Type checker: `abs(&#34;hello&#34;)` → C73 type mismatch
- [x] Type checker: `min(X)` → C72 (arity mismatch)
- [x] Type checker: valid `abs(number_field)` → no diagnostic, inferred kind = `Number`
- [x] Type checker: valid `round(decimal_field, 2)` → no diagnostic (migration path)
- [x] `CatalogDriftTests.cs`: C71 entry with `-&gt; no transition`
- [x] `CatalogDriftTests.cs`: C72 entry with `-&gt; no transition`
- [x] `CatalogDriftTests.cs`: C73 entry with `-&gt; no transition`
- [x] `CatalogDriftTests.cs`: C74 entry with `-&gt; no transition`
- [x] `CatalogDriftTests.cs`: C75 entry with `-&gt; no transition`
- [x] `CatalogDriftTests.cs`: C76 entry with `-&gt; no transition`
- [x] `CatalogDriftTests.cs`: C77 entry with `-&gt; no transition`
### Slice 2: Numeric Functions — Type Checker + Evaluator

#### Type checker — numeric function constraints
- [x] `abs(number) → number`, `abs(integer) → integer`, `abs(decimal) → decimal`: all three overloads resolve correctly
- [x] `floor(number) → integer`, `floor(decimal) → integer`: return type is `integer` (narrowing conversion)
- [x] `ceil(number) → integer`, `ceil(decimal) → integer`: return type is `integer`
- [x] `truncate(number) → integer`, `truncate(decimal) → integer`: return type is `integer`
- [x] `round(number) → number`: 1-arg overload for number type
- [x] `round(decimal) → integer`: 1-arg overload returns integer (consistent with floor/ceil/truncate)
- [x] `round(decimal, N)` → C74 when N is not an integer literal
- [x] `round(decimal, N)` → C75 when N is negative literal
- [x] `pow(number, integer) → number`, `pow(integer, integer) → integer`, `pow(decimal, integer) → decimal`: exponent type must be integer
- [x] `pow(number, number)` → C76 (non-integer exponent)
- [x] `pow(decimal, decimal)` → C76 (non-integer exponent)
- [x] `sqrt(number) → number`, `sqrt(decimal) → decimal`: requires non-negative proof
- [x] `sqrt` with `nonnegative` constraint on field → no diagnostic (proof satisfied)
- [x] `sqrt` with `&gt;= 0` guard in conjunction → no diagnostic (proof satisfied via narrowing)
- [x] `sqrt` without non-negative proof → C77 with actionable message
- [x] `sqrt` on integer type → C73 (no integer overload — sqrt produces irrational results)
- [x] `clamp(number, number, number) → number`: all three args same type
- [x] `clamp(integer, integer, integer) → integer`
- [x] `clamp(decimal, decimal, decimal) → decimal`
- [x] `clamp` with mixed types (e.g., `clamp(number, integer, number)`) → C73
- [x] `min`/`max` variadic: 2 args same type → valid, return type matches
- [x] `min`/`max` variadic: 3+ args same type → valid
- [x] `min`/`max` variadic: mixed types → C73
- [x] `min`/`max` nullable arg without guard → nullable diagnostic (C56-parallel)

#### Evaluator — numeric functions
- [x] `abs`: `Math.Abs()` dispatch for number, integer, decimal
- [x] `floor`: `Math.Floor()` → integer conversion for number and decimal
- [x] `ceil`: `Math.Ceiling()` → integer conversion for number and decimal
- [x] `round(number)`: `Math.Round(value, MidpointRounding.ToEven)` — banker&#39;s rounding
- [x] `round(decimal)`: `Math.Round(value, MidpointRounding.ToEven)` → integer
- [x] `round(decimal, N)`: `Math.Round(value, N, MidpointRounding.ToEven)` — banker&#39;s rounding, exact precision
- [x] `truncate`: `Math.Truncate()` → integer for number and decimal
- [x] `pow(number, integer)`: `Math.Pow()` for number type
- [x] `pow(integer, integer)`: iterative multiplication (avoid floating-point conversion)
- [x] `pow(decimal, integer)`: iterative multiplication (preserve exact decimal arithmetic)
- [x] `pow` with exponent 0 → result is 1 (of same type)
- [x] `pow` with exponent 1 → result is base value
- [x] `sqrt(number)`: `Math.Sqrt()` dispatch
- [x] `sqrt(decimal)`: appropriate precision algorithm (not `Math.Sqrt` which loses decimal precision via double conversion)
- [x] `sqrt(0)` → 0 (boundary)
- [x] `sqrt(4)` → 2 (perfect square)
- [x] `clamp`: `Math.Clamp()` or `Math.Min(Math.Max(value, low), high)`
- [x] `clamp` at lower bound → returns low
- [x] `clamp` at upper bound → returns high
- [x] `clamp` within bounds → returns value unchanged
- [x] `min` variadic: iterative `Math.Min` reduction over N arguments
- [x] `max` variadic: iterative `Math.Max` reduction over N arguments
- [x] `min`/`max` with 2 args → correct result
- [x] `min`/`max` with 5 args → correct result
- [x] Null argument in any numeric function → `EvaluationResult.Fail` (not throw)

#### Tests for Slice 2
- [x] Each numeric function: correct result for representative inputs
- [x] `round` banker&#39;s rounding: `round(0.5)` → 0, `round(1.5)` → 2 (MidpointRounding.ToEven)
- [x] `pow(2, 10)` → 1024 (integer); `pow(2.0, 3)` → 8.0 (number)
- [x] `sqrt(2.0)` → approximately 1.4142 (number); `sqrt(4.0m)` → 2.0m (decimal)
- [x] `clamp(150, 0, 100)` → 100; `clamp(-5, 0, 100)` → 0; `clamp(50, 0, 100)` → 50
- [x] `min(3, 1, 4, 1, 5)` → 1; `max(3, 1, 4, 1, 5)` → 5
- [x] Functions in guard context: `when abs(X - Y) &lt;= 4` routes correctly
- [x] Functions in invariant context: `invariant abs(Delta) &lt;= Threshold`
- [x] Functions in set RHS: `set Score = clamp(RawScore, 0, 100)`
- [x] Functions in assert context: `assert abs(Amount) &gt; 0`
- [x] Nested functions: `round(abs(X), 2)` evaluates correctly

### Slice 3: String Functions — Type Checker + Evaluator

#### Type checker — string functions
- [x] `toLower(string) → string`: valid with string arg
- [x] `toUpper(string) → string`: valid with string arg
- [x] `trim(string) → string`: valid with string arg
- [x] `startsWith(string, string) → boolean`: both args must be string, result is boolean
- [x] `endsWith(string, string) → boolean`: both args must be string, result is boolean
- [x] `left(string, number) → string`: first arg string, second numeric
- [x] `right(string, number) → string`: first arg string, second numeric
- [x] `mid(string, number, number) → string`: first arg string, second and third numeric
- [x] `toLower(42)` → C73 type mismatch (&#34;expects string, received number&#34;)
- [x] `startsWith(42, &#34;x&#34;)` → C73 type mismatch
- [x] `left(42, 3)` → C73 type mismatch (&#34;expects string as first argument&#34;)
- [x] Nullable string arg without guard → nullable diagnostic (C56-parallel)
- [x] `startsWith` / `endsWith` result type is `boolean` (usable in guards without comparison)

#### Evaluator — string functions
- [x] `toLower`: `string.ToLower(CultureInfo.InvariantCulture)` — invariant culture
- [x] `toUpper`: `string.ToUpper(CultureInfo.InvariantCulture)` — invariant culture
- [x] `trim`: `string.Trim()`
- [x] `startsWith`: `string.StartsWith(prefix, StringComparison.Ordinal)` — case-sensitive
- [x] `endsWith`: `string.EndsWith(suffix, StringComparison.Ordinal)` — case-sensitive
- [x] `left(s, n)`: returns first N characters; N &gt; s.Length → returns whole string; N &lt;= 0 → returns empty string
- [x] `right(s, n)`: returns last N characters; N &gt; s.Length → returns whole string; N &lt;= 0 → returns empty string
- [x] `mid(s, start, length)`: 1-indexed extraction; start &gt; s.Length → empty; start &lt;= 0 → treated as 1; length &lt;= 0 → empty; start + length exceeds → returns to end
- [x] Null string argument → `EvaluationResult.Fail` (not throw)
- [x] Empty string edge cases: `toLower(&#34;&#34;)` → `&#34;&#34;`, `left(&#34;&#34;, 5)` → `&#34;&#34;`, `mid(&#34;&#34;, 1, 3)` → `&#34;&#34;`

#### Tests for Slice 3
- [x] `toLower(&#34;HELLO&#34;)` → `&#34;hello&#34;`; `toUpper(&#34;hello&#34;)` → `&#34;HELLO&#34;`
- [x] `trim(&#34;  hello  &#34;)` → `&#34;hello&#34;`
- [x] `startsWith(&#34;hello&#34;, &#34;hel&#34;)` → true; `startsWith(&#34;hello&#34;, &#34;world&#34;)` → false
- [x] `endsWith(&#34;hello&#34;, &#34;llo&#34;)` → true; `endsWith(&#34;hello&#34;, &#34;world&#34;)` → false
- [x] Case sensitivity: `startsWith(&#34;Hello&#34;, &#34;hello&#34;)` → false (case-sensitive)
- [x] `left(&#34;abcde&#34;, 3)` → `&#34;abc&#34;`; `left(&#34;ab&#34;, 5)` → `&#34;ab&#34;` (clamping); `left(&#34;abc&#34;, 0)` → `&#34;&#34;` (clamping)
- [x] `right(&#34;abcde&#34;, 3)` → `&#34;cde&#34;`; `right(&#34;ab&#34;, 5)` → `&#34;ab&#34;`; `right(&#34;abc&#34;, 0)` → `&#34;&#34;`
- [x] `mid(&#34;abcde&#34;, 2, 3)` → `&#34;bcd&#34;` (1-indexed); `mid(&#34;abcde&#34;, 4, 5)` → `&#34;de&#34;` (clamp to end)
- [x] `mid(&#34;abcde&#34;, 0, 3)` → `&#34;abc&#34;` (start &lt;= 0 treated as 1); `mid(&#34;abcde&#34;, 1, 0)` → `&#34;&#34;` (length &lt;= 0)
- [x] `mid(&#34;abcde&#34;, 10, 3)` → `&#34;&#34;` (start &gt; length)
- [x] Nested: `startsWith(toLower(Email), &#34;admin@&#34;)` evaluates correctly
- [x] Functions in invariant: `invariant startsWith(Code, &#34;PRD-&#34;)`
- [x] Functions in guard: `when startsWith(toLower(Submit.Email), &#34;admin&#34;)` routes correctly
- [x] Functions composing with `.length`: `left(ZipCode, 5).length == 5`

### Slice 4: Language Server

#### TextMate grammar (`precept.tmLanguage.json`)
- [x] New `functionName` pattern: matches `abs|floor|ceil|round|truncate|pow|sqrt|clamp|min|max|toLower|toUpper|startsWith|endsWith|trim|left|right|mid` followed by `(`
- [x] Function names highlighted with `entity.name.function.precept` scope (or equivalent)
- [x] Pattern ordering: function name pattern appears before `identifierReference` catch-all
- [x] `min`/`max` highlighted as function name when followed by `(`, as constraint keyword otherwise

#### Completions (`PreceptAnalyzer.cs`)
- [x] Function name completions offered in all expression contexts: `set` RHS, `when` guard, `invariant`, `assert`
- [x] Snippet templates with tab stops: `abs($1)`, `floor($1)`, `ceil($1)`, `round($1)`, `round($1, $2)`, `truncate($1)`, `pow($1, $2)`, `sqrt($1)`, `clamp($1, $2, $3)`, `min($1, $2)`, `max($1, $2)`, `toLower($1)`, `toUpper($1)`, `startsWith($1, $2)`, `endsWith($1, $2)`, `trim($1)`, `left($1, $2)`, `right($1, $2)`, `mid($1, $2, $3)`
- [x] Function completions include brief doc label (e.g., &#34;abs — Absolute value&#34;)
- [x] Functions offered after `(` in nested position (for composability)

#### Hover
- [x] Hover on function call shows resolved signature: `abs(number) → number`
- [x] Hover on function call shows description text
- [x] Hover on variadic min/max shows `min(number, number, ...) → number`

#### Semantic tokens
- [x] `[TokenCategory(Function)]` attribute on function name tokens — semantic tokens handler picks up automatically via `PreceptTokenMeta.GetCategory()`
- [x] Function names receive `function` semantic token type in output

### Slice 5: MCP

#### `precept_language` — LanguageTool.cs
- [x] New `functions` catalog section in output: array of function entries
- [x] Each entry includes: name, signatures (overloads), description, argument constraints (literal-only, non-negative proof, integer-exponent)
- [x] All 18 function names and 34 signatures present
- [x] Variadic min/max entry indicates minimum 2 arguments, no upper limit

#### `precept_compile` — CompileTool.cs
- [x] `PreceptFunctionCallExpression` serialized in expression tree output: `{ &#34;function&#34;: &#34;abs&#34;, &#34;arguments&#34;: [...] }`
- [x] Nested function calls serialize correctly
- [x] Resolved return type included in expression metadata

### Slice 6: Tests (cross-cutting categories)

_Tests are written throughout slices 1–5, but these categories must be explicitly verified:_

- [x] Parser tests: valid function calls, nested calls, variadic args, function in every expression position
- [x] Type checker tests: all 34 signatures valid, all 9 diagnostic codes triggered by specific invalid inputs
- [x] Type checker: `round(decimal, N)` literal constraint (C74), negative precision (C75)
- [x] Type checker: `pow` non-integer exponent (C76)
- [x] Type checker: `sqrt` non-negative proof — satisfied by `nonnegative` constraint, satisfied by `&gt;= 0` guard, rejected without proof (C77)
- [x] Type checker: variadic min/max — 2, 3, 5 args; mixed types rejected (C73); &lt; 2 args (C72)
- [x] Type checker: nullable field arg without guard → appropriate nullable diagnostic
- [x] Evaluator tests: correct result for every function + edge cases (clamping, overflow, empty strings, zero, boundary values)
- [x] Guard routing: events with function expressions in `when` clause fire on correct branch
- [x] `CatalogDriftTests.cs`: all 7 new diagnostic codes (C71-C77) with `-&gt; no transition` triggers
- [x] LS tests: function completions appear in expression contexts
- [x] LS tests: hover shows resolved signature
- [x] MCP tests: `precept_language` includes function catalog
- [x] MCP tests: `precept_compile` serializes function calls in expression tree

### Slice 7: Samples + Docs

#### Sample files (≥ 3 updated)
- [x] `samples/travel-reimbursement.precept`: add `round(Miles * MileageRate, 2)` for currency precision
- [x] `samples/maintenance-work-order.precept`: add `abs(ActualHours - EstimatedHours) &lt;= Tolerance` for range constraint
- [x] `samples/insurance-claim.precept`: add `clamp(AdjustedAmount, 0, MaxPayout)` or similar numeric function usage
- [x] At least one sample with string function: `toLower`, `startsWith`, `left`/`right`/`mid`

#### Documentation
- [x] `docs/PreceptLanguageDesign.md`: function-call syntax form in grammar section
- [x] `docs/PreceptLanguageDesign.md`: function registry — all 18 names, 34 signatures, descriptions
- [x] `docs/PreceptLanguageDesign.md`: expression context table updated (functions valid in set/when/invariant/assert)
- [x] `docs/PreceptLanguageDesign.md`: semantic rules section (purity, totality, closed registry, sqrt domain restriction, variadic min/max, 1-indexed strings)
- [x] `docs/PreceptLanguageDesign.md`: examples for numeric functions (abs, round, pow, sqrt, clamp, min/max)
- [x] `docs/PreceptLanguageDesign.md`: examples for string functions (toLower, startsWith, left/right/mid)
- [x] `docs/PreceptLanguageDesign.md`: explicit exclusions (user-defined functions, regex, collection aggregates, type conversion)
- [x] `docs/ConstraintViolationDesign.md`: C71-C77 entries with descriptions and example triggers
- [x] `docs/McpServerDesign.md`: function catalog section in `precept_language` output spec
- [x] `docs/McpServerDesign.md`: function call serialization in `precept_compile` output spec
- [x] `README.md`: mention built-in functions in feature list

## Critical review focus

1. **`PreceptRoundExpression` migration (Slice 1)** — Must preserve exact existing behavior. Every test that passed before migration must pass after with zero behavior change. The literal precision constraint (`round(decimal, N)` requires literal N) must be enforced through the registry path, not residual special-case code. Check that no `PreceptRoundExpression` references remain anywhere after migration.

2. **`min`/`max` token disambiguation (Slice 1)** — The `AnyFunctionNameToken` combinator must accept `min`/`max` as function names when followed by `(` without breaking their use as constraint keywords in field declarations. Verify that `field Score as number min 0 max 100` still parses correctly after the change. The tokenizer must NOT change — disambiguation is parser-level only.

3. **`sqrt` non-negative proof narrowing (Slice 2)** — The narrowing logic parallels C56 (nullable string requires null guard) but proves a different property (non-negativity instead of non-nullity). Verify both proof paths work: `nonnegative` constraint on the field definition, AND `&gt;= 0` guard in conjunction within the expression context. The narrowing must compose with null narrowing — a nullable nonnegative field should require BOTH a null guard and a non-negative proof.

4. **Variadic min/max type checking (Slice 2)** — All N arguments must resolve to the SAME numeric type. The type checker must reject `min(integer_field, decimal_field)` even though both are numeric. No implicit promotion. Verify the error message is actionable (names the conflicting types).

5. **1-indexed clamping in `left`/`right`/`mid` (Slice 3)** — Off-by-one risk at the evaluator boundary. `mid(s, 1, 3)` must map to `s.Substring(0, 3)` internally. `mid(s, 0, 3)` must behave as `mid(s, 1, 3)` (start &lt;= 0 treated as 1). Verify EVERY clamping boundary case has a dedicated test: N &gt; length, N &lt;= 0, start &gt; length, start + length &gt; length, start &lt;= 0, length &lt;= 0.

