### PR TITLE
feat: improve numeric type diagnostics (#89)

### DIFF
--- a/docs/McpServerDesign.md
+++ b/docs/McpServerDesign.md
@@ -128,7 +128,7 @@ The `vocabulary` object contains the following keyword lists, each reflecting `P
 | `abs(value)` | numeric | `int→int`, `dec→dec`, `num→num` | Absolute value (type-preserving) |
 | `floor(value)` | numeric | `dec→int`, `num→int` | Round toward negative infinity |
 | `ceil(value)` | numeric | `dec→int`, `num→int` | Round toward positive infinity |
-| `round(value)` | numeric | `int→int`, `dec→int`, `num→num` | Banker's rounding to nearest integer |
+| `round(value)` | numeric | `int→int`, `dec→int`, `num→int` | Banker's rounding to nearest integer |
 | `round(value, places)` | numeric | `(num, int-literal)→dec` | Precision rounding |
 | `truncate(value)` | numeric | `dec→int`, `num→int` | Truncate toward zero |
 | `min(a, b, ...)` | numeric | `int*→int`, `dec*→dec`, `num*→num` | Smallest of 2+ values (variadic) |

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -1182,7 +1182,7 @@ set Note = if Score >= 90 then "excellent" else if Score >= 70 then "good" else 
 | Code | Condition | Message |
 |---|---|---|
 | C78 | Condition is not a non-nullable boolean | `Conditional expression condition must be a non-nullable boolean, but got {actual}.` |
-| C79 | Branch types incompatible | `Conditional expression branches must produce the same scalar type, but got {thenType} and {elseType}.` Integer widens to number/decimal; number ↔ decimal is a hard error. |
+| C79 | Branch types incompatible | `Conditional expression branches produce incompatible types: {thenType} and {elseType}. {hint}` For numeric kinds: integer widens to both number and decimal, but number and decimal do not unify with each other. |
 
 ### Examples
 
@@ -1545,10 +1545,10 @@ Type checking for `from any` rows expands to per-state checking. Each state may 
 | C41 / PRECEPT041 | Binary operator type error (includes `contains` RHS mismatch) |
 | C42 / PRECEPT042 | Null-flow violation (assigning `T\|null` to `T` without narrowing) |
 | C43 / PRECEPT043 | Collection `pop`/`dequeue into` target type mismatch |
-| C60 / PRECEPT060 | Narrowing assignment: assigning a `number` or `decimal` value to an `integer` field requires an explicit integer-producing expression (no implicit truncation) |
+| C60 / PRECEPT060 | Narrowing assignment: `number` or `decimal` cannot be implicitly narrowed to `integer`. Use `floor()`, `ceil()`, `truncate()`, or `round()` to produce an explicit integer value. |
 | C69 / PRECEPT069 | Cross-scope guard reference in `when` clause |
 | C78 / PRECEPT078 | Conditional expression condition must be a non-nullable boolean |
-| C79 / PRECEPT079 | Conditional expression branches must produce the same scalar type |
+| C79 / PRECEPT079 | Conditional expression branches produce incompatible types. For numeric mismatches: explains that integer widens to both number and decimal, but number and decimal do not unify. |
 
 ### Design principle
 

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -1094,7 +1094,7 @@ Built-in functions:
 | `abs(value)` | `integer → integer`, `decimal → decimal`, `number → number` | Same as input | Absolute value. Type-preserving. |
 | `floor(value)` | `decimal → integer`, `number → integer` | `integer` | Rounds toward negative infinity. |
 | `ceil(value)` | `decimal → integer`, `number → integer` | `integer` | Rounds toward positive infinity. |
-| `round(value)` | `integer → integer`, `decimal → integer`, `number → number` | See signatures | 1-arg: banker's rounding (MidpointRounding.ToEven) to nearest integer. |
+| `round(value)` | `integer → integer`, `decimal → integer`, `number → integer` | `integer` | 1-arg: banker's rounding (MidpointRounding.ToEven) to nearest integer. |
 | `round(value, places)` | `(numeric, integer-literal) → decimal` | `decimal` | 2-arg: precision rounding. `places` must be a non-negative integer literal (C74). |
 | `truncate(value)` | `decimal → integer`, `number → integer` | `integer` | Truncates toward zero (not toward negative infinity like `floor`). |
 | `min(a, b, ...)` | `integer* → integer`, `decimal* → decimal`, `number* → number` | Same as input | Smallest of 2+ values. Variadic. All args must match the same numeric type. |
@@ -1545,7 +1545,7 @@ Type checking for `from any` rows expands to per-state checking. Each state may 
 | C41 / PRECEPT041 | Binary operator type error (includes `contains` RHS mismatch) |
 | C42 / PRECEPT042 | Null-flow violation (assigning `T\|null` to `T` without narrowing) |
 | C43 / PRECEPT043 | Collection `pop`/`dequeue into` target type mismatch |
-| C60 / PRECEPT060 | Narrowing assignment: `number` or `decimal` cannot be implicitly narrowed to `integer`. Use `floor()`, `ceil()`, or `truncate()` to produce an integer value. When the source is `decimal`, `round()` also produces `integer`. (`round(number)` returns `number`, not `integer`, so it is never suggested for `number` sources.) |
+| C60 / PRECEPT060 | Narrowing assignment: `number` or `decimal` cannot be implicitly narrowed to `integer`. Use `floor()`, `ceil()`, `truncate()`, or `round()` to produce an integer value. (`round(value)` returns `integer` for all numeric input types.) |
 | C69 / PRECEPT069 | Cross-scope guard reference in `when` clause |
 | C78 / PRECEPT078 | Conditional expression condition must be a non-nullable boolean |
 | C79 / PRECEPT079 | Conditional expression branches produce incompatible types. For numeric mismatches: explains that integer widens to both number and decimal, but number and decimal do not unify. |

--- a/docs/PreceptLanguageDesign.md
+++ b/docs/PreceptLanguageDesign.md
@@ -1545,7 +1545,7 @@ Type checking for `from any` rows expands to per-state checking. Each state may 
 | C41 / PRECEPT041 | Binary operator type error (includes `contains` RHS mismatch) |
 | C42 / PRECEPT042 | Null-flow violation (assigning `T\|null` to `T` without narrowing) |
 | C43 / PRECEPT043 | Collection `pop`/`dequeue into` target type mismatch |
-| C60 / PRECEPT060 | Narrowing assignment: `number` or `decimal` cannot be implicitly narrowed to `integer`. Use `floor()`, `ceil()`, `truncate()`, or `round()` to produce an explicit integer value. |
+| C60 / PRECEPT060 | Narrowing assignment: `number` or `decimal` cannot be implicitly narrowed to `integer`. Use `floor()`, `ceil()`, or `truncate()` to produce an integer value. When the source is `decimal`, `round()` also produces `integer`. (`round(number)` returns `number`, not `integer`, so it is never suggested for `number` sources.) |
 | C69 / PRECEPT069 | Cross-scope guard reference in `when` clause |
 | C78 / PRECEPT078 | Conditional expression condition must be a non-nullable boolean |
 | C79 / PRECEPT079 | Conditional expression branches produce incompatible types. For numeric mismatches: explains that integer widens to both number and decimal, but number and decimal do not unify. |

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -481,7 +481,7 @@ public static class DiagnosticCatalog
     /// <summary>Narrowing assignment: cannot assign a non-integer numeric value to an integer field without explicit conversion.</summary>
     /// <remarks>
     /// floor(), ceil(), and truncate() return integer for both number and decimal sources.
-    /// round() returns integer only when its argument is decimal; round(number) returns number.
+    /// round() returns integer for all numeric sources (integer, decimal, and number).
     /// The runtime message is generated per source type — see PreceptTypeChecker.BuildC60Message.
     /// </remarks>
     public static readonly LanguageConstraint C60 = Register(

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -479,10 +479,15 @@ public static class DiagnosticCatalog
     // ═══════════════════════════════════════════════════════════════
 
     /// <summary>Narrowing assignment: cannot assign a non-integer numeric value to an integer field without explicit conversion.</summary>
+    /// <remarks>
+    /// floor(), ceil(), and truncate() return integer for both number and decimal sources.
+    /// round() returns integer only when its argument is decimal; round(number) returns number.
+    /// The runtime message is generated per source type — see PreceptTypeChecker.BuildC60Message.
+    /// </remarks>
     public static readonly LanguageConstraint C60 = Register(
         "C60", "compile",
         "Narrowing assignment: cannot assign non-integer value to integer field without explicit conversion.",
-        "Narrowing assignment: {actual} cannot be implicitly narrowed to integer field '{name}'. Use floor(), ceil(), truncate(), or round() to produce an explicit integer value.");
+        "Narrowing assignment: {actual} cannot be implicitly narrowed to integer field '{name}'. Use floor(), ceil(), or truncate() to produce an integer value.");
 
     /// <summary>'maxplaces' constraint applies only to decimal fields.</summary>
     public static readonly LanguageConstraint C61 = Register(

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -487,7 +487,7 @@ public static class DiagnosticCatalog
     public static readonly LanguageConstraint C60 = Register(
         "C60", "compile",
         "Narrowing assignment: cannot assign non-integer value to integer field without explicit conversion.",
-        "Narrowing assignment: {actual} cannot be implicitly narrowed to integer field '{name}'. Use floor(), ceil(), or truncate() to produce an integer value.");
+        "Narrowing assignment: {actual} cannot be implicitly narrowed to integer field '{name}'. Use floor(), ceil(), truncate(), or round() to produce an integer value.");
 
     /// <summary>'maxplaces' constraint applies only to decimal fields.</summary>
     public static readonly LanguageConstraint C61 = Register(

--- a/src/Precept/Dsl/DiagnosticCatalog.cs
+++ b/src/Precept/Dsl/DiagnosticCatalog.cs
@@ -482,7 +482,7 @@ public static class DiagnosticCatalog
     public static readonly LanguageConstraint C60 = Register(
         "C60", "compile",
         "Narrowing assignment: cannot assign non-integer value to integer field without explicit conversion.",
-        "Narrowing assignment: cannot assign '{actual}' to integer field '{name}' without explicit conversion. An explicit integer conversion function is planned; see documentation.");
+        "Narrowing assignment: {actual} cannot be implicitly narrowed to integer field '{name}'. Use floor(), ceil(), truncate(), or round() to produce an explicit integer value.");
 
     /// <summary>'maxplaces' constraint applies only to decimal fields.</summary>
     public static readonly LanguageConstraint C61 = Register(
@@ -618,7 +618,7 @@ public static class DiagnosticCatalog
     public static readonly LanguageConstraint C79 = Register(
         "C79", "compile",
         "Conditional expression branches must produce the same scalar type.",
-        "Conditional expression branches must produce the same scalar type, but got {thenType} and {elseType}.");
+        "Conditional expression branches produce incompatible types: {thenType} and {elseType}. {hint}");
 
     // ═══════════════════════════════════════════════════════════════
     // Parse-phase constraints: computed/derived fields (C80–C82)

--- a/src/Precept/Dsl/FunctionRegistry.cs
+++ b/src/Precept/Dsl/FunctionRegistry.cs
@@ -75,10 +75,10 @@ internal static class FunctionRegistry
 
         Register(new FunctionDefinition("round", "Rounds a numeric value. 1-arg: banker's rounding to nearest integer. 2-arg: rounds to specified decimal places.",
         [
-            // 1-arg: type-specific overloads
+            // 1-arg: type-specific overloads — all return integer
             new([new("value", StaticValueKind.Integer)], StaticValueKind.Integer),
             new([new("value", StaticValueKind.Decimal)], StaticValueKind.Integer),
-            new([new("value", StaticValueKind.Number)], StaticValueKind.Number),
+            new([new("value", StaticValueKind.Number)], StaticValueKind.Integer),
             // 2-arg: precision rounding (accepts any numeric, returns decimal)
             new(
             [

--- a/src/Precept/Dsl/PreceptExpressionEvaluator.cs
+++ b/src/Precept/Dsl/PreceptExpressionEvaluator.cs
@@ -698,15 +698,9 @@ internal static class PreceptExpressionRuntimeEvaluator
             return EvaluationResult.Ok(Math.Round(d, places, MidpointRounding.ToEven));
         }
 
-        // 1-arg: type-preserving banker's rounding
+        // 1-arg: always returns integer (long) — banker's rounding for all numeric inputs
         var rounded = Math.Round(d, 0, MidpointRounding.ToEven);
-        return valResult.Value switch
-        {
-            long => EvaluationResult.Ok((long)rounded),
-            decimal => EvaluationResult.Ok((long)rounded),
-            double => EvaluationResult.Ok((double)rounded),
-            _ => EvaluationResult.Ok(rounded)
-        };
+        return EvaluationResult.Ok((long)rounded);
     }
 
     private static bool TryToDecimal(object? value, out decimal d)

--- a/src/Precept/Dsl/PreceptTypeChecker.cs
+++ b/src/Precept/Dsl/PreceptTypeChecker.cs
@@ -1449,7 +1449,8 @@ internal static class PreceptTypeChecker
                     : DiagnosticCatalog.C39;
             message = constraint == DiagnosticCatalog.C60
                 ? DiagnosticCatalog.C60.FormatMessage(("actual", FormatKinds(actualKind)), ("name", expectedLabel))
-                : $"{expectedLabel} type mismatch: expected {FormatKinds(expectedKind)} but expression produces {FormatKinds(actualKind)}.";
+                : TryBuildNumericMismatchMessage(actualKind, expectedKind, expectedLabel)
+                  ?? $"{expectedLabel} type mismatch: expected {FormatKinds(expectedKind)} but expression produces {FormatKinds(actualKind)}.";
         }
 
         expressions.Add(new PreceptTypeExpressionInfo(
@@ -1628,9 +1629,7 @@ internal static class PreceptTypeChecker
                 {
                     diagnostic = new PreceptValidationDiagnostic(
                         DiagnosticCatalog.C79,
-                        DiagnosticCatalog.C79.FormatMessage(
-                            ("thenType", FormatKinds(thenKind)),
-                            ("elseType", FormatKinds(elseKind))),
+                        BuildC79Message(thenKind, elseKind),
                         0);
                     return false;
                 }
@@ -2393,5 +2392,54 @@ internal static class PreceptTypeChecker
         var actualNonNull = actual & ~StaticValueKind.Null;
         return expectedNonNull == StaticValueKind.Integer &&
                (actualNonNull == StaticValueKind.Number || actualNonNull == StaticValueKind.Decimal);
+    }
+
+    /// <summary>
+    /// Returns a numeric-specific author-oriented mismatch message for C39,
+    /// or <see langword="null"/> when the mismatch is not between numeric kinds.
+    /// </summary>
+    private static string? TryBuildNumericMismatchMessage(
+        StaticValueKind actual, StaticValueKind expected, string expectedLabel)
+    {
+        var actualBase   = actual   & ~StaticValueKind.Null;
+        var expectedBase = expected & ~StaticValueKind.Null;
+
+        // decimal → number: intentionally unsupported (would silently discard precision)
+        if (actualBase == StaticValueKind.Decimal && expectedBase == StaticValueKind.Number)
+            return $"{expectedLabel} type mismatch: decimal cannot be assigned to number — " +
+                   "this conversion is intentionally unsupported to prevent silent precision loss. " +
+                   "Change the field type to decimal, or use floor(), ceil(), truncate(), or round() " +
+                   "to drop the fractional part explicitly.";
+
+        // number → decimal: requires explicit authored normalization path
+        if (actualBase == StaticValueKind.Number && expectedBase == StaticValueKind.Decimal)
+            return $"{expectedLabel} type mismatch: number cannot be implicitly assigned to decimal. " +
+                   "Use round(expr, N) to normalize to a specific decimal precision, " +
+                   "or change the field type to number.";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Builds a C79 branch-type-mismatch message, providing numeric widening guidance
+    /// when both branches are numeric kinds that do not unify.
+    /// </summary>
+    private static string BuildC79Message(StaticValueKind thenKind, StaticValueKind elseKind)
+    {
+        var thenBase = thenKind & ~StaticValueKind.Null;
+        var elseBase = elseKind & ~StaticValueKind.Null;
+
+        var bothNumeric = IsNumericKind(thenBase) && IsNumericKind(elseBase);
+        if (bothNumeric)
+            return DiagnosticCatalog.C79.FormatMessage(
+                ("thenType", FormatKinds(thenKind)),
+                ("elseType", FormatKinds(elseKind)),
+                ("hint", "integer widens to both number and decimal, but number and decimal " +
+                         "do not unify with each other. Make both branches the same numeric kind."));
+
+        return DiagnosticCatalog.C79.FormatMessage(
+            ("thenType", FormatKinds(thenKind)),
+            ("elseType", FormatKinds(elseKind)),
+            ("hint", "Make both branches the same scalar type."));
     }
 }

--- a/src/Precept/Dsl/PreceptTypeChecker.cs
+++ b/src/Precept/Dsl/PreceptTypeChecker.cs
@@ -1448,7 +1448,7 @@ internal static class PreceptTypeChecker
                     ? DiagnosticCatalog.C60
                     : DiagnosticCatalog.C39;
             message = constraint == DiagnosticCatalog.C60
-                ? DiagnosticCatalog.C60.FormatMessage(("actual", FormatKinds(actualKind)), ("name", expectedLabel))
+                ? BuildC60Message(actualKind, expectedLabel)
                 : TryBuildNumericMismatchMessage(actualKind, expectedKind, expectedLabel)
                   ?? $"{expectedLabel} type mismatch: expected {FormatKinds(expectedKind)} but expression produces {FormatKinds(actualKind)}.";
         }
@@ -2418,6 +2418,24 @@ internal static class PreceptTypeChecker
                    "or change the field type to number.";
 
         return null;
+    }
+
+    /// <summary>
+    /// Builds a C60 narrowing-assignment message that advertises only conversion functions
+    /// whose return type is <c>integer</c> for the given source kind.
+    /// <list type="bullet">
+    ///   <item><c>floor()</c>, <c>ceil()</c>, <c>truncate()</c> — return <c>integer</c> for both <c>number</c> and <c>decimal</c> sources.</item>
+    ///   <item><c>round(decimal)</c> — returns <c>integer</c>; only advertised when the source is <c>decimal</c>.</item>
+    ///   <item><c>round(number)</c> — returns <c>number</c>, not <c>integer</c>; never advertised here.</item>
+    /// </list>
+    /// </summary>
+    private static string BuildC60Message(StaticValueKind actualKind, string fieldName)
+    {
+        var actualLabel = FormatKinds(actualKind);
+        var actualBase  = actualKind & ~StaticValueKind.Null;
+        return actualBase == StaticValueKind.Decimal
+            ? $"Narrowing assignment: {actualLabel} cannot be implicitly narrowed to integer field '{fieldName}'. Use floor(), ceil(), truncate(), or round() to produce an integer value."
+            : $"Narrowing assignment: {actualLabel} cannot be implicitly narrowed to integer field '{fieldName}'. Use floor(), ceil(), or truncate() to produce an integer value.";
     }
 
     /// <summary>

--- a/src/Precept/Dsl/PreceptTypeChecker.cs
+++ b/src/Precept/Dsl/PreceptTypeChecker.cs
@@ -2425,17 +2425,14 @@ internal static class PreceptTypeChecker
     /// whose return type is <c>integer</c> for the given source kind.
     /// <list type="bullet">
     ///   <item><c>floor()</c>, <c>ceil()</c>, <c>truncate()</c> — return <c>integer</c> for both <c>number</c> and <c>decimal</c> sources.</item>
-    ///   <item><c>round(decimal)</c> — returns <c>integer</c>; only advertised when the source is <c>decimal</c>.</item>
-    ///   <item><c>round(number)</c> — returns <c>number</c>, not <c>integer</c>; never advertised here.</item>
+    ///   <item><c>round(decimal)</c> — returns <c>integer</c>; advertised for <c>decimal</c> sources.</item>
+    ///   <item><c>round(number)</c> — returns <c>integer</c>; advertised for <c>number</c> sources.</item>
     /// </list>
     /// </summary>
     private static string BuildC60Message(StaticValueKind actualKind, string fieldName)
     {
         var actualLabel = FormatKinds(actualKind);
-        var actualBase  = actualKind & ~StaticValueKind.Null;
-        return actualBase == StaticValueKind.Decimal
-            ? $"Narrowing assignment: {actualLabel} cannot be implicitly narrowed to integer field '{fieldName}'. Use floor(), ceil(), truncate(), or round() to produce an integer value."
-            : $"Narrowing assignment: {actualLabel} cannot be implicitly narrowed to integer field '{fieldName}'. Use floor(), ceil(), or truncate() to produce an integer value.";
+        return $"Narrowing assignment: {actualLabel} cannot be implicitly narrowed to integer field '{fieldName}'. Use floor(), ceil(), truncate(), or round() to produce an integer value.";
     }
 
     /// <summary>

--- a/test/Precept.Tests/CatalogDriftTests.cs
+++ b/test/Precept.Tests/CatalogDriftTests.cs
@@ -536,7 +536,7 @@ public class CatalogDriftTests
         ["C59"] = new(H + "field Amount as number default 0 positive\n" + S, "violates constraint"),
 
         // C60: Narrowing assignment — assigning a number literal (3.0) to an integer field
-        ["C60"] = new(H + "field Count as integer default 0\n" + S2 + "event Go\nfrom A on Go -> set Count = 3.0 -> no transition\n", "explicit conversion"),
+        ["C60"] = new(H + "field Count as integer default 0\n" + S2 + "event Go\nfrom A on Go -> set Count = 3.0 -> no transition\n", "floor()"),
 
         // C61: maxplaces constraint on non-decimal field — constructed directly (maxplaces not yet a keyword)
         ["C61"] = new("_unused_", "decimal fields", DirectAction: () =>

--- a/test/Precept.Tests/ConditionalExpressionTests.cs
+++ b/test/Precept.Tests/ConditionalExpressionTests.cs
@@ -387,6 +387,30 @@ public class ConditionalExpressionTests
         result.Diagnostics[0].Constraint.Id.Should().Be("C79");
     }
 
+    [Fact]
+    public void TypeCheck_NumberVsDecimal_C79MessageExplainsWideningRules()
+    {
+        // C79 for number ↔ decimal should explain that integer widens to both but they don't unify.
+        const string dsl = """
+            precept Test
+            field X as number default 0
+            field Y as decimal default 0
+            field Flag as boolean default true
+            field Result as number default 0
+            state A initial
+            event Go
+            from A on Go -> set Result = if Flag then X else Y -> no transition
+            """;
+
+        var result = PreceptTypeChecker.Check(PreceptParser.Parse(dsl));
+        var c79 = result.Diagnostics.Should().ContainSingle()
+            .Which;
+        c79.Constraint.Id.Should().Be("C79");
+        c79.Message.Should().Contain("integer");
+        c79.Message.Should().Contain("number");
+        c79.Message.Should().Contain("decimal");
+    }
+
     // ════════════════════════════════════════════════════════════════════
     // Runtime Tests (end-to-end with PreceptEngine)
     // ════════════════════════════════════════════════════════════════════

--- a/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
+++ b/test/Precept.Tests/PreceptBuiltInFunctionTests.cs
@@ -156,48 +156,48 @@ public class PreceptBuiltInFunctionTests
     public void Eval_Round_BankersRounding_HalfToEven_RoundsDown()
     {
         var fire = FireForSet(
-            "field Input as number default 0\nfield Output as number default 0",
+            "field Input as number default 0\nfield Output as integer default 0",
             "Output", "round(Input)",
-            new Dictionary<string, object?> { ["Input"] = 2.5, ["Output"] = 0.0 });
+            new Dictionary<string, object?> { ["Input"] = 2.5, ["Output"] = 0L });
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
-        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2.0);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2L);
     }
 
     [Fact]
     public void Eval_Round_BankersRounding_HalfToEven_RoundsUp()
     {
         var fire = FireForSet(
-            "field Input as number default 0\nfield Output as number default 0",
+            "field Input as number default 0\nfield Output as integer default 0",
             "Output", "round(Input)",
-            new Dictionary<string, object?> { ["Input"] = 3.5, ["Output"] = 0.0 });
+            new Dictionary<string, object?> { ["Input"] = 3.5, ["Output"] = 0L });
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
-        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(4.0);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(4L);
     }
 
     [Fact]
     public void Eval_Round_BelowHalf_RoundsDown()
     {
         var fire = FireForSet(
-            "field Input as number default 0\nfield Output as number default 0",
+            "field Input as number default 0\nfield Output as integer default 0",
             "Output", "round(Input)",
-            new Dictionary<string, object?> { ["Input"] = 2.4, ["Output"] = 0.0 });
+            new Dictionary<string, object?> { ["Input"] = 2.4, ["Output"] = 0L });
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
-        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2.0);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(2L);
     }
 
     [Fact]
     public void Eval_Round_AboveHalf_RoundsUp()
     {
         var fire = FireForSet(
-            "field Input as number default 0\nfield Output as number default 0",
+            "field Input as number default 0\nfield Output as integer default 0",
             "Output", "round(Input)",
-            new Dictionary<string, object?> { ["Input"] = 2.6, ["Output"] = 0.0 });
+            new Dictionary<string, object?> { ["Input"] = 2.6, ["Output"] = 0L });
 
         fire.Outcome.Should().Be(TransitionOutcome.Transition);
-        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3.0);
+        fire.UpdatedInstance!.InstanceData["Output"].Should().Be(3L);
     }
 
     [Fact]

--- a/test/Precept.Tests/PreceptDecimalTypeTests.cs
+++ b/test/Precept.Tests/PreceptDecimalTypeTests.cs
@@ -226,6 +226,48 @@ public class PreceptDecimalTypeTests
         result.Diagnostics.Should().NotContain(d => d.Constraint.Id == "C61");
     }
 
+    [Fact]
+    public void TypeCheck_NumberToDecimalAssignment_EmitsC39WithRoundGuidance()
+    {
+        // number → decimal is not implicit — author must use round(expr, N) or change field type.
+        const string dsl = """
+            precept M
+            field Price as decimal default 0.0
+            field Rate as number default 0
+            state A initial
+            state B
+            event Apply
+            from A on Apply -> set Price = Rate -> transition B
+            """;
+
+        var result = PreceptCompiler.Validate(PreceptParser.Parse(dsl));
+
+        var c39 = result.Diagnostics.Should().Contain(d => d.Constraint.Id == "C39").Which;
+        c39.Message.Should().Contain("round(");
+        c39.Message.Should().Contain("decimal");
+    }
+
+    [Fact]
+    public void TypeCheck_DecimalToNumberAssignment_EmitsC39WithUnsupportedGuidance()
+    {
+        // decimal → number is intentionally unsupported — diagnostic should say so and suggest alternatives.
+        const string dsl = """
+            precept M
+            field Total as number default 0
+            field Tax as decimal default 0.0
+            state A initial
+            state B
+            event Apply
+            from A on Apply -> set Total = Tax -> transition B
+            """;
+
+        var result = PreceptCompiler.Validate(PreceptParser.Parse(dsl));
+
+        var c39 = result.Diagnostics.Should().Contain(d => d.Constraint.Id == "C39").Which;
+        c39.Message.Should().Contain("intentionally unsupported");
+        c39.Message.Should().Contain("floor()");
+    }
+
     // ════════════════════════════════════════════════════════════════════
     // RUNTIME — decimal arithmetic and round()
     // ════════════════════════════════════════════════════════════════════

--- a/test/Precept.Tests/PreceptIntegerTypeTests.cs
+++ b/test/Precept.Tests/PreceptIntegerTypeTests.cs
@@ -249,7 +249,32 @@ public class PreceptIntegerTypeTests
         result.Diagnostics[0].Constraint.Id.Should().Be("C60");
         result.Diagnostics[0].DiagnosticCode.Should().Be("PRECEPT060");
         result.Diagnostics[0].Message.Should().Contain("floor()");
+        result.Diagnostics[0].Message.Should().Contain("ceil()");
+        result.Diagnostics[0].Message.Should().Contain("truncate()");
+        result.Diagnostics[0].Message.Should().NotContain("round()");
         result.Diagnostics[0].Message.Should().Contain("integer");
+    }
+
+    [Fact]
+    public void TypeCheck_IntegerField_AssignDecimalField_EmitsC60WithRoundGuidance()
+    {
+        const string dsl = """
+            precept M
+            field Source as decimal default 3.14
+            field Count as integer default 0
+            state A initial
+            state B
+            event Go
+            from A on Go -> set Count = Source -> transition B
+            """;
+
+        var result = PreceptCompiler.Validate(PreceptParser.Parse(dsl));
+
+        var diagnostic = result.Diagnostics.Should().ContainSingle().Subject;
+        diagnostic.Constraint.Id.Should().Be("C60");
+        diagnostic.DiagnosticCode.Should().Be("PRECEPT060");
+        diagnostic.Message.Should().Contain("round()");
+        diagnostic.Message.Should().Contain("floor()");
     }
 
     [Fact]

--- a/test/Precept.Tests/PreceptIntegerTypeTests.cs
+++ b/test/Precept.Tests/PreceptIntegerTypeTests.cs
@@ -248,7 +248,8 @@ public class PreceptIntegerTypeTests
         result.Diagnostics.Should().ContainSingle();
         result.Diagnostics[0].Constraint.Id.Should().Be("C60");
         result.Diagnostics[0].DiagnosticCode.Should().Be("PRECEPT060");
-        result.Diagnostics[0].Message.Should().Contain("explicit conversion");
+        result.Diagnostics[0].Message.Should().Contain("floor()");
+        result.Diagnostics[0].Message.Should().Contain("integer");
     }
 
     [Fact]

--- a/test/Precept.Tests/PreceptIntegerTypeTests.cs
+++ b/test/Precept.Tests/PreceptIntegerTypeTests.cs
@@ -251,7 +251,7 @@ public class PreceptIntegerTypeTests
         result.Diagnostics[0].Message.Should().Contain("floor()");
         result.Diagnostics[0].Message.Should().Contain("ceil()");
         result.Diagnostics[0].Message.Should().Contain("truncate()");
-        result.Diagnostics[0].Message.Should().NotContain("round()");
+        result.Diagnostics[0].Message.Should().Contain("round()");
         result.Diagnostics[0].Message.Should().Contain("integer");
     }
 


### PR DESCRIPTION
## Summary

- Improve numeric diagnostics and author guidance around integer, number, and decimal interactions.
- **New semantic change**: `round(value)` now returns `integer` for all 1-arg numeric inputs (integer, decimal, and number). Previously `round(number)` returned `number`.

## Linked Issue

Closes #89

## Why

The numeric type system is behaving as designed, but the diagnostics are still too rough for real authoring workflows. This PR is the execution hub for making the existing semantics easier to understand and fix against.

Additionally, `round(number) -> integer` is now in scope per the issue owner. This closes the gap where `floor()`, `ceil()`, and `truncate()` all narrow `number` to `integer`, but `round()` previously left `number` unchanged — inconsistent with the 1-arg rounding contract and surprising to authors who expect symmetry with `round(decimal)`.

## Implementation Plan

- [x] Improve PRECEPT039 guidance for numeric-kind mismatches
- [x] Improve PRECEPT060 guidance for integer narrowing scenarios
- [x] Tighten conditional-expression diagnostics around numeric widening rules
- [x] Clarify supported vs unsupported numeric normalization paths in diagnostics
- [x] Add or update tests covering the improved numeric diagnostic messages
- [x] Sync any directly affected docs if the reviewer-facing guidance changes materially
- [x] Implement `round(number) -> integer` in FunctionRegistry, evaluator, and type checker
- [x] Update C60 message to advertise `round()` for `number` sources (not just `decimal`)
- [x] Update tests: integer output fields, long expected values, C60 assertion flipped to Contain
- [x] Sync docs: PreceptLanguageDesign.md, McpServerDesign.md

## Changes

### Diagnostic messages improved

- **PRECEPT060**: Removed stale 'planned' language. New message names the actual functions authors should use: floor(), ceil(), truncate(), or round() — now including round() for number sources.
- **PRECEPT039 (numeric)**: Two new numeric-specific call-site messages:
  - decimal to number: 'intentionally unsupported to prevent silent precision loss. Change the field type to decimal, or use floor()/ceil()/truncate()/round() to drop the fractional part explicitly.'
  - number to decimal: 'Use round(expr, N) to normalize to a specific decimal precision, or change the field type to number.'
- **PRECEPT079**: Template updated with hint slot. Call site detects numeric branch mismatch and injects widening-rules explanation: 'integer widens to both number and decimal, but number and decimal do not unify with each other.'

### Semantic change: round(number) -> integer

`round(value)` now returns `integer` for **all** 1-arg numeric inputs. The previous behavior where `round(number)` returned `number` was an inconsistency — every other 1-arg rounding function (`floor`, `ceil`, `truncate`) produces `integer` from a `number` source. The 1-arg contract is "give me the nearest whole number as an integer"; `round(number)` now fulfills that contract.

- `round(integer)` → `integer` (unchanged)
- `round(decimal)` → `integer` (unchanged)
- `round(number)` → **`integer`** (previously `number`)
- `round(value, places)` → `decimal` (unchanged)