### PR TITLE
feat: conditional expressions — if condition then value else value (#9)

### DIFF
--- a/.squad/agents/george/history.md
+++ b/.squad/agents/george/history.md
@@ -232,3 +232,15 @@ Added 5 tests requested by Soup Nazi to resolve reviewer blockers on PR #63:
 - **B4** (`NewSyntaxRuntimeTests.Fire_GuardedEventAssert_WhenNot_SkipsWhenTrue`): `on Submit assert Submit.Amount > 0 when not Submit.IsDraft` — IsDraft=true skips (transition), IsDraft=false rejects.
 - **B5** (`GuardedEditTests.Update_GuardedEdit_WhenNot_NegativeGuard`): `in Open when not IsLocked edit Notes` — IsLocked=false → editable, IsLocked=true → UneditableField.
 - All 5 tests passing.
+
+### 2026-04-12 — Conditional expression tests (Issue #9)
+
+Wrote 24 tests for conditional expressions (`if <cond> then <expr> else <expr>`) and fixed 3 catalog drift entries:
+- **Parser tests (8):** simple conditional, field ref + comparison, nested via parens, set RHS in full precept, invariant expression, when guard expression, arithmetic branches, boolean branches.
+- **Type checker tests (9):** valid conditional (no diags), C78 non-boolean condition (number, string, nullable boolean — 3 tests), C79 branch type mismatch (string vs number, boolean vs string — 2 tests), null-narrowing in then-branch, nested conditional type consistency, function call in branch.
+- **Runtime tests (7):** set with conditional, true branch, false branch, comparison condition, nested conditional, invariant with conditional, null-narrowing produces correct value.
+- **Catalog drift fixes:** Added C78 and C79 to `ConstraintTriggers` dictionary and `LineAccuracyCases`. Both use `-> no transition` to avoid C54 masking.
+- **Key gotchas found:**
+  - Literal `0` is typed as `integer`, not `number`. When using `abs(field)` (returns `number`) in a conditional branch, the other branch must also be `number`-typed (e.g. `0.0`), or C79 fires for branch type mismatch.
+  - An unguarded transition row followed by a reject row triggers C25 (unreachable duplicate). For conditional expressions that handle both null and non-null cases inline (via `if Name != null then Name else "default"`), the reject fallback row is unnecessary and must be omitted.
+  - All 1,096 tests passing after changes.

--- a/.squad/agents/kramer/history.md
+++ b/.squad/agents/kramer/history.md
@@ -6,6 +6,14 @@
 
 ## Recent Updates
 
+### 2026-04-12 — Issue #9: Grammar + language server completions for conditional expressions (if/then/else)
+
+- Grammar (`precept.tmLanguage.json`): added `if|then|else` to `controlKeywords` alternation alongside `when`. Updated regex from `\\bwhen\\b` to `\\b(when|if|then|else)\\b`.
+- Completions (`PreceptAnalyzer.cs`): added `if ... then ... else` snippet to `ExpressionOperatorItems` — appears in all expression contexts (set RHS, guard, invariant, event assert, data expression). Excluded `if`, `then`, `else` from `TopLevelItems` (expression-only, not statement keywords). Excluded `then`, `else` from `KeywordItems` (continuation-only keywords).
+- Semantic tokens: zero changes needed — `TokenCategory.Control → "preceptKeywordSemantic"` auto-picks up `If`, `Then`, `Else` from the enum. Verified by test.
+- Tests: 4 new completion tests (set RHS, invariant, guard, statement-start exclusion) + 1 semantic token test. All 151 LS tests pass. All 9 grammar drift tests pass.
+- Build: 0 errors.
+
 ### 2026-04-11 — Slices 6+7: Language server completions + grammar verification (conditional `when` guards)
 
 - **Slice 7 (grammar verification):** Confirmed `when` is already in `controlKeywords` in `precept.tmLanguage.json`. All LanguageServer tests pass. Zero grammar changes needed.
@@ -86,6 +94,13 @@
 - Key learning: When a grammar already has a named pattern for specific dotted accessors (not relying on catch-all), new accessors must be added explicitly to that pattern — the catch-all produces a semantically different token scope.
 
 ## Learnings
+
+### 2026-04-12 — Issue #9: Conditional expression tooling
+
+- Expression-only control keywords (`if`, `then`, `else`) must be excluded from `TopLevelItems` even though they share `TokenCategory.Control` with statement-level keywords like `when`. The `BuildTopLevelItems()` method auto-includes all Control tokens — add explicit symbol-name exclusions.
+- Continuation keywords (`then`, `else`) should also be excluded from `KeywordItems` — they're never meaningful standalone, only as part of `if ... then ... else`.
+- `ExpressionOperatorItems` is the correct insertion point for expression-level keywords — it feeds into `BuildGuardCompletions`, `BuildExpressionCompletions`, `BuildDataExpressionCompletions`, and `BuildEventAssertCompletions` (all four expression contexts).
+- Using a snippet (`if ${1:condition} then ${2:value} else ${3:value}`) for conditional expressions provides better UX than a bare keyword since the full form is always required.
 
 ### 2026-04-11 — Issue #14 final tooling spec (all 4 forms)
 

--- a/.squad/agents/newman/history.md
+++ b/.squad/agents/newman/history.md
@@ -193,3 +193,16 @@ Both skills use `precept_language` for syntax authority, handle Mermaid diagrams
 - **`StaticValueKind` display:** `FormatValueKind` helper collapses `Number|Integer|Decimal` → `"number"`, surfaces specific types otherwise. `FormatArgConstraint` maps `MustBeIntegerLiteral` → `"must be integer literal"`.
 - **Test impact:** Fixed assertion in `ConstructsIncludeRoundFunction` (checks description contains "built-in function" instead of form starts with "round"). Updated `CatalogDriftTests` switch case for new construct ID. All 1187 tests pass.
 - **Docs note:** `docs/McpServerDesign.md` needs a `functions` section added in the final doc sync slice. The existing `round()` reference table should expand to cover all 18 functions.
+
+### Issue #9 — MCP updates for conditional expressions (2026-04-12)
+
+- **`LanguageTool.cs`:** Zero changes needed. `if`, `then`, `else` tokens carry `[TokenCategory(TokenCategory.Control)]` attributes — `BuildVocabulary()` picks them up automatically. C78/C79 diagnostics in `DiagnosticCatalog` surface automatically via catalog reflection.
+- **`CompileTool.cs`:** Zero changes needed. Conditional expressions serialize via `ReconstituteExpr` in the parser (`if <cond> then <then> else <else>`). `ExpressionText` on set assignments captures the full conditional text. No new DTO fields required.
+- **`InspectTool.cs`:** No changes made — **trace enhancement (AC-9: `conditionResult` + `branchTaken`) requires core engine changes.** The evaluator's `EvaluationResult(bool Success, object? Value, string? Error)` returns only the final value, not which branch was taken. `EventInspectionResult` carries no per-expression evaluation trace. Surfacing conditional branch decisions requires: (1) the evaluator to produce trace metadata, (2) `EventInspectionResult` to carry it, (3) the MCP layer to project it. Items 1–2 are George's domain. MCP shape would be an optional `ConditionalTraceDto(string conditionText, bool conditionResult, string branchTaken, object? value)` array on `InspectEventDto`.
+- **`FireTool.cs`:** Zero changes needed. `engine.Fire()` evaluates conditionals correctly — field values reflect branch selection.
+- **Tests added (8 new, 83 total, 0 failed):**
+  - `CompileToolTests`: conditional in set RHS compiles cleanly, C78 (non-boolean condition), C79 (branch type mismatch)
+  - `LanguageToolTests`: `if`/`then`/`else` in control keywords vocabulary, C78/C79 in constraints catalog
+  - `FireToolTests`: conditional set produces correct value (then branch), conditional set produces correct value (else branch)
+  - `InspectToolTests`: conditional set assignment shows correct transition outcome
+- **Docs note:** `docs/McpServerDesign.md` may need a note about conditional expression support in compile output. Deferred to doc sync.

--- a/.squad/ceremonies.md
+++ b/.squad/ceremonies.md
@@ -38,6 +38,13 @@
 | **Time budget** | focused |
 | **Enabled** | ✅ yes |
 
+### Coordinator pre-flight (BLOCKING — do these BEFORE spawning reviewers)
+
+1. **Read `.squad/skills/pr-review/SKILL.md`** — this defines the structured JSON format, the posting workflow via `squad-review.js`, and the full review conversation lifecycle (initial review → dev fix → re-review). Do not spawn reviewers without reading it.
+2. **Spawn reviewers as full agents (not Explore)** — reviewers need tool access to read files with accurate line numbers. Never use `agentName: "Explore"` for reviews.
+3. **Include in each reviewer's prompt:** their charter identity, the linked issue's acceptance criteria, the structured JSON output format from the skill file, and the instruction to produce a JSON review file (not chat-only analysis).
+4. **After collecting results:** post reviews to the PR via `node tools/scripts/squad-review.js <pr-number> <review-file.json>`. Reviews must be durable on the PR, not buried in chat.
+
 **Output:** Follow `.squad/skills/pr-review/SKILL.md` for structured review format and posting workflow. Every reviewer produces structured JSON; Scribe posts each review via `squad-reviewer[bot]`. Reviews are durable on the PR, not buried in chat.
 
 **Agenda:**

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ See the [Quickstart Guide](docs/RuntimeApiDesign.md) for a complete runtime inte
 - Compile-time checking — unreachable states and type errors caught before runtime
 - **Stateful or stateless** — precepts can govern stateful workflows (with lifecycle states and transitions) or stateless domain objects (fields and edit rules only, no states)
 - **Conditional declarations** — `when` guards on invariants, asserts, and edit blocks make rules apply only when a precondition is met
+- **Conditional expressions** — `if...then...else` selects between values inline, replacing row duplication for data-dependent field assignments
 
 Precept is not a workflow orchestrator, event sourcing framework, or ORM — it integrates with all of them. It governs the entity contract; they handle orchestration, persistence, and storage. Think: scattered governance across six service classes — Precept puts it in one file.
 

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -1148,7 +1148,7 @@ set Tier = if CreditScore >= 750 then "prime" else if CreditScore >= 680 then "s
 ### Explicit exclusions
 
 - **No ternary syntax** — `condition ? value : value` is not supported. The keyword form `if...then...else` is deliberate per Principle #13 (keywords for domain, symbols for math).
-- **No statement-level `if`** — `if` does not control declaration applicability. Use `when` guards for structural branching.
+- **No statement-level `if`** — `if` does not control declaration applicability. Use `when` guards for structural branching. The parser detects `if` at statement level and emits a redirect message pointing to `when`.
 - **No short-circuit evaluation** — both branches are type-checked at compile time. At runtime, only the selected branch is evaluated.
 - **No implicit boolean coercion** — numbers and strings are not truthy/falsy. The condition must be explicitly boolean.
 

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -409,7 +409,8 @@ Full reserved keyword list:
 `transition`, `no`, `reject`,
 `string`, `number`, `boolean`, `integer`, `decimal`, `choice`, `maxplaces`, `ordered`,
 `true`, `false`, `null`, `contains`,
-`and`, `or`, `not`
+`and`, `or`, `not`,
+`if`, `then`, `else`
 
 ### Dual-use: `set`
 
@@ -428,7 +429,7 @@ No ambiguity in the token stream — the parser knows which meaning applies from
 - `string`
 - `number`
 - `boolean`
-- `integer` — whole number, no decimal component. Supports arithmetic and numeric range constraints (`nonnegative`, `positive`, `min`, `max`). Widens to `number` and `decimal` in mixed arithmetic. Integer division truncates toward zero.
+- `integer` — whole number, no decimal component. Supports arithmetic and numeric range constraints (`nonnegative`, `positive`, `min`, `max`). Widens to `number` and `decimal` — an integer value is accepted wherever a number or decimal is expected (assignment, comparison, arithmetic, conditional branches). This is lossless: every integer is a valid number and a valid decimal. Integer division truncates toward zero.
 - `decimal` — exact base-10 decimal number. Supports the `maxplaces` constraint and the `round()` built-in function.
 - `choice("A","B","C")` — constrained string value set; the value must be one of the declared members. Supports the `ordered` constraint for ordinal comparison. At least one member required (C62). No duplicate members (C63). Default value must be a declared member (C64).
 
@@ -1013,6 +1014,7 @@ The expression language supports:
 - logical: `and`, `or`
 - comparisons: `==`, `!=`, `>`, `>=`, `<`, `<=`
 - membership: `contains`
+- conditional: `if <condition> then <value> else <value>` (see [Conditional Expressions](#conditional-expressions-locked))
 - parentheses
 - identifier expressions with optional dotted member access (`Name.member`)
 
@@ -1058,6 +1060,97 @@ Function arguments must be non-nullable — passing a nullable field without a n
 Exact operator precedence and literal forms should align with the runtime expression parser.
 
 See [Keyword vs Symbol Design Framework](#keyword-vs-symbol-design-framework-locked) for the rationale behind using keywords for logical operators and symbols for math/comparison.
+
+---
+
+## Conditional Expressions (Locked)
+
+Conditional expressions select between two values based on a boolean condition.
+
+### Syntax
+
+```
+if <condition> then <value> else <value>
+```
+
+All three keywords (`if`, `then`, `else`) are required. There is no short-form ternary (`? :`), no statement-level `if`, and no short-circuit evaluation — both branches are type-checked at compile time, and exactly one is evaluated at runtime.
+
+### Semantics
+
+A conditional expression is a **pure value expression**. It produces a single value and is valid in any expression position: `set` RHS, `invariant`, `assert`, and `when` guard. It is not a control-flow statement — it does not skip or apply declarations.
+
+### Type rules
+
+- The **condition** must be a non-nullable `boolean`. Non-boolean conditions (numbers, strings) emit **C78**. Nullable booleans also emit C78 — narrow with an explicit comparison first.
+- Both **branches** must resolve to compatible scalar base types. Integer widens to number or decimal (lossless subset), so `if Flag then abs(X) else 0` is valid when X is `number`. Incompatible types (e.g., `string` vs `number`, or `number` vs `decimal`) emit **C79**.
+- The result type is the wider of the two branch types. If either branch is nullable, the result is nullable.
+
+### `when` vs `if` — the teaching model
+
+`when` and `if` serve fundamentally different roles in Precept:
+
+| | `when` | `if` |
+|---|---|---|
+| **Kind** | Structural guard | Value expression |
+| **Effect** | Applies or skips an entire declaration (row, invariant, assert, edit block) | Selects between two values within an expression |
+| **Position** | After `from...on`, on `invariant`, `assert`, `edit` declarations | Inside any expression position |
+| **Branching** | Multiple rows with different `when` guards → first-match routing | Single expression with two branches → one value produced |
+
+`when` answers: *does this rule apply?* `if` answers: *which value do I use?*
+
+### Null-narrowing
+
+When the condition is a null check (`field != null`), the field is narrowed to non-nullable in the `then` branch. The `else` branch retains the original nullable type.
+
+```precept
+# Name is string nullable — narrowed to string in then-branch
+set Display = if Name != null then Name else "anonymous"
+```
+
+### Nesting
+
+Conditional expressions nest via parentheses. Without parentheses, the `else` branch greedily consumes the next `if`:
+
+```precept
+# Nested conditional — explicit parentheses for clarity
+set X = if A then (if B then 1 else 2) else 3
+
+# Chained else-if — greedy else binding
+set Note = if Score >= 90 then "excellent" else if Score >= 70 then "good" else "needs work"
+```
+
+### Diagnostic codes
+
+| Code | Condition | Message |
+|---|---|---|
+| C78 | Condition is not a non-nullable boolean | `Conditional expression condition must be a non-nullable boolean, but got {actual}.` |
+| C79 | Branch types incompatible | `Conditional expression branches must produce the same scalar type, but got {thenType} and {elseType}.` Integer widens to number/decimal; number ↔ decimal is a hard error. |
+
+### Examples
+
+```precept
+# Conditional in set assignment
+from Decision on ExtendOffer when FeedbackCount >= 2
+    -> set OfferAmount = ExtendOffer.Amount
+    -> set FinalNote = if FeedbackCount >= 3 then "Strong Hire" else "Standard Hire"
+    -> transition OfferExtended
+
+# Conditional in invariant
+invariant ApprovedAmount <= (if FraudFlag then ClaimAmount / 2 else ClaimAmount) because "Fraud-flagged claims capped at half"
+
+# Null-narrowing with conditional
+set DecisionNote = if Approve.Note != null then Approve.Note else "Auto-approved"
+
+# Nested conditional (chained else-if)
+set Tier = if CreditScore >= 750 then "prime" else if CreditScore >= 680 then "standard" else "subprime"
+```
+
+### Explicit exclusions
+
+- **No ternary syntax** — `condition ? value : value` is not supported. The keyword form `if...then...else` is deliberate per Principle #13 (keywords for domain, symbols for math).
+- **No statement-level `if`** — `if` does not control declaration applicability. Use `when` guards for structural branching.
+- **No short-circuit evaluation** — both branches are type-checked at compile time. At runtime, only the selected branch is evaluated.
+- **No implicit boolean coercion** — numbers and strings are not truthy/falsy. The condition must be explicitly boolean.
 
 ---
 
@@ -1396,6 +1489,8 @@ Type checking for `from any` rows expands to per-state checking. Each state may 
 | C43 / PRECEPT043 | Collection `pop`/`dequeue into` target type mismatch |
 | C60 / PRECEPT060 | Narrowing assignment: assigning a `number` or `decimal` value to an `integer` field requires an explicit integer-producing expression (no implicit truncation) |
 | C69 / PRECEPT069 | Cross-scope guard reference in `when` clause |
+| C78 / PRECEPT078 | Conditional expression condition must be a non-nullable boolean |
+| C79 / PRECEPT079 | Conditional expression branches must produce the same scalar type |
 
 ### Design principle
 
@@ -1460,6 +1555,7 @@ Locked in this discussion:
 - Static impossibility boundary: the compile-time checker proves contradictions only from type information and null-flow narrowing (single-symbol, local reasoning). Additionally, identical-guard duplicate rows for the same `(state, event)` are a compile-time error. No cross-field arithmetic reasoning — the inspector handles data-dependent impossibility.
 - Diagnostic severity: three-tier model. **Error** = provably wrong (blocks compilation). **Warning** = structural quality concern (does not block). **Hint** = informational observation. The checker never guesses; uncertain cases are left to the inspector.
 - Diagnostic codes: overload existing codes for same conceptual category; new codes only for genuinely new categories. C38–C45 are stable and will not be split. New codes start at C46.
+- Conditional expressions: `if <condition> then <value> else <value>` — pure value expressions valid in set RHS, invariant, assert, and guard positions. Both branches type-checked; condition must be non-nullable boolean (C78). Branches must produce compatible scalar types with integer widening (C79). Null-narrowing applies in then-branch when condition is a null check. No ternary syntax, no statement-level `if`, no short-circuit evaluation.
 
 Not yet locked:
 - Full EBNF and tokenization rules

--- a/samples/event-registration.precept
+++ b/samples/event-registration.precept
@@ -51,7 +51,7 @@ on Cancel assert Reason == null or Reason != "" because "If a cancellation reaso
 event CheckIn with Desk as string
 on CheckIn assert Desk != "" because "The check-in desk is required"
 
-from Draft on StartRegistration -> set RegistrantName = StartRegistration.Name -> set ContactEmail = StartRegistration.Email -> set SeatsReserved = StartRegistration.Seats -> set AmountDue = round(StartRegistration.Seats * StartRegistration.PricePerSeat, 2) -> transition PendingPayment
+from Draft on StartRegistration -> set RegistrantName = StartRegistration.Name -> set ContactEmail = StartRegistration.Email -> set SeatsReserved = StartRegistration.Seats -> set AmountDue = if StartRegistration.Seats >= 10 then round(StartRegistration.Seats * StartRegistration.PricePerSeat * 0.9, 2) else round(StartRegistration.Seats * StartRegistration.PricePerSeat, 2) -> transition PendingPayment
 
 from PendingPayment on UpdateSeats -> set SeatsReserved = UpdateSeats.Seats -> set TicketsIssued = 0 -> set AmountDue = round(UpdateSeats.Seats * 25, 2) -> no transition
 from PendingPayment on RecordPayment when SeatsReserved > 0 -> set TicketsIssued = SeatsReserved -> transition Confirmed

--- a/samples/hiring-pipeline.precept
+++ b/samples/hiring-pipeline.precept
@@ -50,7 +50,7 @@ from InterviewLoop on RecordInterviewFeedback when PendingInterviewers contains 
 from InterviewLoop on RecordInterviewFeedback -> reject "Only assigned interviewers can submit feedback"
 from InterviewLoop on RejectCandidate -> set FinalNote = RejectCandidate.Note -> transition Rejected
 
-from Decision on ExtendOffer when FeedbackCount >= 2 -> set OfferAmount = ExtendOffer.Amount -> transition OfferExtended
+from Decision on ExtendOffer when FeedbackCount >= 2 -> set OfferAmount = ExtendOffer.Amount -> set FinalNote = if FeedbackCount >= 3 then "Strong Hire" else "Standard Hire" -> transition OfferExtended
 from Decision on ExtendOffer -> reject "At least two completed interview feedback entries are required before extending an offer"
 from Decision on RejectCandidate -> set FinalNote = RejectCandidate.Note -> transition Rejected
 

--- a/samples/insurance-claim.precept
+++ b/samples/insurance-claim.precept
@@ -64,7 +64,7 @@ from UnderReview on RequestDocument -> add MissingDocuments RequestDocument.Name
 from UnderReview on ReceiveDocument when MissingDocuments contains ReceiveDocument.Name -> remove MissingDocuments ReceiveDocument.Name -> no transition
 from UnderReview on ReceiveDocument -> reject "That document is not currently outstanding"
 
-from UnderReview on Approve when (not PoliceReportRequired or MissingDocuments.count == 0) and Approve.Amount <= ClaimAmount -> set ApprovedAmount = Approve.Amount -> set DecisionNote = Approve.Note -> transition Approved
+from UnderReview on Approve when (not PoliceReportRequired or MissingDocuments.count == 0) and Approve.Amount <= ClaimAmount -> set ApprovedAmount = if FraudFlag then min(Approve.Amount, ClaimAmount / 2) else Approve.Amount -> set DecisionNote = Approve.Note -> transition Approved
 from UnderReview on Approve -> reject "Required documents must be complete before a claim can be approved"
 
 from UnderReview on Deny -> set DecisionNote = Deny.Note -> transition Denied

--- a/samples/loan-application.precept
+++ b/samples/loan-application.precept
@@ -54,7 +54,7 @@ from Draft on Submit -> set ApplicantName = Submit.Applicant -> set RequestedAmo
 
 from UnderReview on VerifyDocuments -> set DocumentsVerified = true -> no transition
 
-from UnderReview on Approve when DocumentsVerified and CreditScore >= 680 and AnnualIncome >= ExistingDebt * 2 and RequestedAmount < AnnualIncome / 2 and Approve.Amount <= RequestedAmount -> set ApprovedAmount = min(Approve.Amount, RequestedAmount) -> set DecisionNote = Approve.Note -> transition Approved
+from UnderReview on Approve when DocumentsVerified and CreditScore >= 680 and AnnualIncome >= ExistingDebt * 2 and RequestedAmount < AnnualIncome / 2 and Approve.Amount <= RequestedAmount -> set ApprovedAmount = min(Approve.Amount, RequestedAmount) -> set DecisionNote = if Approve.Note != null then Approve.Note else if CreditScore >= 750 then "Prime tier  — auto-approved" else "Standard tier — approved" -> transition Approved
 from UnderReview on Approve -> reject "Approval requires verified documents, strong credit, and affordable debt load"
 
 from UnderReview on Decline -> set DecisionNote = Decline.Note -> transition Declined

--- a/samples/subscription-cancellation-retention.precept
+++ b/samples/subscription-cancellation-retention.precept
@@ -38,7 +38,7 @@ on DeclineOffer assert Note == null or Note != "" because "A supplied decline no
 
 from Active on RequestCancellation -> set SubscriberName = RequestCancellation.Name -> set PlanName = RequestCancellation.Plan -> set MonthlyPrice = RequestCancellation.Price -> set CancellationReason = RequestCancellation.Reason -> set SaveOfferAccepted = false -> transition RetentionReview
 
-from RetentionReview on MakeSaveOffer when not SaveOfferAccepted and RetentionDiscount == 0 -> set RetentionDiscount = MakeSaveOffer.DiscountPercent -> no transition
+from RetentionReview on MakeSaveOffer when not SaveOfferAccepted and RetentionDiscount == 0 -> set RetentionDiscount = MakeSaveOffer.DiscountPercent -> set LastAgentNote = if MonthlyPrice >= 50 then "Premium plan retention" else "Standard plan retention" -> no transition
 from RetentionReview on MakeSaveOffer -> reject "Only one outstanding save offer can exist at a time"
 
 from RetentionReview on AcceptOffer -> set SaveOfferAccepted = true -> set CancellationReason = null -> transition Active

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -601,4 +601,22 @@ public static class DiagnosticCatalog
         "C77", "compile",
         "Function does not accept nullable arguments.",
         "Function '{name}' does not accept nullable arguments. '{arg}' may be null. Add a null check.");
+
+    // ═══════════════════════════════════════════════════════════════
+    // Compile-phase constraints: conditional expressions (C78–C79)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>Conditional expression condition must be a non-nullable boolean.</summary>
+    // SYNC:CONSTRAINT:C78
+    public static readonly LanguageConstraint C78 = Register(
+        "C78", "compile",
+        "Conditional expression condition must be a non-nullable boolean.",
+        "Conditional expression condition must be a non-nullable boolean, but got {actual}.");
+
+    /// <summary>Conditional expression branches must produce the same scalar type.</summary>
+    // SYNC:CONSTRAINT:C79
+    public static readonly LanguageConstraint C79 = Register(
+        "C79", "compile",
+        "Conditional expression branches must produce the same scalar type.",
+        "Conditional expression branches must produce the same scalar type, but got {thenType} and {elseType}.");
 }

--- a/src/Precept/Dsl/PreceptExpressionEvaluator.cs
+++ b/src/Precept/Dsl/PreceptExpressionEvaluator.cs
@@ -25,6 +25,7 @@ internal static class PreceptExpressionRuntimeEvaluator
             PreceptUnaryExpression unary => EvaluateUnary(unary, context),
             PreceptBinaryExpression binary => EvaluateBinary(binary, context, fieldContracts),
             PreceptFunctionCallExpression fn => EvaluateFunction(fn, context),
+            PreceptConditionalExpression cond => EvaluateConditional(cond, context, fieldContracts),
             _ => EvaluationResult.Fail("unsupported expression node.")
         };
     }
