### PR TITLE
fix: scope precept name as entity.name.type.precept.precept (#100)

### DIFF
--- a/test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs
@@ -122,7 +122,7 @@ public class PreceptSemanticTokensClassificationTests
     }
 
     [Fact]
-    public void GetClassifiedTokens_PreceptName_IsPreceptMessage()
+    public void GetClassifiedTokens_PreceptName_IsPreceptName()
     {
         const string dsl = """
             precept ApartmentRentalApplication
@@ -135,7 +135,7 @@ public class PreceptSemanticTokensClassificationTests
 
         tokens.Should().Contain(t =>
             t.Text == "ApartmentRentalApplication" &&
-            t.Type == "preceptMessage");
+            t.Type == "preceptName");
     }
 
     [Fact]

--- a/tools/Precept.LanguageServer/PreceptSemanticTokensHandler.cs
+++ b/tools/Precept.LanguageServer/PreceptSemanticTokensHandler.cs
@@ -34,6 +34,7 @@ internal sealed class PreceptSemanticTokensHandler : SemanticTokensHandlerBase
             "preceptState",
             "preceptEvent",
             "preceptFieldName",
+            "preceptName",
             "preceptType",
             "preceptValue",
             "preceptMessage"
@@ -319,7 +320,7 @@ internal sealed class PreceptSemanticTokensHandler : SemanticTokensHandlerBase
 
     /// <summary>
     /// Classifies an identifier token based on the preceding token:
-    /// - After precept → "preceptMessage" (gold — the contract name)
+    /// - After precept → "preceptName"
     /// - After state/from/transition/in/to → "preceptState"
     /// - After event/on → "preceptEvent"
     /// - After field/set/add/remove/.../into → "preceptFieldName"
@@ -328,7 +329,7 @@ internal sealed class PreceptSemanticTokensHandler : SemanticTokensHandlerBase
     /// </summary>
     private static string ClassifyIdentifier(PreceptToken? previousKind, DeclContext context) => previousKind switch
     {
-        PreceptToken.Precept => "preceptMessage",
+        PreceptToken.Precept => "preceptName",
         PreceptToken.From => "preceptState",
         PreceptToken.Dot => "preceptFieldName",
         PreceptToken.Comma when context == DeclContext.State => "preceptState",

--- a/tools/Precept.VsCode/package.json
+++ b/tools/Precept.VsCode/package.json
@@ -109,6 +109,7 @@
       { "id": "preceptState",           "description": "Precept state name" },
       { "id": "preceptEvent",           "description": "Precept event name" },
       { "id": "preceptFieldName",       "description": "Precept field or argument name" },
+      { "id": "preceptName",           "description": "Precept declaration name" },
       { "id": "preceptType",            "description": "Precept type keyword" },
       { "id": "preceptValue",           "description": "Precept literal value" },
       { "id": "preceptMessage",         "description": "Precept rule message string" }
@@ -149,6 +150,9 @@
           "preceptFieldName.preceptConstrained": [
             "variable.other.field.constrained.precept"
           ],
+          "preceptName": [
+            "entity.name.type.precept.precept"
+          ],
           "preceptType": [
             "storage.type.precept"
           ],
@@ -179,6 +183,9 @@
           },
           "preceptMessage": {
             "foreground": "#FBBF24"
+          },
+          "preceptName": {
+            "foreground": "#6366F1"
           }
         }
       },

--- a/tools/Precept.VsCode/package.json
+++ b/tools/Precept.VsCode/package.json
@@ -156,7 +156,6 @@
             "constant.other.value.precept"
           ],
           "preceptMessage": [
-            "entity.name.precept.message.precept",
             "string.quoted.double.message.precept"
           ]
         }
@@ -204,7 +203,7 @@
             { "scope": "constant.other.value.precept",           "settings": { "foreground": "#84929F" } },
             { "scope": "constant.language.precept",              "settings": { "foreground": "#84929F" } },
             { "scope": "constant.numeric.precept",               "settings": { "foreground": "#84929F" } },
-            { "scope": "entity.name.precept.message.precept",    "settings": { "foreground": "#FBBF24" } },
+            { "scope": "entity.name.type.precept.precept",         "settings": { "foreground": "#6366F1" } },
             { "scope": "string.quoted.double.precept",           "settings": { "foreground": "#84929F" } },
             { "scope": "string.quoted.double.message.precept",   "settings": { "foreground": "#FBBF24" } },
             { "scope": "keyword.operator.comparison.precept",    "settings": { "foreground": "#6366F1" } },

--- a/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
+++ b/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
@@ -86,7 +86,7 @@
           "match": "^(\\s*)(precept)(\\s+)([A-Za-z_][A-Za-z0-9_]*)",
           "captures": {
             "2": { "name": "keyword.control.precept" },
-            "4": { "name": "entity.name.precept.message.precept" }
+            "4": { "name": "entity.name.type.precept.precept" }
           }
         }
       ]


### PR DESCRIPTION
## Summary

Fixes the precept name token scope so it renders Structure Indigo (`#6366F1`) instead of gold. The precept name (for example `OrderWorkflow` in `precept OrderWorkflow`) now has a dedicated semantic token path and matching TextMate scope instead of falling through the message styling pipeline.

## Linked Issue

Closes #100

## Why

The original bug had two layers:

1. The TextMate grammar scoped the precept name as `entity.name.precept.message.precept`, which incorrectly matched the gold message styling.
2. Semantic highlighting is enabled for `.precept` files, and the language server still classified the identifier after `precept` as `preceptMessage`, so even a grammar-only fix could not change the rendered color.

The fix now aligns both layers on a dedicated precept-name classification that renders with Structure Indigo.

## Implementation Plan

- [x] Fix the precept name grammar scope in `tools/Precept.VsCode/syntaxes/precept.tmLanguage.json`
- [x] Update the semantic token classification in `tools/Precept.LanguageServer/PreceptSemanticTokensHandler.cs`
- [x] Add the matching semantic token type and color rule in `tools/Precept.VsCode/package.json`
- [x] Update the classification test in `test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs`
- [x] Run directly affected tests (`dotnet test test/Precept.LanguageServer.Tests/`)
- [x] Sync directly affected docs/tests only if needed — no docs changed; this is an editor-coloring fix only