### PR TITLE
chore: harden squad and copilot workflow hygiene

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -843,6 +843,10 @@ prompt: |
   The user says: "{message}"
   
   Do the work. Respond as {Name}.
+  For issue-based implementation work, treat the draft PR as the live execution hub.
+  Work in vertical slices. After each completed slice or logical group, commit,
+  push, and update the PR-body implementation checklist before continuing.
+  Do not create a separate implementation-plan markdown file.
   
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,6 +49,17 @@ npm run loop:local     # Package + install locally (also a VS Code task)
 
 Keep `tools/Precept.Plugin/.mcp.json` in shipped `dotnet tool run precept-mcp` form. That plugin file uses its own `mcpServers` payload schema. Use `.vscode/mcp.json` for repo-local MCP development with the VS Code `servers` schema, `.github/agents/` and `.github/skills/` as the workspace-native customization source, and treat plugin/distribution-shaped validation as explicit validation, not the default inner loop.
 
+## Issue Implementation Workflow
+
+For issue-based implementation work:
+
+- Read `CONTRIBUTING.md` before starting.
+- Open or reuse the linked **draft PR** immediately and treat it as the execution hub for the issue.
+- Put the implementation plan in the **PR body** as a checkbox checklist and keep it updated as work progresses.
+- Work in vertical slices. After each completed slice, commit, push, and update the PR-body checklist before continuing.
+- Link the PR to the issue with `Closes #N`.
+- Do **not** create a separate implementation-plan markdown file; the PR body is the ephemeral plan artifact for this repo.
+
 ## Use the MCP Tools First
 
 This project ships a Precept MCP server with 5 tools. **Use them as your primary research tools** before reading source code or making assumptions about the DSL:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,19 @@
 ## Summary
 
-- 
+- ...
 
 ## Linked Issue
 
 - Closes #
+
+## Implementation Plan
+
+> Replace these placeholders with issue-specific vertical slices. Keep this checklist in the PR body and update it after each completed slice.
+
+- [ ] Slice 1 — ...
+- [ ] Slice 2 — ...
+- [ ] Docs and surface sync — ...
+- [ ] Validation — ...
 
 ## Docs Sync
 
@@ -13,11 +22,11 @@
 
 ### Docs touched
 
-- 
+- ...
 
 ### If no docs changed, why not?
 
-- 
+- ...
 
 ## Precept-Specific Sync Checklist
 
@@ -37,4 +46,4 @@
 
 ### Validation notes
 
-- 
+- ...