@@ -363,6 +364,23 @@ internal static class PreceptExpressionRuntimeEvaluator
             return rightResult;
 
         return EvaluationResult.Ok(collection.Contains(rightResult.Value));
+    }
+
+    private static EvaluationResult EvaluateConditional(
+        PreceptConditionalExpression cond,
+        IReadOnlyDictionary<string, object?> context,
+        IReadOnlyDictionary<string, PreceptField>? fieldContracts)
+    {
+        var condResult = Evaluate(cond.Condition, context, fieldContracts);
+        if (!condResult.Success)
+            return condResult;
+
+        if (condResult.Value is not bool condBool)
+            return EvaluationResult.Fail("conditional expression condition must be a boolean.");
+
+        return condBool
+            ? Evaluate(cond.ThenBranch, context, fieldContracts)
+            : Evaluate(cond.ElseBranch, context, fieldContracts);
     }
 
     private static EvaluationResult EvaluateFunction(PreceptFunctionCallExpression fn, IReadOnlyDictionary<string, object?> context)

--- a/src/Precept/Dsl/PreceptModel.cs
+++ b/src/Precept/Dsl/PreceptModel.cs
@@ -134,6 +134,9 @@ public sealed record PreceptParenthesizedExpression(PreceptExpression Inner) : P
 /// <summary>General built-in function call: name(arg1, arg2, ...).</summary>
 public sealed record PreceptFunctionCallExpression(string Name, PreceptExpression[] Arguments) : PreceptExpression;
 
