### PR TITLE
feat: guarded root-level edit — `edit <Fields> when <Guard>` (#84)

### DIFF
--- a/docs/EditableFieldsDesign.md
+++ b/docs/EditableFieldsDesign.md
@@ -116,14 +116,27 @@ edit all
 
 # Specific fields are editable
 edit Field1, Field2
+
+# Conditional editability with guards
+edit Field1 when Guard
+edit all when Guard
 ```
 
 - `edit all` — the `all` sentinel is stored as `["all"]` in `FieldNames`. At engine construction, `ExpandEditFieldNames()` expands `["all"]` to every declared scalar and collection field name. This is a stateless-only shorthand for "every field the precept declares."
 - `edit Field1, Field2` — only the listed fields are editable. The remaining fields are read-only.
+- `edit Field1 when Guard` — the listed fields are editable only when the guard expression evaluates to `true`. The guard uses the same `WhenOpt` grammar as state-scoped edit declarations.
+- `edit all when Guard` — all fields are editable only when the guard is satisfied.
 
-**Relationship to state-scoped edit:** Root-level `edit` is only valid for stateless precepts. Using it alongside `state` declarations produces **C55 (compile Error)**: `"Root-level 'edit' is not valid when states are declared."` For stateful precepts, use `in any edit all` or `in <State> edit <Fields>`.
+**Guard semantics** for root-level guarded edits follow the same rules as state-scoped guarded edits:
 
-**Access:** At runtime, `Update` on a stateless instance uses `_rootEditableFields` as the editable field set. `BuildEditableFieldInfosForStateless()` surfaces root-editable fields in the `Inspect(instance)` aggregate result.
+- **Additive union:** Unconditional and guarded root-level edit blocks combine. A field is editable if ANY unconditional or passing-guard block grants it.
+- **Fail-closed:** Guard evaluation error → field not granted.
+- **Dynamic evaluation:** Guards are evaluated on each `Update` / `Inspect` call with current instance data.
+- **Type checking:** Guard must be a non-nullable boolean expression. C69 fires for out-of-scope references; C46 rejects nullable guard expressions.
+
+**Relationship to state-scoped edit:** Root-level `edit` (with or without guards) is only valid for stateless precepts. Using it alongside `state` declarations produces **C55 (compile Error)**: `"Root-level 'edit' is not valid when states are declared."` For stateful precepts, use `in any edit all` or `in <State> edit <Fields>`.
+
+**Access:** At runtime, `Update` on a stateless instance uses the union of `_rootEditableFields` (unconditional root edit blocks) and guarded root-level edit blocks whose guards pass. `EvaluateGuardedEditFields(null, data)` evaluates root-level guards by matching on `null` state. `BuildEditableFieldInfosForStateless()` surfaces the combined editable field set in the `Inspect(instance)` aggregate result.
 
 ## Semantics
 
@@ -235,11 +248,11 @@ private readonly IReadOnlyList<PreceptEditBlock> _guardedEditBlocks;
 private HashSet<string>? _rootEditableFields;
 ```
 
-`_rootEditableFields` is populated from `PreceptEditBlock` entries where `State == null`. The `ExpandEditFieldNames()` private helper expands `["all"]` to all scalar and collection field names. `BuildEditableFieldInfosForStateless()` is used by `Inspect(instance)` to surface root-editable fields for stateless instances.
+`_rootEditableFields` is populated from unconditional `PreceptEditBlock` entries where `State == null` and `WhenGuard == null`. The `ExpandEditFieldNames()` private helper expands `["all"]` to all scalar and collection field names.
 
-`_guardedEditBlocks` contains edit blocks where `WhenGuard != null`. The constructor routes these blocks to `_guardedEditBlocks` instead of `_editableFieldsByState`. At runtime, `EvaluateGuardedEditFields(state, data)` iterates guarded blocks matching the current state, evaluates each guard fail-closed (guard error → field not granted), and returns the union of passing field names. The static + guarded fields are unioned to produce the effective editable set.
+`_guardedEditBlocks` contains edit blocks where `WhenGuard != null`, including both state-scoped and root-level guarded edit blocks. The constructor routes these blocks to `_guardedEditBlocks` instead of `_editableFieldsByState` or `_rootEditableFields`. At runtime, `EvaluateGuardedEditFields(state, data)` iterates guarded blocks matching the current state (or `null` for root-level blocks), evaluates each guard fail-closed (guard error → field not granted), and returns the union of passing field names.
 
-At runtime, `Update` Stage 1 branches on `IsStateless`: stateless instances pull the editable field set from `_rootEditableFields`; stateful instances use the `_editableFieldsByState` lookup unioned with guarded edit results.
+At runtime, `Update` Stage 1 branches on `IsStateless`: stateless instances pull the editable field set from the union of `_rootEditableFields` and `EvaluateGuardedEditFields(null, data)`; stateful instances use the `_editableFieldsByState` lookup unioned with guarded edit results. `BuildEditableFieldInfosForStateless()` is used by `Inspect(instance)` to surface the combined editable field set for stateless instances.
 
 This precomputed map makes `Update` validation O(1) per field.
 

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -229,7 +229,7 @@ ClearAction        := "clear" Identifier
 
 EditDecl           := StateEditDecl | RootEditDecl
 StateEditDecl      := "in" StateTarget WhenOpt "edit" FieldTarget
-RootEditDecl       := "edit" FieldTarget
+RootEditDecl       := "edit" FieldTarget WhenOpt
 FieldTarget        := "all" | Identifier ("," Identifier)*
 
 EventDecl          := "event" Identifier ("," Identifier)* ("with" ArgList)?
@@ -938,14 +938,25 @@ Stateless precepts (no `state` declarations) use a root-level `edit` form withou
 ```
 edit all
 edit Field1, Field2
+edit Field1 when Guard
+edit all when Guard
 ```
 
 - `edit all` — declares all declared fields as editable. The `all` sentinel is stored as `["all"]` in `FieldNames` and expanded to all scalar and collection field names at engine construction via `ExpandEditFieldNames()`.
 - `edit Field1, Field2` — declares specific named fields as editable.
+- `edit Field1 when Guard` — declares fields as editable only when the guard expression evaluates to `true`. The guard uses the same `WhenOpt` grammar as state-scoped edit declarations.
+- `edit all when Guard` — declares all fields as editable only when the guard is satisfied.
 
-Root-level `edit` is only valid on stateless precepts. Using it alongside `state` declarations produces **C55 (Error)**: `"Root-level \`edit\` is not valid when states are declared. Use \`in any edit all\` or \`in <State> edit <Fields>\` instead."`
+**Guard semantics** follow the same rules as state-scoped guarded edits:
 
-At runtime, `Update` on a stateless instance pulls the editable field set from `_rootEditableFields` (the internal set built from root edit blocks). The `BuildEditableFieldInfosForStateless()` method is used by `Inspect(instance)` to surface root-editable fields for stateless instances.
+- **Additive union:** Unconditional and guarded root-level edit blocks combine. A field is editable if ANY unconditional or passing-guard block grants it.
+- **Fail-closed:** Guard evaluation error → field not granted.
+- **Dynamic evaluation:** Guards are evaluated on each `Update` / `Inspect` call with current instance data.
+- **Type checking:** Guard must be a non-nullable boolean expression. C69 fires for out-of-scope references.
+
+Root-level `edit` (with or without guards) is only valid on stateless precepts. Using it alongside `state` declarations produces **C55 (Error)**: `"Root-level \`edit\` is not valid when states are declared. Use \`in any edit all\` or \`in <State> edit <Fields>\` instead."`
+
+At runtime, `Update` on a stateless instance pulls the editable field set from the union of `_rootEditableFields` (unconditional root edit blocks) and any guarded root-level edit blocks whose guards pass. `EvaluateGuardedEditFields(null, data)` evaluates root-level guards by matching on `null` state. The `BuildEditableFieldInfosForStateless()` method is used by `Inspect(instance)` to surface the combined editable field set for stateless instances.
 
 ### Compile-time checks
 

--- a/src/Precept/Dsl/PreceptParser.cs
+++ b/src/Precept/Dsl/PreceptParser.cs
@@ -1066,18 +1066,22 @@ public static class PreceptParser
     // Root Edit Declarations (stateless precepts)
     // ═══════════════════════════════════════════════════════════════════
 
-    // edit <FieldTarget>  (root-level; valid only when no states declared)
+    // edit <FieldTarget> [when <Guard>]  (root-level; valid only when no states declared)
     private static readonly TokenListParser<PreceptToken, StatementResult> RootEditDecl =
         (from kw in Token.EqualTo(PreceptToken.Edit)
          from fields in FieldTarget
-         select (StatementResult)new RootEditResult(fields, SourceLine: kw.Span.Position.Line))
+         from whenGuard in OptionalWhenGuardParser
+         select (StatementResult)new RootEditResult(fields,
+             WhenText: whenGuard is not null ? ReconstituteExpr(whenGuard) : null,
+             WhenGuard: whenGuard,
+             SourceLine: kw.Span.Position.Line))
         .Named("root edit declaration")
             .Register(new ConstructInfo(
                 "root-edit-declaration",
-                "edit <Field>, ... | edit all",
+                "edit <Field>, ... [when <Guard>] | edit all [when <Guard>]",
                 "top-level",
                 "Declares which fields are editable (stateless precepts)",
-                "edit all"));
+                "edit Priority when Active"));
 
     // ═══════════════════════════════════════════════════════════════════
     // Transition Rows