--- a/.github/workflows/pr-implementation-hygiene.yml
+++ b/.github/workflows/pr-implementation-hygiene.yml
@@ -1,0 +1,83 @@
+name: PR Implementation Hygiene
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check linked issue and implementation plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const headRef = pr.head.ref || '';
+
+            const issueBranchPattern = /^(copilot\/|squad\/|feature\/issue-\d+)/i;
+            const issueLinkPattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#\d+\b/i;
+            const separatePlanPattern = /(^|\/)implementation[-_ ]plan[^/]*\.md$/i;
+
+            const isIssueFlow = issueBranchPattern.test(headRef) || issueLinkPattern.test(body);
+            if (!isIssueFlow) {
+              core.info('PR is not using the issue-driven squad/copilot flow; skipping implementation hygiene checks.');
+              return;
+            }
+
+            const errors = [];
+
+            if (!issueLinkPattern.test(body)) {
+              errors.push('PR body must link the issue with `Closes #N`, `Fixes #N`, or `Resolves #N`.');
+            }
+
+            const implementationSectionMatch = body.match(/##\s+Implementation Plan\b([\s\S]*?)(?:\n##\s+|$)/i);
+            if (!implementationSectionMatch) {
+              errors.push('PR body must include a `## Implementation Plan` section.');
+            }
+
+            const implementationSection = implementationSectionMatch ? implementationSectionMatch[1] : '';
+            const checklistItems = implementationSection.match(/^- \[[ xX]\] .+/gm) || [];
+            const checkedItems = implementationSection.match(/^- \[[xX]\] .+/gm) || [];
+            const uncheckedItems = implementationSection.match(/^- \[ \] .+/gm) || [];
+
+            if (implementationSectionMatch && checklistItems.length === 0) {
+              errors.push('The `## Implementation Plan` section must contain markdown checkbox items.');
+            }
+
+            if (pr.draft && pr.commits >= 2 && checkedItems.length === 0) {
+              errors.push('Draft PR has multiple commits but no completed implementation-plan items checked off yet. Update the PR body as slices land.');
+            }
+
+            if (!pr.draft && uncheckedItems.length > 0) {
+              errors.push('Ready-for-review PR still has unchecked implementation-plan items. Finish them or consciously remove them before review.');
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const separatePlanFiles = files
+              .map(file => file.filename)
+              .filter(filename => separatePlanPattern.test(filename));
+
+            if (separatePlanFiles.length > 0) {
+              errors.push(
+                `Remove separate implementation-plan markdown files from the PR: ${separatePlanFiles.join(', ')}. Use the PR body as the plan instead.`
+              );
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(errors.map((error, index) => `${index + 1}. ${error}`).join('\n'));
+              return;
+            }
+
+            core.notice('Implementation hygiene checks passed.');

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -158,7 +158,7 @@ jobs:
                     agent_assignment: {
                       target_repo: `${context.repo.owner}/${context.repo.repo}`,
                       base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md (or .ai-team/team.md) for team context and .squad/routing.md (or .ai-team/routing.md) for routing rules.`
+                      custom_instructions: `Read CONTRIBUTING.md, .github/copilot-instructions.md, .squad/team.md (or .ai-team/team.md), and .squad/routing.md (or .ai-team/routing.md) first. For implementation issues, open or use the draft PR linked to the issue immediately and treat it as the execution hub. Put the implementation plan in the PR body as a checkbox checklist, work in vertical slices, and after each completed slice commit, push, and update the PR-body checklist before continuing. Link the PR with Closes #N, and do not create a separate implementation-plan markdown file. Use the repository-configured Precept MCP server when available, and prefer the Precept MCP tools before source inspection.`
                     }
                   });
                   core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -85,9 +85,9 @@ jobs:
                 '',
                 `**Issue:** #${issue.number} — ${issue.title}`,
                 '',
-                `@copilot has been assigned and will pick this up automatically.`,
+                `@copilot has been routed for automatic pickup.`,
                 '',
-                `> The coding agent will create a \`copilot/*\` branch and open a draft PR.`,
+                `> The workflow will now attempt coding-agent assignment and create a \`copilot/*\` branch on success.`,
                 `> Review the PR as you would any team member's work.`,
               ].join('\n');
             } else {
@@ -137,7 +137,7 @@ jobs:
                 agent_assignment: {
                   target_repo: `${owner}/${repo}`,
                   base_branch: baseBranch,
-                  custom_instructions: '',
+                  custom_instructions: 'Read CONTRIBUTING.md, .github/copilot-instructions.md, .squad/team.md, and .squad/routing.md first. For implementation issues, open or use the draft PR linked to the issue immediately and treat it as the execution hub. Put the implementation plan in the PR body as a checkbox checklist, work in vertical slices, and after each completed slice commit, push, and update the PR-body checklist before continuing. Link the PR with Closes #N, and do not create a separate implementation-plan markdown file. Use the repository-configured Precept MCP server when available, and prefer the Precept MCP tools before source inspection.',
                   custom_agent: '',
                   model: ''
                 },
@@ -157,5 +157,21 @@ jobs:
                 core.info(`Fallback assigned copilot-swe-agent to issue #${issue_number}`);
               } catch (err2) {
                 core.warning(`Fallback also failed: ${err2.message}`);
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: [
+                    '### ⚠️ @copilot assignment failed',
+                    '',
+                    'The routing workflow recognized this as `squad:copilot`, but the coding-agent assignment API call failed.',
+                    '',
+                    `Primary error: ${err.message}`,
+                    `Fallback error: ${err2.message}`,
+                    '',
+                    '> Check the workflow token configuration and retry the assignment.'
+                  ].join('\n')
+                });
+                throw err2;
               }
             }