+/// <summary>Conditional expression: if &lt;condition&gt; then &lt;thenBranch&gt; else &lt;elseBranch&gt;.</summary>
+public sealed record PreceptConditionalExpression(PreceptExpression Condition, PreceptExpression ThenBranch, PreceptExpression ElseBranch) : PreceptExpression;
+
 public sealed record PreceptSetAssignment(
     string Key,
     string ExpressionText,

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -164,6 +164,10 @@ public static class PreceptParser
                 else
                     msg = $"Could not parse transition row 'from {remaining[1].ToStringValue()} on {remaining[3].ToStringValue()}' — expected '{transitionForm}'";
             }
+            else if (next.Kind == PreceptToken.If)
+            {
+                msg = "'if' is a value expression, not a statement. To conditionally apply a transition row, use 'when' as a guard: from <State> on <Event> when <Condition> -> ...";
+            }
             else if (matchingForms.Count > 0)
             {
                 msg += ". Expected: " + string.Join(" or ", matchingForms.Select(f => $"'{f}'"));

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -312,6 +312,22 @@ public static class PreceptParser
         from _rp in Token.EqualTo(PreceptToken.RightParen)
         select (PreceptExpression)new PreceptParenthesizedExpression(inner);
 
+    // Conditional expression: if <condition> then <value> else <value>
+    private static readonly TokenListParser<PreceptToken, PreceptExpression> ConditionalExpr =
+        (from _if in Token.EqualTo(PreceptToken.If)
+         from condition in Superpower.Parse.Ref(BoolExprRef)
+         from _then in Token.EqualTo(PreceptToken.Then)
+         from thenBranch in Superpower.Parse.Ref(BoolExprRef)
+         from _else in Token.EqualTo(PreceptToken.Else)
+         from elseBranch in Superpower.Parse.Ref(BoolExprRef)
+         select (PreceptExpression)new PreceptConditionalExpression(condition, thenBranch, elseBranch))
+        .Register(new ConstructInfo(
+            "conditional-expression",
+            "if <condition> then <value> else <value>",
+            "expression",
+            "Selects between two values based on a boolean condition. Valid in set RHS, invariant, assert, and guard expressions. Nesting via parentheses: if A then (if B then 1 else 2) else 3.",
+            "from Idle on Apply -> set Label = if Priority > 5 then \"urgent\" else \"normal\" -> no transition"));
+
     // Built-in function call: FunctionName(expr, expr, ...)
     // Function names are identifiers validated against the FunctionRegistry,
     // plus keyword tokens (min/max) that also serve as function names.
@@ -349,6 +365,7 @@ public static class PreceptParser
             .Try().Or(FalseAtom)
             .Try().Or(NullAtom)
             .Try().Or(ParenExpr)
+            .Try().Or(ConditionalExpr)
             .Try().Or(FunctionCallAtom)
             .Or(DottedIdentifier);
 
@@ -807,6 +824,7 @@ public static class PreceptParser
             PreceptBinaryExpression bin => $"{ReconstituteExpr(bin.Left)} {bin.Operator} {ReconstituteExpr(bin.Right)}",
             PreceptParenthesizedExpression paren => $"({ReconstituteExpr(paren.Inner)})",
             PreceptFunctionCallExpression fn => $"{fn.Name}({string.Join(", ", fn.Arguments.Select(ReconstituteExpr))})",
+            PreceptConditionalExpression cond => $"if {ReconstituteExpr(cond.Condition)} then {ReconstituteExpr(cond.ThenBranch)} else {ReconstituteExpr(cond.ElseBranch)}",
             _ => expr.ToString() ?? ""
         };
 

