### PR TITLE
feat: add variable.parameter.precept color rule (#97)

### DIFF
--- a/tools/Precept.VsCode/package.json
+++ b/tools/Precept.VsCode/package.json
@@ -199,6 +199,7 @@
             { "scope": "variable.other.field.constrained.precept", "settings": { "foreground": "#B0BEC5", "fontStyle": "italic" } },
             { "scope": "variable.other.property.precept",        "settings": { "foreground": "#B0BEC5" } },
             { "scope": "variable.other.precept",                 "settings": { "foreground": "#B0BEC5" } },
+            { "scope": "variable.parameter.precept",             "settings": { "foreground": "#B0BEC5" } },
             { "scope": "storage.type.precept",                   "settings": { "foreground": "#9AA8B5" } },
             { "scope": "constant.other.value.precept",           "settings": { "foreground": "#84929F" } },
             { "scope": "constant.language.precept",              "settings": { "foreground": "#84929F" } },


### PR DESCRIPTION
## Summary
Added the missing `variable.parameter.precept` token color rule to `tools/Precept.VsCode/package.json`. Event argument names (the identifier before `as` in event declarations) now render in `#B0BEC5` — consistent with the rest of the Precept variable surface — instead of falling through to the editor theme default.

No docs sync needed: this is a pure color-rule fix with no DSL surface change, grammar change, or language server behavior change. `docs/SyntaxHighlightingDesign.md` does not enumerate individual color rules; no other doc is affected.

## Linked Issue
Closes #97

## Why
Event argument declarations already receive the correct TextMate scope (`variable.parameter.precept`), but the extension had no explicit color rule for that scope. Themes like GitHub Dark bleed their own parameter color (gold) through the gap. Adding one rule closes the bleed without touching grammar or completions.

## Implementation Plan
- [x] add the missing `variable.parameter.precept` token color rule in `tools/Precept.VsCode/package.json`
- [x] rebuild and install the extension to validate the updated token color behavior (166/166 LS tests passing, clean TypeScript compile)
- [x] update the PR summary/checklist as slices land