--- a/.squad/agents/newman/history.md
+++ b/.squad/agents/newman/history.md
@@ -16,6 +16,8 @@
 ### 2026-04-10 — Issue #31 shipped
 - PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
 
+### Issue #31 Slice 6 — Operator Inventory (2026-04-10)
+
 ### Issue #27/#25/#29 Slice 6 — MCP Vocabulary + Spec (2026-04-11)
 
 - `LanguageTool.cs` needed zero code changes for `integer`/`decimal`/`choice`/`maxplaces`/`ordered`. All five tokens already existed in `PreceptToken` with correct `TokenCategory` attributes — the catalog-driven vocabulary mechanism picked them up automatically.

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -35,13 +35,28 @@ How to decide who handles what.
 |-------|--------|-----|
 | `squad` | Triage: analyze issue, assign `squad:{member}` label | Lead |
 | `squad:{name}` | Pick up issue and complete the work | Named member |
+| `squad:copilot` | Pick up issue and complete the work autonomously | @copilot |
 
 ### How Issue Assignment Works
 
 1. When a GitHub issue gets the `squad` label, the **Lead** triages it — analyzing content, assigning the right `squad:{member}` label, and commenting with triage notes.
-2. When a `squad:{member}` label is applied, that member picks up the issue in their next session.
-3. Members can reassign by removing their label and adding another member's label.
+2. When a `squad:{member}` label is applied, that member picks up the issue in their next session. When `squad:copilot` is applied, the coding agent picks it up asynchronously.
+3. Members can reassign by removing their label and adding another member's label, including `squad:copilot` when the issue fits the coding agent capability profile.
 4. The `squad` label marks the shared backlog entry point — issues waiting for Lead triage and board placement.
+5. Small explicit chore issues that clearly fit the coding-agent capability profile may skip base `squad` triage and be created directly with `squad:copilot`.
+6. When an `@copilot` PR is marked ready for review, the PR Review ceremony runs before human approval and merge.
+7. Normal review feedback on an `@copilot` PR routes back to `@copilot`. Hard reviewer rejection transfers ownership to a different squad member under the lockout rules.
+
+### `squad:copilot` Routing Criteria
+
+Route directly to `squad:copilot` only when the issue is all of the following:
+
+1. Bounded to a small chore, bug fix, cleanup, or narrowly scoped improvement
+2. Backed by clear reproduction steps, acceptance criteria, or an obvious existing pattern to follow
+3. Limited enough that one PR can complete it without cross-team coordination
+4. Verifiable with the repository's existing validation path
+
+Do **not** route directly to `squad:copilot` when the issue changes product philosophy, DSL semantics, parser/runtime behavior, syntax grammar, language-server completions, MCP contracts, security-sensitive behavior, or any cross-cutting design/architecture boundary. Route those through the normal Lead triage path instead.
 
 ## Rules
 

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -24,6 +24,54 @@
 | Scribe | Session Logger | `.squad/agents/scribe/charter.md` | 🟢 Active |
 | Ralph | Work Monitor | — | 🔄 Monitor |
 