--- a/src/Precept/Dsl/PreceptToken.cs
+++ b/src/Precept/Dsl/PreceptToken.cs
@@ -150,6 +150,21 @@ public enum PreceptToken
     [TokenSymbol("when")]
     When,
 
+    [TokenCategory(TokenCategory.Control)]
+    [TokenDescription("Conditional expression — selects between two values")]
+    [TokenSymbol("if")]
+    If,
+
+    [TokenCategory(TokenCategory.Control)]
+    [TokenDescription("Conditional expression — introduces the true branch")]
+    [TokenSymbol("then")]
+    Then,
+
+    [TokenCategory(TokenCategory.Control)]
+    [TokenDescription("Conditional expression — introduces the false branch")]
+    [TokenSymbol("else")]
+    Else,
+
     [TokenCategory(TokenCategory.Grammar)]
     [TokenDescription("Wildcard for all declared states")]
     [TokenSymbol("any")]

--- a/src/Precept/Dsl/PreceptTypeChecker.cs
+++ b/src/Precept/Dsl/PreceptTypeChecker.cs
@@ -1259,6 +1259,67 @@ internal static class PreceptTypeChecker
             case PreceptFunctionCallExpression fn:
                 return TryInferFunctionCallKind(fn, symbols, out kind, out diagnostic);
 
+            // SYNC:CONSTRAINT:C78
+            // SYNC:CONSTRAINT:C79
+            case PreceptConditionalExpression cond:
+            {
+                // Infer condition type
+                if (!TryInferKind(cond.Condition, symbols, out var condKind, out diagnostic))
+                    return false;
+
+                // C78: condition must be non-nullable boolean
+                if (!IsExactly(condKind, StaticValueKind.Boolean))
+                {
+                    diagnostic = new PreceptValidationDiagnostic(
+                        DiagnosticCatalog.C78,
+                        DiagnosticCatalog.C78.FormatMessage(("actual", FormatKinds(condKind))),
+                        0);
+                    return false;
+                }
+
+                // Null-narrow symbols for then-branch (condition assumed true)
+                var thenSymbols = ApplyNarrowing(cond.Condition, symbols, assumeTrue: true);
+                if (!TryInferKind(cond.ThenBranch, thenSymbols, out var thenKind, out diagnostic))
+                    return false;
+
+                // Else branch uses original symbols (no reverse narrowing)
+                if (!TryInferKind(cond.ElseBranch, symbols, out var elseKind, out diagnostic))
+                    return false;
+
+                // C79: branches must produce compatible scalar types (with integer widening)
+                var thenBase = thenKind & ~StaticValueKind.Null;
+                var elseBase = elseKind & ~StaticValueKind.Null;
+                StaticValueKind resultBase;
+                if (thenBase == elseBase)
+                {
+                    resultBase = thenBase;
+                }
+                else if (IsAssignable(thenBase, elseBase))
+                {
+                    // then-branch widens to else-branch's type (e.g. integer → number)
+                    resultBase = elseBase;
+                }
+                else if (IsAssignable(elseBase, thenBase))
+                {
+                    // else-branch widens to then-branch's type (e.g. integer → number)
+                    resultBase = thenBase;
+                }
+                else
+                {
+                    diagnostic = new PreceptValidationDiagnostic(
+                        DiagnosticCatalog.C79,
+                        DiagnosticCatalog.C79.FormatMessage(
+                            ("thenType", FormatKinds(thenKind)),
+                            ("elseType", FormatKinds(elseKind))),
+                        0);
+                    return false;
+                }
+
+                // Result type is the wider base + Null if either branch is nullable
+                kind = resultBase | ((thenKind | elseKind) & StaticValueKind.Null);
+                return true;
+            }
+
             default:
                 diagnostic = new PreceptValidationDiagnostic(
                     DiagnosticCatalog.C39,

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -1168,6 +1168,85 @@ public class PreceptAnalyzerCompletionTests
             because: "choice type should be offered as collection inner type");
     }
 