@@ -1135,7 +1139,8 @@ public static class PreceptParser
         ParsedAction[] Actions) : StatementResult;
     private sealed record EditResult(string[] States, string[] Fields,
         string? WhenText = null, PreceptExpression? WhenGuard = null, int SourceLine = 0) : StatementResult;
-    private sealed record RootEditResult(string[] Fields, int SourceLine = 0) : StatementResult;
+    private sealed record RootEditResult(string[] Fields,
+        string? WhenText = null, PreceptExpression? WhenGuard = null, int SourceLine = 0) : StatementResult;
     private sealed record TransitionRowResult(string[] States, string EventName,
         PreceptExpression? WhenGuard, ParsedAction[] ActionsAndOutcome, int SourceLine = 0) : StatementResult;
 
@@ -1277,7 +1282,8 @@ public static class PreceptParser
                     break;
 
                 case RootEditResult redr:
-                    editBlocks.Add(new PreceptEditBlock(null, redr.Fields.ToList(), SourceLine: redr.SourceLine));
+                    editBlocks.Add(new PreceptEditBlock(null, redr.Fields.ToList(), SourceLine: redr.SourceLine,
+                        WhenText: redr.WhenText, WhenGuard: redr.WhenGuard));
                     break;
 
                 case TransitionRowResult trr:

--- a/src/Precept/Dsl/PreceptRuntime.cs
+++ b/src/Precept/Dsl/PreceptRuntime.cs
@@ -217,12 +217,13 @@ public sealed class PreceptEngine
     /// Returns the set of field names granted by passing guards.
     /// Fail-closed: guard evaluation error → field not granted.
     /// </summary>
-    private HashSet<string> EvaluateGuardedEditFields(string state, IReadOnlyDictionary<string, object?> data)
+    private HashSet<string> EvaluateGuardedEditFields(string? state, IReadOnlyDictionary<string, object?> data)
     {
         var result = new HashSet<string>(StringComparer.Ordinal);
         foreach (var block in _guardedEditBlocks)
         {
-            if (block.State is null || !string.Equals(block.State, state, StringComparison.Ordinal))
+            // Match: null state ↔ root-level block; named state ↔ same-named block
+            if (!string.Equals(block.State, state, StringComparison.Ordinal))
                 continue;
 
             // Fail-closed: any evaluation error → guard treated as false
@@ -658,7 +659,19 @@ public sealed class PreceptEngine
         HashSet<string>? editableNames;
         if (IsStateless)
         {
-            editableNames = _rootEditableFields;
+            editableNames = _rootEditableFields is not null
+                ? new HashSet<string>(_rootEditableFields, StringComparer.Ordinal) : null;
+
+            if (_guardedEditBlocks.Count > 0)
+            {
+                var hydrated = HydrateInstanceData(instance.InstanceData);
+                var guardedFields = EvaluateGuardedEditFields(null, hydrated);
+                if (guardedFields.Count > 0)
+                {
+                    editableNames ??= new HashSet<string>(StringComparer.Ordinal);
+                    editableNames.UnionWith(guardedFields);
+                }
+            }
         }
         else
         {
@@ -974,7 +987,19 @@ public sealed class PreceptEngine
         HashSet<string>? editableFields;
         if (IsStateless)
         {
-            editableFields = _rootEditableFields;
+            editableFields = _rootEditableFields is not null
+                ? new HashSet<string>(_rootEditableFields, StringComparer.Ordinal) : null;
+
+            // Add fields from guarded root edit blocks that pass their guards
+            if (_guardedEditBlocks.Count > 0)
+            {
+                var guardedFields = EvaluateGuardedEditFields(null, internalData);
+                if (guardedFields.Count > 0)
+                {
+                    editableFields ??= new HashSet<string>(StringComparer.Ordinal);
+                    editableFields.UnionWith(guardedFields);
+                }
+            }
         }
         else
         {
@@ -1148,13 +1173,31 @@ public sealed class PreceptEngine
     private IReadOnlyList<PreceptEditableFieldInfo>? BuildEditableFieldInfosForStateless(
         IReadOnlyDictionary<string, object?> instanceData)
     {
-        if (_rootEditableFields is null || _rootEditableFields.Count == 0)
-            return null;
+        // Build combined editable field set: static root + guarded root
+        HashSet<string>? editableNames = _rootEditableFields is not null
+            ? new HashSet<string>(_rootEditableFields, StringComparer.Ordinal) : null;
+
+        if (_guardedEditBlocks.Count > 0)
+        {
+            var hydrated = HydrateInstanceData(instanceData);
+            var guardedFields = EvaluateGuardedEditFields(null, hydrated);
+            if (guardedFields.Count > 0)
+            {
+                editableNames ??= new HashSet<string>(StringComparer.Ordinal);
+                editableNames.UnionWith(guardedFields);
+            }
+        }
+
+        if (editableNames is null || editableNames.Count == 0)
+        {
+            // Return null only if there are NO edit blocks at all
+            return (_rootEditableFields is null && _guardedEditBlocks.Count == 0) ? null : Array.Empty<PreceptEditableFieldInfo>();
+        }
 
         var result = new List<PreceptEditableFieldInfo>();
         foreach (var field in Fields)
         {
-            if (!_rootEditableFields.Contains(field.Name))
+            if (!editableNames.Contains(field.Name))
                 continue;
             instanceData.TryGetValue(field.Name, out var currentValue);
             var typeName = field.Type.ToString().ToLowerInvariant();
@@ -1162,7 +1205,7 @@ public sealed class PreceptEngine
         }
         foreach (var col in CollectionFields)
         {
-            if (!_rootEditableFields.Contains(col.Name))
+            if (!editableNames.Contains(col.Name))
                 continue;
             instanceData.TryGetValue(col.Name, out var currentValue);
             var typeName = $"{col.CollectionKind.ToString().ToLowerInvariant()}<{col.InnerType.ToString().ToLowerInvariant()}>";
@@ -1177,7 +1220,23 @@ public sealed class PreceptEngine
     internal IReadOnlySet<string> GetEditableFieldNames(string? state, IReadOnlyDictionary<string, object?>? instanceData = null)
     {
         if (state is null)
-            return _rootEditableFields is not null ? _rootEditableFields : EmptyStringSet.Instance;
+        {
+            HashSet<string>? statelessCombined = _rootEditableFields is not null
+                ? new HashSet<string>(_rootEditableFields, StringComparer.Ordinal) : null;
+
+            if (_guardedEditBlocks.Count > 0 && instanceData is not null)
+            {
+                var hydrated = HydrateInstanceData(instanceData);
+                var guardedFields = EvaluateGuardedEditFields(null, hydrated);
+                if (guardedFields.Count > 0)
+                {
+                    statelessCombined ??= new HashSet<string>(StringComparer.Ordinal);
+                    statelessCombined.UnionWith(guardedFields);
+                }
+            }
+
+            return statelessCombined is not null ? statelessCombined : EmptyStringSet.Instance;
+        }
 
         HashSet<string>? combined = null;
         if (_editableFieldsByState.TryGetValue(state, out var staticFields))

--- a/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptAnalyzerCompletionTests.cs
@@ -1817,4 +1817,37 @@ public class PreceptAnalyzerCompletionTests
 
         completions.Should().NotContain("->", "derivation operator must not be offered when default is already present");
     }
+
+    [Fact]
+    public void Completions_RootEdit_AfterFieldList_OffersWhen()
+    {
+        const string text = """
+            precept M
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("when");
+    }
+
+    [Fact]
+    public void Completions_RootEdit_AfterWhen_OffersFields()
+    {
+        const string text = """
+            precept M
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when $$
+            """;
+
+        var (code, position) = ExtractPosition(text);
+        var completions = AnalyzeCompletions(code, position).Select(static item => item.Label).ToArray();
+
+        completions.Should().Contain("Active");
+        completions.Should().Contain("Priority");
+    }
 }

--- a/test/Precept.Tests/GuardedRootEditTests.cs
+++ b/test/Precept.Tests/GuardedRootEditTests.cs
@@ -380,7 +380,7 @@ public class GuardedRootEditTests
     // ════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public void Update_GuardedRootEdit_CompoundGuard()
+    public void Update_GuardedRootEdit_CompoundGuard_And()
     {
         const string dsl = """
             precept Test
@@ -399,6 +399,28 @@ public class GuardedRootEditTests
         var (engine2, inst2) = CompileAndCreate(dsl,
             new Dictionary<string, object?> { ["X"] = 0.0, ["A"] = true, ["B"] = false });
         engine2.Update(inst2, p => p.Set("X", 10.0)).Outcome.Should().Be(UpdateOutcome.UneditableField);
+    }
+
+    [Fact]
+    public void Update_GuardedRootEdit_CompoundGuard_Or()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field A as boolean default true
+            field B as boolean default true
+            edit X when A or B
+            """;
+
+        // Both false → not editable
+        var (engine1, inst1) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["A"] = false, ["B"] = false });
+        engine1.Update(inst1, p => p.Set("X", 10.0)).Outcome.Should().Be(UpdateOutcome.UneditableField);
+
+        // One true → editable
+        var (engine2, inst2) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["A"] = false, ["B"] = true });
+        engine2.Update(inst2, p => p.Set("X", 10.0)).Outcome.Should().Be(UpdateOutcome.Update);
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -451,30 +473,42 @@ public class GuardedRootEditTests
     [Fact]
     public void Inspect_Patch_GuardedRootEdit_FlipGuard()
     {
+        // Only guarded edit — no unconditional edit for Priority
         const string dsl = """
             precept Test
             field Priority as number default 1
             field Active as boolean default true
-            edit Priority, Active
+            edit Active
             edit Priority when Active
             """;
 
-        // Active=false, patch sets Active=true — but edit guard evaluates on pre-patch data
-        // So Priority is NOT guarded-editable (Active=false), only unconditionally editable
-        var (engine, instance) = CompileAndCreate(dsl,
+        // Active=true → Priority IS in editable set (guard passes)
+        var (engineTrue, instTrue) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = true });
+
+        var trueResult = engineTrue.Inspect(instTrue);
+        trueResult.EditableFields.Should().NotBeNull();
+        trueResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Priority",
+            "guard is true so Priority should be editable");
+        trueResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Active");
+
+        // Active=false → Priority NOT in editable set (guard fails)
+        var (engineFalse, instFalse) = CompileAndCreate(dsl,
             new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = false });
 
-        // Priority is unconditionally editable, Active is unconditionally editable
-        var baseResult = engine.Inspect(instance);
-        baseResult.EditableFields.Should().NotBeNull();
-        baseResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Priority");
-        baseResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Active");
+        var falseResult = engineFalse.Inspect(instFalse);
+        falseResult.EditableFields.Should().NotBeNull();
+        falseResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Active");
+        falseResult.EditableFields!.Select(f => f.FieldName).Should().NotContain("Priority",
+            "guard is false so Priority should not be editable");
 
-        // Patch: set Priority → should succeed since Priority is unconditionally editable
-        var patchResult = engine.Inspect(instance, p => p.Set("Priority", 5.0));
+        // Patch: set Priority on false-guard instance — Priority is not editable, expect violation
+        var patchResult = engineFalse.Inspect(instFalse, p => p.Set("Priority", 5.0));
         patchResult.EditableFields.Should().NotBeNull();
+        // Priority is not in editable set, so the patch should show a violation
         var priorityField = patchResult.EditableFields!.FirstOrDefault(f => f.FieldName == "Priority");
-        priorityField.Should().NotBeNull();
-        priorityField!.Violation.Should().BeNull();
+        // Priority may not appear at all (not editable) — that's correct behavior
+        if (priorityField is not null)
+            priorityField.Violation.Should().NotBeNull("Priority is not editable when guard is false");
     }
 }

--- a/test/Precept.Tests/GuardedRootEditTests.cs
+++ b/test/Precept.Tests/GuardedRootEditTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Precept;
+using Xunit;
+
+namespace Precept.Tests;
+
+/// <summary>
+/// Tests for guarded root-level edit declarations —
+/// <c>edit &lt;fields&gt; when &lt;guard&gt;</c> in stateless precepts.
+/// Validates parsing, type checking, and compilation of the new form.
+/// Runtime tests (Update, Inspect) are in the runtime slice.
+/// </summary>
+public class GuardedRootEditTests
+{
+    private static (PreceptEngine engine, PreceptInstance instance) CompileAndCreate(
+        string dsl, Dictionary<string, object?>? data = null)
+    {
+        var def = PreceptParser.Parse(dsl);
+        var engine = PreceptCompiler.Compile(def);
+        var instance = engine.CreateInstance(data);
+        return (engine, instance);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Parsing: guarded root edit parses
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_GuardedRootEdit_Succeeds()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when Active
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+
+        model.EditBlocks.Should().HaveCount(1);
+        var eb = model.EditBlocks![0];
+        eb.State.Should().BeNull();
+        eb.FieldNames.Should().Contain("Priority");
+        eb.WhenText.Should().Be("Active");
+        eb.WhenGuard.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Parse_GuardedRootEditAll_Succeeds()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field Y as string default ""
+            field Active as boolean default true
+            edit all when Active
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+
+        model.EditBlocks.Should().HaveCount(1);
+        var eb = model.EditBlocks![0];
+        eb.State.Should().BeNull();
+        eb.FieldNames.Should().Contain("all");
+        eb.WhenText.Should().Be("Active");
+        eb.WhenGuard.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Parse_UnguardedRootEdit_StillWorks()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            edit Priority
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+
+        model.EditBlocks.Should().HaveCount(1);
+        var eb = model.EditBlocks![0];
+        eb.State.Should().BeNull();
+        eb.FieldNames.Should().Contain("Priority");
+        eb.WhenText.Should().BeNull();
+        eb.WhenGuard.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_GuardedRootEdit_CompoundGuard()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field A as boolean default true
+            field B as boolean default true
+            edit X when A and B
+            """;
+
+        var model = PreceptParser.Parse(dsl);
+
+        model.EditBlocks.Should().HaveCount(1);
+        var eb = model.EditBlocks![0];
+        eb.WhenText.Should().Be("A and B");
+        eb.WhenGuard.Should().NotBeNull();
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Compile: guard stored in PreceptEditBlock
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Compile_GuardedRootEdit_Succeeds()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when Active
+            """;
+
+        var def = PreceptParser.Parse(dsl);
+        var engine = PreceptCompiler.Compile(def);
+
+        engine.Should().NotBeNull();
+        engine.IsStateless.Should().BeTrue();
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Type checker: C69 — out-of-scope guard reference
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Compile_GuardedRootEdit_C69_OutOfScopeRef()
+    {
+        // Guard references an identifier not in field scope
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            edit Priority when NonExistent
+            """;
+
+        var act = () => PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        act.Should().Throw<InvalidOperationException>().WithMessage("*PRECEPT038*");
+    }
+
+    [Fact]
+    public void Compile_GuardedRootEdit_BooleanTypeRequired()
+    {
+        // Guard must evaluate to boolean — number field is rejected
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Score as number default 5
+            edit Priority when Score
+            """;
+
+        var act = () => PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        act.Should().Throw<InvalidOperationException>().WithMessage("*boolean*");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Type checker: C87 — computed field in guarded edit target
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Compile_GuardedRootEdit_C87_ComputedFieldRejected()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 1
+            field Active as boolean default true
+            field Doubled as number -> X * 2
+            edit Doubled when Active
+            """;
+
+        var result = PreceptCompiler.CompileFromText(dsl);
+
+        result.Diagnostics.Should().Contain(d =>
+            d.Code == "PRECEPT087" &&
+            d.Message.Contains("Doubled"));
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // C55: guarded root edit with states = compile error
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Compile_GuardedRootEdit_C55_WithStates()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            state Open initial, Closed
+            event Close
+            edit Priority when Active
+            from Open on Close -> transition Closed
+            """;
+
+        var act = () => PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        act.Should().Throw<InvalidOperationException>().WithMessage("*PRECEPT055*");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Nullable guard rejected (PRECEPT046)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Compile_GuardedRootEdit_NullableGuard_Rejected()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field MaybeActive as boolean nullable
+            edit Priority when MaybeActive
+            """;
+
+        var act = () => PreceptCompiler.Compile(PreceptParser.Parse(dsl));
+        act.Should().Throw<InvalidOperationException>().WithMessage("*PRECEPT046*");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Update: guard true / guard false
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Update_GuardedRootEdit_GuardTrue_FieldEditable()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = true });
+
+        var result = engine.Update(instance, p => p.Set("Priority", 5.0));
+
+        result.Outcome.Should().Be(UpdateOutcome.Update);
+        result.UpdatedInstance!.InstanceData["Priority"].Should().Be(5.0);
+    }
+
+    [Fact]
+    public void Update_GuardedRootEdit_GuardFalse_FieldNotEditable()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = false });
+
+        var result = engine.Update(instance, p => p.Set("Priority", 5.0));
+
+        result.Outcome.Should().Be(UpdateOutcome.UneditableField);
+        result.UpdatedInstance.Should().BeNull();
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Update: edit all when guard
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Update_GuardedRootEditAll_GuardTrue_AllFieldsEditable()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field Y as string default ""
+            field Active as boolean default true
+            edit all when Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["Y"] = "", ["Active"] = true });
+
+        engine.Update(instance, p => p.Set("X", 5.0)).Outcome.Should().Be(UpdateOutcome.Update);
+        engine.Update(instance, p => p.Set("Y", "hello")).Outcome.Should().Be(UpdateOutcome.Update);
+    }
+
+    [Fact]
+    public void Update_GuardedRootEditAll_GuardFalse_NoFieldsEditable()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field Y as string default ""
+            field Active as boolean default true
+            edit all when Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["Y"] = "", ["Active"] = false });
+
+        engine.Update(instance, p => p.Set("X", 5.0)).Outcome.Should().Be(UpdateOutcome.UneditableField);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Update: additive union of unconditional + guarded
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Update_GuardedRootEdit_AdditiveUnion()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field Y as number default 0
+            field Active as boolean default true
+            edit X
+            edit Y when Active
+            """;
+
+        // Active=true → both X and Y editable
+        var (engine1, inst1) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["Y"] = 0.0, ["Active"] = true });
+
+        engine1.Update(inst1, p => p.Set("X", 1.0)).Outcome.Should().Be(UpdateOutcome.Update);
+        engine1.Update(inst1, p => p.Set("Y", 2.0)).Outcome.Should().Be(UpdateOutcome.Update);
+
+        // Active=false → only X editable, Y not
+        var (engine2, inst2) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["Y"] = 0.0, ["Active"] = false });
+
+        engine2.Update(inst2, p => p.Set("X", 1.0)).Outcome.Should().Be(UpdateOutcome.Update);
+        engine2.Update(inst2, p => p.Set("Y", 2.0)).Outcome.Should().Be(UpdateOutcome.UneditableField);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Update: fail-closed
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Update_GuardedRootEdit_WhenNot_GuardTrue_FieldNotEditable()
+    {
+        // "when not Active" → Active=true means guard is false → field not editable
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when not Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = true });
+
+        var result = engine.Update(instance, p => p.Set("Priority", 5.0));
+        result.Outcome.Should().Be(UpdateOutcome.UneditableField);
+    }
+
+    [Fact]
+    public void Update_GuardedRootEdit_WhenNot_GuardFalse_FieldEditable()
+    {
+        // "when not Active" → Active=false means guard is true → field editable
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when not Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = false });
+
+        var result = engine.Update(instance, p => p.Set("Priority", 5.0));
+        result.Outcome.Should().Be(UpdateOutcome.Update);
+        result.UpdatedInstance!.InstanceData["Priority"].Should().Be(5.0);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Update: compound guard (and/or)
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Update_GuardedRootEdit_CompoundGuard()
+    {
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field A as boolean default true
+            field B as boolean default true
+            edit X when A and B
+            """;
+
+        // Both true → editable
+        var (engine1, inst1) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["A"] = true, ["B"] = true });
+        engine1.Update(inst1, p => p.Set("X", 10.0)).Outcome.Should().Be(UpdateOutcome.Update);
+
+        // One false → not editable
+        var (engine2, inst2) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["X"] = 0.0, ["A"] = true, ["B"] = false });
+        engine2.Update(inst2, p => p.Set("X", 10.0)).Outcome.Should().Be(UpdateOutcome.UneditableField);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Inspect: editable fields reflect guard
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Inspect_GuardedRootEdit_GuardTrue_FieldInEditableList()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = true });
+
+        var result = engine.Inspect(instance);
+
+        result.EditableFields.Should().NotBeNull();
+        result.EditableFields!.Select(f => f.FieldName).Should().Contain("Priority");
+    }
+
+    [Fact]
+    public void Inspect_GuardedRootEdit_GuardFalse_FieldNotInEditableList()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority when Active
+            """;
+
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = false });
+
+        var result = engine.Inspect(instance);
+
+        // EditableFields should either be null/empty or not contain Priority
+        if (result.EditableFields is not null)
+            result.EditableFields.Select(f => f.FieldName).Should().NotContain("Priority");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Runtime — Inspect patch: guard flip changes editable set
+    // ════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Inspect_Patch_GuardedRootEdit_FlipGuard()
+    {
+        const string dsl = """
+            precept Test
+            field Priority as number default 1
+            field Active as boolean default true
+            edit Priority, Active
+            edit Priority when Active
+            """;
+
+        // Active=false, patch sets Active=true — but edit guard evaluates on pre-patch data
+        // So Priority is NOT guarded-editable (Active=false), only unconditionally editable
+        var (engine, instance) = CompileAndCreate(dsl,
+            new Dictionary<string, object?> { ["Priority"] = 1.0, ["Active"] = false });
+
+        // Priority is unconditionally editable, Active is unconditionally editable
+        var baseResult = engine.Inspect(instance);
+        baseResult.EditableFields.Should().NotBeNull();
+        baseResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Priority");
+        baseResult.EditableFields!.Select(f => f.FieldName).Should().Contain("Active");
+
+        // Patch: set Priority → should succeed since Priority is unconditionally editable
+        var patchResult = engine.Inspect(instance, p => p.Set("Priority", 5.0));
+        patchResult.EditableFields.Should().NotBeNull();
+        var priorityField = patchResult.EditableFields!.FirstOrDefault(f => f.FieldName == "Priority");
+        priorityField.Should().NotBeNull();
+        priorityField!.Violation.Should().BeNull();
+    }
+}

--- a/tools/Precept.LanguageServer/PreceptAnalyzer.cs
+++ b/tools/Precept.LanguageServer/PreceptAnalyzer.cs
@@ -411,6 +411,17 @@ internal sealed class PreceptAnalyzer
         if (Regex.IsMatch(beforeCursor, "\\bbecause\\s+[^\\n]*$", RegexOptions.IgnoreCase))
             return [SnippetItem("because reason", "because \"${1:Reason}\"", "Constraint reason")];
 
+        // After root "edit <fields> when <guard>" (guard in progress) → suggest field completions
+        if (Regex.IsMatch(beforeCursor, @"^\s*edit\s+[^\n]+\s+when\s+[^\n]*$", RegexOptions.IgnoreCase))
+            return BuildDataExpressionCompletions(dataFields, collectionKinds);
+
+        // After root "edit <fields> " (completed field list) → suggest 'when' + more field names
+        if (Regex.IsMatch(beforeCursor, @"^\s*edit\s+(?:all|[A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*)\s+$", RegexOptions.IgnoreCase))
+            return DistinctAndSort(
+                new CompletionItem[] { WhenItem }
+                    .Concat(BuildItems(editableDataFields, CompletionItemKind.Field))
+                    .Concat(BuildItems(collectionFields, CompletionItemKind.Field)));
+
         // After root "edit " → suggest 'all' + field names (excludes computed fields)
         if (Regex.IsMatch(beforeCursor, "^\\s*edit\\s+[^\\n]*$", RegexOptions.IgnoreCase))
             return DistinctAndSort(


### PR DESCRIPTION
## Summary

Extend root-level `edit` declarations to accept an optional `when` guard, closing the only `when`-guard gap in the declaration surface. Stateless precepts gain conditional editability: `edit Priority when Active`, `edit all when not Expired`.

**Changes:**
- **Parser:** `RootEditDecl` now accepts optional `WhenOpt` trailing guard. `RootEditResult` record extended with `WhenText`/`WhenGuard`. `AssembleModel` passes guard through to `PreceptEditBlock`.
- **Runtime:** `EvaluateGuardedEditFields` accepts nullable state (`null` = root-level). Five stateless code paths updated (`Update`, `Inspect`, `GetEditableFieldNames`, `BuildEditableFieldInfosForStateless`) to union `_rootEditableFields` with guarded root blocks whose guards pass.
- **Completions:** Two new regex branches — `when` suggested after root edit field list, field names suggested after `when`.
- **Tests:** 23 new tests (21 core + 2 LS completions) covering parse, type check (C38/C87/C55/C46/boolean), runtime Update (guard true/false, additive union, edit all when, when not, compound), runtime Inspect (guard reflection, patch flip), and completions.
- **Docs:** `PreceptLanguageDesign.md` grammar updated (`RootEditDecl := "edit" FieldTarget WhenOpt`), root-level section expanded with guard semantics. `EditableFieldsDesign.md` root-level section updated with conditional editability and runtime internals.

## Linked Issue

Closes #84

## Why

Root-level `edit` was the sole declaration form where `when` is available on the state-scoped sibling but not the root form. Root-level `invariant` already supports `when` guards — this completes the symmetry. Real use cases (expired card locks, compliance holds, admin locks) don't benefit from state promotion because they model externally-driven flags, not lifecycles.

## Implementation Plan

- [x] **Slice 1: Parser + model** — add `OptionalWhenGuardParser` to `RootEditDecl`, extend `RootEditResult` record
- [x] **Slice 2: AssembleModel** — pass guard to `PreceptEditBlock` for root-level edits
- [x] **Slice 3: Runtime (Update)** — stateless `Update` path evaluates guarded root edits
- [x] **Slice 4: Runtime (Inspect + GetEditableFieldNames)** — stateless paths incorporate guard evaluation
- [x] **Slice 5: Type checker** — existing guard validation (C38 scope, C46 nullable, boolean check) applies to root-level edit guards automatically
- [x] **Slice 6: Tooling** — `when` completion in root edit context + field completions after `when`
- [x] **Slice 7: MCP** — ConstructInfo syntax update for `root-edit-declaration` (automatic via parser ConstructInfo change)
- [x] **Slice 8: Tests** — parser, type checker, runtime, inspect, additive union, edit all when, when not, compound guard, completions
- [x] **Slice 9: Docs** — `PreceptLanguageDesign.md` grammar, `EditableFieldsDesign.md` conditional root edit