+## Coding Agent
+
+<!-- copilot-auto-assign: true -->
+
+| Name | Role | Charter | Status |
+|------|------|---------|--------|
+| @copilot | Coding Agent | — | 🤖 Coding Agent |
+
+### Capabilities
+
+**🟢 Good fit — auto-route when enabled:**
+- Bug fixes with clear reproduction steps
+- Test coverage (adding missing tests, fixing flaky tests)
+- Lint/format fixes and code style cleanup
+- Dependency updates and version bumps
+- Small isolated features with clear specs and established implementation patterns
+- Boilerplate/scaffolding generation
+- Documentation fixes and README updates
+- Narrow tooling or workflow fixes that stay within an existing pattern
+
+**🟡 Needs review — route to @copilot but flag for squad member PR review:**
+- Medium features with clear specs and acceptance criteria
+- Refactoring with existing test coverage
+- API endpoint additions following established patterns
+- Migration scripts with well-defined schemas
+- Changes that touch multiple files but remain low-ambiguity and pattern-following
+
+**🔴 Not suitable — route to squad member instead:**
+- Architecture decisions and system design
+- Multi-system integration requiring coordination
+- Ambiguous requirements needing clarification
+- Security-critical changes (auth, encryption, access control)
+- Performance-critical paths requiring benchmarking
+- Changes requiring cross-team discussion
+- Product philosophy or positioning changes
+- DSL surface, parser, runtime semantics, or constraint-model changes
+- Syntax grammar, language-server completion, or MCP contract changes
+- Work that needs new design direction instead of following an established pattern
+
+### Workflow
+
+- Small explicit chore issues that clearly fit the coding-agent profile may be created directly with the `squad:copilot` label.
+- Use direct `squad:copilot` routing only for bounded, low-ambiguity work with clear acceptance criteria and an existing pattern to follow.
+- Keep philosophy, language-surface, runtime-semantics, MCP-contract, security-sensitive, and cross-cutting design work on the normal squad triage path.
+- `@copilot` picks up those issues automatically, opens the PR, and keeps ownership through normal review feedback.
+- When the PR is marked ready for review, the squad PR Review ceremony runs.
+- Shane handles final approval and merge.
+
 ## Human Members
 
 | Name | Role | Badge | Status | Notes |

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -139,8 +139,18 @@ cd ../worktrees/{issue-number}
 
 **Actions:**
 1. Agent makes code changes
-2. Commits reference the issue number
-3. Pushes branch to remote
+2. Updates the draft PR body's implementation checklist after each completed slice or logical group
+3. Commits reference the issue number
+4. Pushes branch to remote
+
+**Slice loop:**
+
+For active implementation work, repeat this loop throughout the PR instead of waiting until the end:
+
+1. Finish one vertical slice or logical group
+2. Check off the corresponding implementation-plan items in the draft PR body
+3. Commit the completed slice
+4. Push the branch
 
 **Commit message format:**
 ```
@@ -169,8 +179,9 @@ git push -u origin squad/{issue-number}-{slug}
 **Actions:**
 1. Open PR from feature branch to base branch
 2. Reference issue in PR description
-3. Apply labels if needed
-4. Transition issue to `In Review`
+3. Seed the PR body with the implementation checklist if it is not already present
+4. Apply labels if needed
+5. Transition issue to `In Review`
 
 **PR creation commands:**
 


### PR DESCRIPTION
## Summary

- add a PR implementation hygiene workflow for issue-driven Squad and @copilot PRs
- seed the PR template with an implementation-plan checklist in the PR body
- tighten direct `squad:copilot` routing criteria and sync autonomous handoff instructions
- carry the same slice-by-slice commit/push/checklist rule into interactive Squad governance

## Linked Issue

- None

## Docs Sync

- [x] I updated all relevant docs in the same PR
- [ ] No doc updates were needed, and I explained why below

### Docs touched

- `.github/copilot-instructions.md`
- `.squad/routing.md`
- `.squad/team.md`
- `.squad/templates/issue-lifecycle.md`
- `.github/agents/squad.agent.md`

### If no docs changed, why not?

- n/a

## Validation

- [x] Workflow and template changes reviewed locally
- [ ] `dotnet build`
- [ ] `dotnet test`

### Validation notes

- No runtime or product code changed in this PR.