+    // ════════════════════════════════════════════════════════════════════
+    // Conditional Expression Completions (if / then / else)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Completions_SetAssignmentExpr_SuggestsIfSnippet()
+    {
+        const string text = """
+            precept M
+            field Status as string default ""
+            state A initial
+            event Go
+            from A on Go -> set Status = $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain(c => c.StartsWith("if", StringComparison.Ordinal),
+            because: "conditional expression must be offered in set-assignment RHS");
+    }
+
+    [Fact]
+    public void Completions_InvariantExpr_SuggestsIfSnippet()
+    {
+        const string text = """
+            precept M
+            field Balance as number default 0
+            state A initial
+            event Go
+            invariant $$
+            from A on Go -> no transition
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain(c => c.StartsWith("if", StringComparison.Ordinal),
+            because: "conditional expression must be offered in invariant body");
+    }
+
+    [Fact]
+    public void Completions_GuardExpr_SuggestsIfSnippet()
+    {
+        const string text = """
+            precept M
+            field Balance as number default 0
+            state A initial
+            event Go with Amount as number
+            from A on Go when $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain(c => c.StartsWith("if", StringComparison.Ordinal),
+            because: "conditional expression must be offered in guard position");
+    }
+
+    [Fact]
+    public void Completions_StatementStart_DoesNotSuggestIfThenElse()
+    {
+        const string text = """
+            precept M
+            field Balance as number default 0
+            state A initial
+            event Go
+            $$
+            from A on Go -> no transition
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().NotContain("if", because: "if is an expression keyword, not a statement keyword");
+        completions.Should().NotContain("then", because: "then is a continuation keyword, not a statement keyword");
+        completions.Should().NotContain("else", because: "else is a continuation keyword, not a statement keyword");
+    }
+
     private static (string text, Position position) ExtractPosition(string textWithMarker)
     {
         var index = textWithMarker.IndexOf("$$", StringComparison.Ordinal);

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerDiagnosticRangeTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerDiagnosticRangeTests.cs
@@ -92,6 +92,33 @@ public class PreceptAnalyzerDiagnosticRangeTests
             "a field declaration error should squiggle the field line, not the precept header");
     }
 
+    [Fact]
+    public void Diagnostics_C78_ConditionalNonBooleanCondition_SquigglesCorrectLine()
+    {
+        // Line 0: precept Test
+        // Line 1: field Score as number default 0
+        // Line 2: field Label as string default ""
+        // Line 3: state A initial
+        // Line 4: state B
+        // Line 5: event Go
+        // Line 6: from A on Go -> set Label = if Score then "high" else "low" -> transition B
+        const string text = """
+            precept Test
+            field Score as number default 0
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if Score then "high" else "low" -> transition B
+            """;
+
+        var diagnostics = Analyze(text);
+
+        diagnostics.Should().ContainSingle();
+        diagnostics[0].Message.Should().Contain("Conditional expression condition must be a non-nullable boolean");
+        diagnostics[0].Range.Start.Line.Should().Be(6);
+    }
+
     private static Diagnostic[] Analyze(string text)
     {
         var analyzer = new PreceptAnalyzer();

--- a/test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs
@@ -140,4 +140,31 @@ public class PreceptSemanticTokensClassificationTests
             t.Type == "preceptState" &&
             t.Modifier == "preceptConstrained");
     }
+
+    [Fact]
+    public void GetClassifiedTokens_ConditionalKeywords_ArePreceptKeywordSemantic()
+    {
+        const string dsl = """
+            precept M
+            field Balance as number default 0
+            field Label as string default ""
+            state Active initial
+            event Go with Amount as number
+            from Active on Go -> set Label = if Amount > 0 then "positive" else "zero" -> no transition
+            """;
+
+        var tokens = PreceptSemanticTokensHandler.GetClassifiedTokens(dsl);
+
+        tokens.Should().Contain(t =>
+            t.Text == "if" &&
+            t.Type == "preceptKeywordSemantic");
+
+        tokens.Should().Contain(t =>
+            t.Text == "then" &&
+            t.Type == "preceptKeywordSemantic");
+
+        tokens.Should().Contain(t =>
+            t.Text == "else" &&
+            t.Type == "preceptKeywordSemantic");
+    }
 }

--- a/test/Precept.Mcp.Tests/CompileToolTests.cs
+++ b/test/Precept.Mcp.Tests/CompileToolTests.cs
@@ -481,4 +481,64 @@ public class CompileToolTests
         unguarded.Should().NotBeNull();
         unguarded!.When.Should().BeNull("an unguarded invariant should have When = null");
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Conditional expressions (issue #9)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Compile_ConditionalExpressionInSetRhs_CompilesCleanly()
+    {
+        var text = """
+            precept Test
+            field Urgent as boolean default false
+            field Priority as number default 1
+            state Open initial
+            state Done
+            event Finish
+            from Open on Finish -> set Priority = if Urgent then 10 else 1 -> transition Done
+            """;
+
+        var result = CompileTool.Run(text);
+
+        result.Valid.Should().BeTrue();
+        result.Diagnostics.Should().BeEmpty();
+        result.Transitions.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Compile_ConditionalNonBooleanCondition_C78Diagnostic()
+    {
+        var text = """
+            precept Test
+            field Label as string default "x"
+            field Priority as number default 1
+            state A initial
+            event Go
+            from A on Go -> set Priority = if Label then 10 else 1 -> no transition
+            """;
+
+        var result = CompileTool.Run(text);
+
+        result.Valid.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Code == "PRECEPT078");
+    }
+
+    [Fact]
+    public void Compile_ConditionalBranchTypeMismatch_C79Diagnostic()
+    {
+        var text = """
+            precept Test
+            field Flag as boolean default true
+            field Value as number default 0
+            state A initial
+            event Go
+            from A on Go -> set Value = if Flag then 10 else "nope" -> no transition
+            """;
+
+        var result = CompileTool.Run(text);
+
+        result.Valid.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Code == "PRECEPT079");
+    }
 }

--- a/test/Precept.Mcp.Tests/FireToolTests.cs
+++ b/test/Precept.Mcp.Tests/FireToolTests.cs
@@ -151,4 +151,62 @@ public class FireToolTests
         result.FromState.Should().Be("Scheduled");
         result.Violations.Should().BeEmpty();
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Conditional expressions (issue #9)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ConditionalSetAssignment_ThenBranch_ProducesCorrectValue()
+    {
+        var text = """
+            precept Test
+            field Urgent as boolean default true
+            field Priority as number default 0
+            state Open initial
+            state Done
+            event Finish
+            from Open on Finish -> set Priority = if Urgent then 10 else 1 -> transition Done
+            """;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["Urgent"] = true,
+            ["Priority"] = 0.0
+        };
+
+        var result = FireTool.Fire(text, "Open", "Finish", data);
+
+        result.Error.Should().BeNull();
+        result.Outcome.Should().Be("Transition");
+        result.ToState.Should().Be("Done");
+        result.Data!["Priority"].Should().Be(10.0);
+    }
+
+    [Fact]
+    public void ConditionalSetAssignment_ElseBranch_ProducesCorrectValue()
+    {
+        var text = """
+            precept Test
+            field Urgent as boolean default false
+            field Priority as number default 0
+            state Open initial
+            state Done
+            event Finish
+            from Open on Finish -> set Priority = if Urgent then 10 else 1 -> transition Done
+            """;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["Urgent"] = false,
+            ["Priority"] = 0.0
+        };
+
+        var result = FireTool.Fire(text, "Open", "Finish", data);
+
+        result.Error.Should().BeNull();
+        result.Outcome.Should().Be("Transition");
+        result.ToState.Should().Be("Done");
+        result.Data!["Priority"].Should().Be(1.0);
+    }
 }

--- a/test/Precept.Mcp.Tests/InspectToolTests.cs
+++ b/test/Precept.Mcp.Tests/InspectToolTests.cs
@@ -368,4 +368,36 @@ from Open on Update -> set Name = Update.NewName -> transition Done
         result.EditableFields!.Select(f => f.Name).Should().Contain("X",
             "when the edit block guard is true, the field should appear in editable fields");
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Conditional expressions (issue #9)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Inspect_ConditionalSetAssignment_ShowsCorrectOutcome()
+    {
+        var text = """
+            precept Test
+            field Urgent as boolean default true
+            field Priority as number default 0
+            state Open initial
+            state Done
+            event Finish
+            from Open on Finish -> set Priority = if Urgent then 10 else 1 -> transition Done
+            """;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["Urgent"] = true,
+            ["Priority"] = 0.0
+        };
+
+        var result = InspectTool.Inspect(text, "Open", data);
+
+        result.Error.Should().BeNull();
+        var finish = result.Events.FirstOrDefault(e => e.Event == "Finish");
+        finish.Should().NotBeNull();
+        finish!.Outcome.Should().Be("Transition");
+        finish.ResultState.Should().Be("Done");
+    }
 }

--- a/test/Precept.Mcp.Tests/LanguageToolTests.cs
+++ b/test/Precept.Mcp.Tests/LanguageToolTests.cs
@@ -170,4 +170,27 @@ public class LanguageToolTests
         deserialized.Should().NotBeNull();
         deserialized!.Vocabulary.ControlKeywords.Should().HaveCount(result.Vocabulary.ControlKeywords.Count);
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Conditional expressions (issue #9)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ControlKeywordsIncludeConditionalExpressionTokens()
+    {
+        var result = LanguageTool.Run();
+
+        result.Vocabulary.ControlKeywords.Should().Contain("if");
+        result.Vocabulary.ControlKeywords.Should().Contain("then");
+        result.Vocabulary.ControlKeywords.Should().Contain("else");
+    }
+
+    [Fact]
+    public void ConstraintsIncludeConditionalExpressionRange()
+    {
+        var result = LanguageTool.Run();
+
+        result.Constraints.Select(c => c.Id)
+            .Should().Contain(["C78", "C79"]);
+    }
 }

--- a/test/Precept.Tests/CatalogDriftTests.cs
+++ b/test/Precept.Tests/CatalogDriftTests.cs
@@ -653,6 +653,14 @@ public class CatalogDriftTests
         ["C77"] = new(H + "field X as number nullable default null\n" + S2 +
             "event Go\nfrom A on Go when abs(X) > 0 -> no transition\n", "nullable"),
 
+        // C78: conditional expression condition must be a non-nullable boolean
+        ["C78"] = new(H + "field X as string default \"\"\n" + S2 +
+            "event Go\nfrom A on Go -> set X = if 42 then \"a\" else \"b\" -> no transition\n", "non-nullable boolean"),
+
+        // C79: conditional expression branches must produce the same scalar type
+        ["C79"] = new(H + "field X as number default 0\n" + S2 +
+            "event Go\nfrom A on Go -> set X = if true then 42 else \"text\" -> no transition\n", "same scalar type"),
+
         // ── Runtime-phase (C33–C37) ───────────────────────────────────
 
         // C33: CreateInstance with empty initial state
@@ -1421,6 +1429,12 @@ public class CatalogDriftTests
 
         // C77: nullable arg — row on line 6
         ["C77"] = ("precept Test\nfield X as number nullable default null\nstate A initial\nstate B\nevent Go\nfrom A on Go when abs(X) > 0 -> no transition\n", "compile", 6),
+
+        // C78: conditional with non-boolean condition — row on line 6
+        ["C78"] = ("precept Test\nfield X as string default \"\"\nstate A initial\nstate B\nevent Go\nfrom A on Go -> set X = if 42 then \"a\" else \"b\" -> no transition\n", "compile", 6),
+
+        // C79: conditional with mismatched branch types — row on line 6
+        ["C79"] = ("precept Test\nfield X as number default 0\nstate A initial\nstate B\nevent Go\nfrom A on Go -> set X = if true then 42 else \"text\" -> no transition\n", "compile", 6),
     };
 
     [Theory]

--- a/test/Precept.Tests/ConditionalExpressionTests.cs
+++ b/test/Precept.Tests/ConditionalExpressionTests.cs
@@ -551,6 +551,81 @@ public class ConditionalExpressionTests
         result2.UpdatedInstance!.InstanceData["Display"].Should().Be("anonymous");
     }
 
+    [Fact]
+    public void Fire_Conditional_WithArithmeticBranches()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field X as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set X = if Flag then X + 10 else X - 5 -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+
+        // Flag = true, X = 100 → 100 + 10 = 110
+        var inst1 = wf.CreateInstance("A", new Dictionary<string, object?> { ["Flag"] = true, ["X"] = 100.0 });
+        var result1 = wf.Fire(inst1, "Go");
+        result1.Outcome.Should().Be(TransitionOutcome.Transition);
+        result1.UpdatedInstance!.InstanceData["X"].Should().Be(110.0);
+
+        // Flag = false, X = 100 → 100 - 5 = 95
+        var inst2 = wf.CreateInstance("A", new Dictionary<string, object?> { ["Flag"] = false, ["X"] = 100.0 });
+        var result2 = wf.Fire(inst2, "Go");
+        result2.Outcome.Should().Be(TransitionOutcome.Transition);
+        result2.UpdatedInstance!.InstanceData["X"].Should().Be(95.0);
+    }
+
+    [Fact]
+    public void Fire_Conditional_InWhenGuard_GatesTransition()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Score as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go when (if Active then Score > 50 else true) -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+
+        // Active = true, Score = 60 → guard is (Score > 50) = true → transitions
+        var inst1 = wf.CreateInstance("A", new Dictionary<string, object?> { ["Active"] = true, ["Score"] = 60.0 });
+        var result1 = wf.Fire(inst1, "Go");
+        result1.Outcome.Should().Be(TransitionOutcome.Transition);
+
+        // Active = true, Score = 30 → guard is (Score > 50) = false → no matching row
+        var inst2 = wf.CreateInstance("A", new Dictionary<string, object?> { ["Active"] = true, ["Score"] = 30.0 });
+        var result2 = wf.Fire(inst2, "Go");
+        result2.Outcome.Should().Be(TransitionOutcome.Unmatched);
+    }
+
+    [Fact]
+    public void Fire_Conditional_IntegerWidensToNumber_CorrectRuntimeValue()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field Value as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Value = if Flag then 42 else 0 -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var inst = wf.CreateInstance("A", new Dictionary<string, object?> { ["Flag"] = true, ["Value"] = 0.0 });
+        var result = wf.Fire(inst, "Go");
+
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["Value"].Should().Be(42L);
+    }
+
     // ════════════════════════════════════════════════════════════════════
     // Statement-Level `if` Misuse Detection Tests
     // ════════════════════════════════════════════════════════════════════

--- a/test/Precept.Tests/ConditionalExpressionTests.cs
+++ b/test/Precept.Tests/ConditionalExpressionTests.cs
@@ -1,0 +1,553 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Precept;
+using Precept.Tests.Infrastructure;
+using Xunit;
+
+namespace Precept.Tests;
+
+/// <summary>
+/// Tests for conditional expressions: if &lt;condition&gt; then &lt;expr&gt; else &lt;expr&gt;.
+/// Covers parser, type checker, and runtime behavior.
+/// </summary>
+public class ConditionalExpressionTests
+{
+    // ════════════════════════════════════════════════════════════════════
+    // Parser Tests
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_SimpleConditional_StringBranches()
+    {
+        var expression = PreceptExpressionTestHelper.ParseFirstSetExpression(
+            "if true then \"yes\" else \"no\"");
+
+        expression.Should().BeOfType<PreceptConditionalExpression>();
+        var cond = (PreceptConditionalExpression)expression;
+        cond.Condition.Should().BeOfType<PreceptLiteralExpression>();
+        ((PreceptLiteralExpression)cond.Condition).Value.Should().Be(true);
+        cond.ThenBranch.Should().BeOfType<PreceptLiteralExpression>();
+        ((PreceptLiteralExpression)cond.ThenBranch).Value.Should().Be("yes");
+        cond.ElseBranch.Should().BeOfType<PreceptLiteralExpression>();
+        ((PreceptLiteralExpression)cond.ElseBranch).Value.Should().Be("no");
+    }
+
+    [Fact]
+    public void Parse_ConditionalWithFieldRefAndComparison()
+    {
+        // Uses a string field so the comparison and identifier work
+        var dsl = """
+            precept Parser
+            field Status as string nullable
+            event Advance
+            state Red initial
+            state Green
+            from Red on Advance -> set Status = if Status != null then Status else "default" -> transition Green
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        model.TransitionRows.Should().ContainSingle();
+        model.TransitionRows![0].SetAssignments.Should().ContainSingle();
+
+        var expr = model.TransitionRows[0].SetAssignments[0].Expression;
+        expr.Should().BeOfType<PreceptConditionalExpression>();
+        var cond = (PreceptConditionalExpression)expr;
+        cond.Condition.Should().BeOfType<PreceptBinaryExpression>();
+        ((PreceptBinaryExpression)cond.Condition).Operator.Should().Be("!=");
+        cond.ThenBranch.Should().BeOfType<PreceptIdentifierExpression>();
+        cond.ElseBranch.Should().BeOfType<PreceptLiteralExpression>();
+    }
+
+    [Fact]
+    public void Parse_NestedConditionalViaParens()
+    {
+        var expression = PreceptExpressionTestHelper.ParseFirstSetExpression(
+            "if true then (if false then 1 else 2) else 3");
+
+        expression.Should().BeOfType<PreceptConditionalExpression>();
+        var outer = (PreceptConditionalExpression)expression;
+        outer.ThenBranch.Should().BeOfType<PreceptParenthesizedExpression>();
+        var inner = ((PreceptParenthesizedExpression)outer.ThenBranch).Inner;
+        inner.Should().BeOfType<PreceptConditionalExpression>();
+        var nested = (PreceptConditionalExpression)inner;
+        nested.Condition.Should().BeOfType<PreceptLiteralExpression>();
+        ((PreceptLiteralExpression)nested.Condition).Value.Should().Be(false);
+    }
+
+    [Fact]
+    public void Parse_ConditionalInSetRHS_WithinFullPrecept()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if Active then "on" else "off" -> transition B
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        model.TransitionRows.Should().ContainSingle();
+        var setExpr = model.TransitionRows![0].SetAssignments[0].Expression;
+        setExpr.Should().BeOfType<PreceptConditionalExpression>();
+    }
+
+    [Fact]
+    public void Parse_ConditionalInInvariant()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Score as number default 10
+            invariant (if Active then Score > 0 else true) because "active needs score"
+            state A initial
+            event Go
+            from A on Go -> no transition
+            """;
+
+        var (model, diags) = PreceptParser.ParseWithDiagnostics(dsl);
+        diags.Should().BeEmpty();
+        model.Should().NotBeNull();
+        model!.Invariants.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Parse_ConditionalInWhenGuard()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Score as number default 10
+            state A initial
+            state B
+            event Go
+            from A on Go when (if Active then Score > 5 else true) -> transition B
+            from A on Go -> reject "blocked"
+            """;
+
+        var (model, diags) = PreceptParser.ParseWithDiagnostics(dsl);
+        diags.Should().BeEmpty();
+        model.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Parse_ConditionalWithArithmeticBranches()
+    {
+        var dsl = """
+            precept Parser
+            field Flag as boolean default true
+            field X as number default 5
+            event Advance
+            state Red initial
+            state Green
+            from Red on Advance -> set X = if Flag then X + 1 else X - 1 -> transition Green
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+        var expr = model.TransitionRows![0].SetAssignments[0].Expression;
+        expr.Should().BeOfType<PreceptConditionalExpression>();
+        var cond = (PreceptConditionalExpression)expr;
+        cond.ThenBranch.Should().BeOfType<PreceptBinaryExpression>();
+        ((PreceptBinaryExpression)cond.ThenBranch).Operator.Should().Be("+");
+        cond.ElseBranch.Should().BeOfType<PreceptBinaryExpression>();
+        ((PreceptBinaryExpression)cond.ElseBranch).Operator.Should().Be("-");
+    }
+
+    [Fact]
+    public void Parse_ConditionalWithBooleanBranches()
+    {
+        var expression = PreceptExpressionTestHelper.ParseFirstSetExpression(
+            "if true then true else false");
+
+        expression.Should().BeOfType<PreceptConditionalExpression>();
+        var cond = (PreceptConditionalExpression)expression;
+        cond.ThenBranch.Should().BeOfType<PreceptLiteralExpression>();
+        ((PreceptLiteralExpression)cond.ThenBranch).Value.Should().Be(true);
+        cond.ElseBranch.Should().BeOfType<PreceptLiteralExpression>();
+        ((PreceptLiteralExpression)cond.ElseBranch).Value.Should().Be(false);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Type Checker Tests
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void TypeCheck_ValidConditional_BooleanCondition_MatchingStringBranches_NoDiagnostics()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if Active then "on" else "off" -> transition B
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeCheck_C78_NonBooleanCondition_Number()
+    {
+        const string dsl = """
+            precept Test
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if 42 then "a" else "b" -> no transition
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().ContainSingle();
+        result.Diagnostics[0].Constraint.Id.Should().Be("C78");
+    }
+
+    [Fact]
+    public void TypeCheck_C78_NonBooleanCondition_String()
+    {
+        const string dsl = """
+            precept Test
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if "text" then "a" else "b" -> no transition
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().ContainSingle();
+        result.Diagnostics[0].Constraint.Id.Should().Be("C78");
+    }
+
+    [Fact]
+    public void TypeCheck_C78_NullableBooleanCondition()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean nullable
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if Flag then "a" else "b" -> no transition
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().ContainSingle();
+        result.Diagnostics[0].Constraint.Id.Should().Be("C78");
+    }
+
+    [Fact]
+    public void TypeCheck_C79_BranchTypeMismatch_StringVsNumber()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set X = if true then 42 else "text" -> no transition
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().ContainSingle();
+        result.Diagnostics[0].Constraint.Id.Should().Be("C79");
+    }
+
+    [Fact]
+    public void TypeCheck_C79_BranchTypeMismatch_BooleanVsString()
+    {
+        const string dsl = """
+            precept Test
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if true then true else "text" -> no transition
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().ContainSingle();
+        result.Diagnostics[0].Constraint.Id.Should().Be("C79");
+    }
+
+    [Fact]
+    public void TypeCheck_NullNarrowing_ThenBranchSeesNonNullableField()
+    {
+        const string dsl = """
+            precept Test
+            field Name as string nullable
+            field Display as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Display = if Name != null then Name else "anonymous" -> transition B
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        // No C42 null-flow violation — Name is narrowed to non-nullable in then-branch
+        result.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeCheck_NestedConditional_TypeConsistency()
+    {
+        const string dsl = """
+            precept Test
+            field A as boolean default true
+            field B as boolean default false
+            field X as number default 0
+            state S initial
+            state T
+            event Go
+            from S on Go -> set X = if A then (if B then 1 else 2) else 3 -> transition T
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeCheck_ConditionalWithFunctionCallInBranch()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field X as number default 5
+            field Y as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Y = if Flag then abs(X) else 0.0 -> transition B
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeCheck_IntegerWidensToNumber_InConditionalBranches()
+    {
+        // abs() returns number, 0 is integer — widening should accept this
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field X as number default 5
+            field Y as number default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Y = if Flag then abs(X) else 0 -> transition B
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeCheck_IntegerWidensToDecimal_InConditionalBranches()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field Price as decimal default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Price = if Flag then Price else 0 -> transition B
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TypeCheck_NumberVsDecimal_StillC79Error()
+    {
+        // number ↔ decimal is NOT lossless — should remain a hard error
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field Y as decimal default 0
+            field Flag as boolean default true
+            field Result as number default 0
+            state A initial
+            event Go
+            from A on Go -> set Result = if Flag then X else Y -> no transition
+            """;
+
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        result.Diagnostics.Should().ContainSingle();
+        result.Diagnostics[0].Constraint.Id.Should().Be("C79");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime Tests (end-to-end with PreceptEngine)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Fire_SetWithConditional_CorrectDataInInstance()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Label as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Label = if Active then "on" else "off" -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var inst = wf.CreateInstance("A", new Dictionary<string, object?> { ["Active"] = true, ["Label"] = "" });
+        var result = wf.Fire(inst, "Go");
+
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["Label"].Should().Be("on");
+    }
+
+    [Fact]
+    public void Fire_Conditional_EvaluatesTrueBranch()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field Result as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Result = if Flag then "true-path" else "false-path" -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var inst = wf.CreateInstance("A", new Dictionary<string, object?> { ["Flag"] = true, ["Result"] = "" });
+        var result = wf.Fire(inst, "Go");
+
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["Result"].Should().Be("true-path");
+    }
+
+    [Fact]
+    public void Fire_Conditional_EvaluatesFalseBranch()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field Result as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Result = if Flag then "true-path" else "false-path" -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var inst = wf.CreateInstance("A", new Dictionary<string, object?> { ["Flag"] = false, ["Result"] = "" });
+        var result = wf.Fire(inst, "Go");
+
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["Result"].Should().Be("false-path");
+    }
+
+    [Fact]
+    public void Fire_Conditional_WithComparisonAsCondition()
+    {
+        const string dsl = """
+            precept Test
+            field Score as number default 0
+            field Grade as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Grade = if Score >= 50 then "pass" else "fail" -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var inst = wf.CreateInstance("A", new Dictionary<string, object?> { ["Score"] = 75.0, ["Grade"] = "" });
+        var result = wf.Fire(inst, "Go");
+
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["Grade"].Should().Be("pass");
+    }
+
+    [Fact]
+    public void Fire_NestedConditional_CorrectValue()
+    {
+        const string dsl = """
+            precept Test
+            field A as boolean default true
+            field B as boolean default false
+            field X as number default 0
+            state S initial
+            state T
+            event Go
+            from S on Go -> set X = if A then (if B then 10 else 20) else 30 -> transition T
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        var inst = wf.CreateInstance("S", new Dictionary<string, object?>
+        {
+            ["A"] = true, ["B"] = false, ["X"] = 0.0
+        });
+        var result = wf.Fire(inst, "Go");
+
+        result.Outcome.Should().Be(TransitionOutcome.Transition);
+        result.UpdatedInstance!.InstanceData["X"].Should().Be(20.0);
+    }
+
+    [Fact]
+    public void Fire_InvariantWithConditional_ValidatesCorrectly()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            field Score as number default 10
+            invariant (if Active then Score > 0 else true) because "active needs score"
+            state A initial
+            state B
+            event Go with NewScore as number
+            from A on Go -> set Score = Go.NewScore -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        // Active = true, Score set to 0 should violate
+        var inst = wf.CreateInstance("A", new Dictionary<string, object?> { ["Active"] = true, ["Score"] = 10.0 });
+        var result = wf.Fire(inst, "Go", new Dictionary<string, object?> { ["NewScore"] = 0.0 });
+
+        result.Outcome.Should().Be(TransitionOutcome.ConstraintFailure);
+        result.Violations.Should().ContainSingle().Which.Message.Should().Be("active needs score");
+    }
+
+    [Fact]
+    public void Fire_ConditionalWithNullNarrowing_ProducesCorrectValue()
+    {
+        const string dsl = """
+            precept Test
+            field Name as string nullable
+            field Display as string default ""
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Display = if Name != null then Name else "anonymous" -> transition B
+            """;
+
+        var wf = PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+
+        // Name is non-null — should use Name
+        var inst1 = wf.CreateInstance("A", new Dictionary<string, object?> { ["Name"] = "Alice", ["Display"] = "" });
+        var result1 = wf.Fire(inst1, "Go");
+        result1.Outcome.Should().Be(TransitionOutcome.Transition);
+        result1.UpdatedInstance!.InstanceData["Display"].Should().Be("Alice");
+
+        // Name is null — should use "anonymous"
+        var inst2 = wf.CreateInstance("A", new Dictionary<string, object?> { ["Name"] = null, ["Display"] = "" });
+        var result2 = wf.Fire(inst2, "Go");
+        result2.Outcome.Should().Be(TransitionOutcome.Transition);
+        result2.UpdatedInstance!.InstanceData["Display"].Should().Be("anonymous");
+    }
+}

--- a/test/Precept.Tests/ConditionalExpressionTests.cs
+++ b/test/Precept.Tests/ConditionalExpressionTests.cs
@@ -550,4 +550,47 @@ public class ConditionalExpressionTests
         result2.Outcome.Should().Be(TransitionOutcome.Transition);
         result2.UpdatedInstance!.InstanceData["Display"].Should().Be("anonymous");
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Statement-Level `if` Misuse Detection Tests
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_StatementLevelIf_ProducesRedirectToWhen()
+    {
+        const string dsl = """
+            precept Test
+            field Flag as boolean default true
+            field X as number default 0
+            state A initial
+            state B
+            event Go
+            if Flag -> set X = 1 -> transition B
+            """;
+
+        var (model, diags) = PreceptParser.ParseWithDiagnostics(dsl);
+        model.Should().BeNull();
+        diags.Should().ContainSingle();
+        diags[0].Message.Should().Contain("if");
+        diags[0].Message.Should().Contain("value expression");
+        diags[0].Message.Should().Contain("when");
+    }
+
+    [Fact]
+    public void Parse_StatementLevelIf_ErrorMessageIsActionable()
+    {
+        const string dsl = """
+            precept Test
+            field Active as boolean default true
+            state A initial
+            event Go
+            if Active -> transition A
+            """;
+
+        var (model, diags) = PreceptParser.ParseWithDiagnostics(dsl);
+        model.Should().BeNull();
+        diags.Should().ContainSingle();
+        diags[0].Message.Should().Be(
+            "'if' is a value expression, not a statement. To conditionally apply a transition row, use 'when' as a guard: from <State> on <Event> when <Condition> -> ...");
+    }
 }

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -1032,6 +1032,9 @@ internal sealed class PreceptAnalyzer
             if (!symbol.All(char.IsLetter)) continue;
             if (category is TokenCategory.Structure or TokenCategory.Value) continue;
 
+            // Exclude continuation-only keywords that are never valid standalone
+            if (symbol is "then" or "else") continue;
+
             items.Add(new CompletionItem
             {
                 Label = symbol,
@@ -1078,6 +1081,9 @@ internal sealed class PreceptAnalyzer
             if (category is null || symbol is null) continue;
             if (!symbol.All(char.IsLetter)) continue;
             if (!topLevelCategories.Contains(category.Value)) continue;
+
+            // Exclude expression-only control keywords from statement-start completions
+            if (symbol is "if" or "then" or "else") continue;
 
             items.Add(new CompletionItem
             {
@@ -1127,7 +1133,9 @@ internal sealed class PreceptAnalyzer
         FunctionSnippetItem("trim(expr)", "trim(${1:expr})", "Remove leading/trailing whitespace"),
         FunctionSnippetItem("left(str, count)", "left(${1:str}, ${2:count})", "First N characters (clamping)"),
         FunctionSnippetItem("right(str, count)", "right(${1:str}, ${2:count})", "Last N characters"),
-        FunctionSnippetItem("mid(str, start, count)", "mid(${1:str}, ${2:start}, ${3:count})", "Substring from position (1-indexed)")
+        FunctionSnippetItem("mid(str, start, count)", "mid(${1:str}, ${2:start}, ${3:count})", "Substring from position (1-indexed)"),
+        // Conditional expression
+        SnippetItem("if ... then ... else", "if ${1:condition} then ${2:value} else ${3:value}", "Conditional expression")
     ];
 
     internal static readonly IReadOnlyList<CompletionItem> LiteralItems =

--- a/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
+++ b/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
@@ -404,7 +404,7 @@
       "patterns": [
         {
           "name": "keyword.control.precept",
-          "match": "\\bwhen\\b"
+          "match": "\\b(when|if|then|else)\\b"
         }
       ]
     },


### PR DESCRIPTION
## What this does

Adds conditional expressions (`if condition then value else value`) to the Precept DSL, enabling inline value branching within `set` assignments, invariants, state/event asserts, and guard expressions. Both branches are type-checked at compile time; the `else` branch is always required. This provides a clean separation from `when` (structural guard) vs `if` (value expression).

Additionally implements integer widening in conditional branches: when one branch is `integer` and the other is `number` or `decimal`, the result widens to the broader type (lossless subset relationship). `number` ↔ `decimal` remains a hard C79 error.

Closes #9

## Implementation notes

- **Diagnostic codes:** C78/C79 (not C72/C73 as in the original proposal — those were already assigned to function diagnostics)
- **Integer widening in C79:** After Frank's architectural review confirmed integer widening is philosophically sound (lossless, compile-time-provable subset relationship), the C79 check uses `IsAssignable`-based unification instead of strict base-type equality. The design doc's widening scope was broadened from "mixed arithmetic" to a general compatibility rule.
- **AC-9 (inspect trace) deferred:** Filed as issue #80 — adding `conditionResult`/`branchTaken` to inspect would be the first case of reporting intermediate expression evaluation, and needs a cohesive design across all expression contexts (guards, set values, invariants). Added to M3 milestone.
- **Statement-level `if` redirect (AC-4):** Parser error recovery detects `if` at statement level and emits: "'if' is a value expression, not a statement. To conditionally apply a transition row, use 'when' as a guard."

## Implementation checklist

### Parser (tokens + tokenizer + combinator + model)

- [x] `PreceptToken` enum: add `If`, `Then`, `Else` members with `[TokenCategory(TokenCategory.Control)]`, `[TokenDescription]`, and `[TokenSymbol]` attributes
- [x] Tokenizer: automatic — picked up via `PreceptTokenMeta.BuildKeywordDictionary()` reflection
- [x] Model: `PreceptConditionalExpression(Condition, ThenBranch, ElseBranch) : PreceptExpression`
- [x] Parser: `ConditionalExpr` combinator in `Atom` chain (after `ParenExpr`, before `FunctionCallAtom`)
- [x] Parser: nesting via parentheses — works automatically through `ParenExpr → BoolExprRef` recursion
- [x] Parser: `ConstructInfo` registered as `"conditional-expression"`
- [x] Parser: statement-level `if` misuse — redirects to `when` (AC-4)

### Type checker

- [x] `DiagnosticCatalog.cs`: C78 and C79 registered
- [x] `TryInferKind`: `PreceptConditionalExpression` case with `IsAssignable`-based branch unification
- [x] C78 fires for non-boolean and nullable boolean conditions
- [x] C79 fires for incompatible branch types (integer widening accepted; number↔decimal hard error)
- [x] Null-narrowing in `then` branch; original types in `else` branch
- [x] `SYNC:CONSTRAINT:C78` and `SYNC:CONSTRAINT:C79` comments

### Runtime evaluator

- [x] `EvaluateConditional`: evaluate condition → select branch → return result
- [x] Non-boolean/null condition → `EvaluationResult.Fail`
- [x] Pure expression, no side effects

### Language server

- [x] `if` in expression-position completions; excluded from statement-level positions
- [x] `then`/`else` not in general keyword completions
- [x] Statement-level `if` redirect via parser error recovery
- [x] Semantic tokens: automatic via `[TokenCategory(Control)]`

### Grammar

- [x] `if|then|else` in `controlKeywords` pattern
- [x] Pattern ordering verified

### MCP

- [x] `precept_language` vocabulary: automatic
- [x] `precept_compile` serialization: automatic via expression reconstitution
- [N/A] `precept_inspect` trace: deferred → #80
- [x] `ConstructCatalog`: automatic

### Tests (1,335 total — all passing)

- [x] 10 parser tests (8 positive + 2 AC-4 redirect)
- [x] 12 type checker tests (incl. 3 widening: integer→number, integer→decimal, number↔decimal hard error)
- [x] 7 runtime tests (end-to-end with PreceptEngine)
- [x] 5 LS tests (completions + semantic tokens)
- [x] 8 MCP tests (compile, fire, inspect, language)
- [x] Catalog drift entries (C78, C79 triggers + line accuracy)

### Samples (5 updated, all zero diagnostics)

- [x] hiring-pipeline, subscription-cancellation-retention, insurance-claim, loan-application, event-registration

### Documentation

- [x] `PreceptLanguageDesign.md`: conditional expressions section, widening scope broadened, C78/C79 documented, exclusions noted
- [x] `README.md`: feature bullet added

## Known gaps

- **AC-9 inspect trace** — deferred to #80. Requires cohesive design for intermediate expression evaluation across all expression contexts.
- **Negative parser tests** (missing `else`, bare `if`) — implicitly covered by parser combinator structure but no explicit negative tests.

## Critical review focus

1. **Integer widening in C79:** `IsAssignable`-based unification replaces strict base-type equality. Verify symmetry and that number↔decimal correctly remains a hard error.
2. **Null-narrowing scoping:** `then` branch narrows; `else` retains originals. Verify no leakage across conditional boundary.
3. **AC-4 redirect message:** Clear and actionable for both humans and AI agents.
4. **Design doc widening scope:** Broadened from "mixed arithmetic" to general compatibility rule — verify accuracy.