### PR TITLE
chore: add implementation plan quality bar to process docs

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -125,7 +125,7 @@ This repository's canonical workflow lives in [CONTRIBUTING.md](/CONTRIBUTING.md
 
 ### Implementation Gate — Draft PR Required (Enforced by Coordinator)
 
-**No implementation work may be routed until a draft PR exists.** This is the coordinator's responsibility to enforce — it is NOT delegated to agents.
+**No implementation work may be routed until a draft PR exists with a detailed implementation plan.** This is the coordinator's responsibility to enforce — it is NOT delegated to agents.
 
 When a user asks to "work on" an issue or an agent creates a feature branch, the coordinator MUST:
 
@@ -133,7 +133,8 @@ When a user asks to "work on" an issue or an agent creates a feature branch, the
 2. **Check for an existing PR.** Use `mcp_github_list_pull_requests` (or `gh pr list`) to confirm whether a PR already exists for that branch.
 3. **If branch exists but no PR:** The gate is unmet. The coordinator opens the draft PR immediately — before spawning any implementation agents — using `mcp_github_create_pull_request` with `draft: true`. The PR title follows `feat: {short description} (#N)`, the body contains the implementation checklist from the issue's "Implementation scope" section, and the PR is linked with `Closes #N`.
 4. **If neither branch nor PR exists:** Create the branch with an empty chore commit (`git commit --allow-empty -m "chore: open feature branch for issue #N — {description}"`), push it, then open the draft PR as above.
-5. **Only after the draft PR is confirmed open:** Route implementation work to agents.
+5. **After the draft PR is confirmed open, build the implementation plan.** Spawn Frank to author the plan following `.squad/skills/implementation-planning/SKILL.md`. The plan must meet the quality bar defined in CONTRIBUTING.md § Implementation Plan Quality Bar: vertical slices with method-level specificity, exact file paths, tests per slice, regression anchors, dependency ordering, file inventory, and tooling/MCP sync assessment.
+6. **Only after the implementation plan is in the PR body:** Route implementation work to agents.
 
 **What counts as a gate breach:** Any session that routes implementation commits without a draft PR is a gate breach. The coordinator is accountable — agents following coordinator instructions are not at fault.
 

--- a/.squad/agents/frank/charter.md
+++ b/.squad/agents/frank/charter.md
@@ -58,6 +58,21 @@ Before any agent writes code, a design document must exist that covers:
   - **Tooling** — syntax highlighting (all positions: standalone, after `as`, after `of`), completions (all contexts), hover, semantic tokens
   - **MCP** — type vocabulary in `precept_language`, field/arg DTOs in `precept_compile`, serialization in fire/inspect/update
 
+## Implementation Plan Gate
+
+**No coding starts without a detailed implementation plan.** After a design is approved, I author the implementation plan in the draft PR body before any agent writes code.
+
+**The plan must meet the quality bar defined in CONTRIBUTING.md § Implementation Plan Quality Bar.** Read `.squad/skills/implementation-planning/SKILL.md` for the full planning workflow.
+
+**My planning process:**
+1. Read the full issue body AND all comments — scope additions, implementation notes, and test requirements often live in comments.
+2. Explore the codebase to locate exact files, methods, and line numbers. I do not plan from assumptions.
+3. Decompose into vertical slices with method-level specificity: what to create, what to modify, what to test, and which existing tests are at risk.
+4. Include ordering constraints, a file inventory table, and a tooling/MCP sync assessment.
+5. Present the plan for review before authorizing implementation agents to begin.
+
+**Quality bar exemplar:** PR #108 demonstrates the expected depth — 9 vertical slices, method-level specificity, ~56 edge-case tests mapped to slices, 16 named regression anchors.
+
 A proposal that changes the language surface without an **Impact** section covering all three categories is incomplete. I send it back before it advances. Implementing devs (George, Kramer, Newman) must participate in the design review to flag impacts I may miss — they know the internal surfaces best.
 
 **Every locked design decision must carry rationale.** When writing or reviewing proposals, I require:

--- a/.squad/skills/implementation-planning/SKILL.md
+++ b/.squad/skills/implementation-planning/SKILL.md
@@ -1,0 +1,113 @@
+# Skill: Implementation Planning
+
+**Confidence:** high
+**Domain:** implementation planning, vertical slice design, PR body authoring
+
+## What this skill covers
+
+How to build a detailed, actionable implementation plan for a Precept feature PR — from issue research through codebase exploration to vertical slice decomposition. This skill covers the **planning process**; for PR body structure and checklist formatting, see `.squad/skills/pr-implementation-plan/SKILL.md`.
+
+## Relationship to CONTRIBUTING.md
+
+This skill operationalizes the [Implementation Plan Quality Bar](../../CONTRIBUTING.md#implementation-plan-quality-bar) section of CONTRIBUTING.md. That section defines the required elements; this skill defines the workflow for producing them.
+
+## When to use
+
+- When Frank (or any agent) is building an implementation plan for a new feature PR
+- When a plan has been rejected for insufficient detail
+- When onboarding a new squad member to the planning process
+
+## Quality bar exemplar
+
+PR #108 (`feat: compile-time divisor safety via unified narrowing`) is the reference implementation for this skill. It demonstrates all required elements at the expected depth.
+
+## Planning workflow
+
+### Phase 1: Issue research (no assumptions)
+
+1. **Read the full issue body.** Extract: summary, design decisions, acceptance criteria, test plan, impact assessment, resolved questions.
+2. **Read ALL comments.** Issue comments contain implementation notes, scope additions, additional tests, ordering constraints, and reviewer feedback that amend the body. Treat the full comment thread as part of the spec.
+3. **Build a scope inventory** from both sources. Track each item's origin (body vs. comment N) so nothing is lost.
+
+Common comment types that add scope:
+- "Implementation note — ..." (code-level guidance: case ordering, filtering patterns, caching)
+- "Additional scope — ..." (new items added after initial review)
+- "Additional test — ..." (specific test cases from reviewers)
+- "Regression anchor exact method names" (test names that must pass unchanged)
+
+### Phase 2: Codebase exploration
+
+Before writing any plan, locate the exact code that will change:
+
+1. **Find every file involved.** Use search tools to locate the methods, classes, and line numbers referenced in the issue.
+2. **Read the relevant code.** Understand the current structure — method signatures, call sites, data flow. A plan built on assumptions about code structure will be wrong.
+3. **Identify integration points.** Where does new code wire into existing code? What line numbers? What methods call what?
+4. **Identify regression risk.** Which existing tests exercise the code being changed? These become regression anchors.
+
+Key things to locate:
+- Methods to modify (with line numbers and surrounding structure)
+- Methods to create (where they fit in the file, what they parallel)
+- Test files and existing test method names for regression anchors
+- Diagnostic catalog (next available code, registration pattern)
+- Any infrastructure the new code will reuse (helpers, patterns, conventions)
+
+### Phase 3: Vertical slice decomposition
+
+Organize the work into slices. Each slice is a coherent unit that can be implemented, tested, and verified independently.
+
+**Slice design principles:**
+- **Each slice is testable.** It includes its own tests — not "implement in slice 3, test in slice 8."
+- **Each slice has a clear boundary.** "Create method X, modify method Y, add tests A/B/C" — not "work on narrowing."
+- **Dependencies are explicit.** If Slice 2 needs Slice 1's infrastructure, say so and say why.
+- **Regression anchors live with the slice that creates risk.** If Slice 3 replaces existing behavior, Slice 3 lists the tests that must pass unchanged.
+
+**Slice anatomy (required per slice):**
+
+```markdown
+### Slice N — {descriptive title}
+
+{1-2 sentence summary of what this slice delivers and why it matters.}
+
+**Create:**
+- `MethodName(params)` — {purpose} (~N lines) in `path/to/File.cs`. {Brief description of logic.}
+
+**Modify:**
+- `ExistingMethod()` (~LN–LN) — {what changes and where in the method.}
+
+**Tests (in `path/to/TestFile.cs`):**
+- {Test description} — `[Fact]` or `[Theory]` with N rows
+- {Test description} — what it verifies
+
+**Regression anchors:**
+- `ExactTestMethodName` — {why it's at risk}
+
+**Files:** `file1.cs`, `file2.cs`
+
+- [ ] Checkbox 1
+- [ ] Checkbox 2
+```
+
+### Phase 4: Plan-level elements
+
+After all slices are defined, add these plan-level sections:
+
+1. **Ordering constraints** — A narrative section explaining the dependency graph. "Slice 1 must be first because...", "Slices 3 and 4 can be parallelized because..."
+2. **File inventory table** — Every file mapped to the slices that touch it.
+3. **Tooling/MCP sync assessment** — Per-category statement: syntax highlighting, completions, semantic tokens, MCP. Either "changes needed" with specifics or "no changes needed" with reasoning.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Plan says "modify type checker" without naming methods | Name the method, the file, and the line number or structural landmark |
+| Tests grouped as a separate slice at the end | Tests belong in the slice that creates the behavior they verify |
+| Missing regression anchors for refactored code | Any slice that replaces existing behavior must list exact test method names that must pass unchanged |
+| Plan built without reading issue comments | Comments contain scope additions, implementation notes, and test requirements. Read all of them. |
+| Slice dependencies implied but not stated | Write an explicit ordering constraints section |
+| "No tooling changes needed" without justification | Explain WHY no changes are needed (e.g., "no new keywords, operators, or syntax forms") |
+
+## Relationship to other skills
+
+- **`pr-implementation-plan`** — covers PR body structure and checklist formatting. This skill covers the planning *process* that produces those checklists.
+- **`proposal-review`** — the design review ceremony that produces the issue content this skill consumes.
+- **`pr-review`** — reviewers use the plan to scope their review. A good plan makes review faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ When ready to implement:
    - `## Linked Issue` — include `Closes #N`
    - `## Why` — why this PR exists, what problem it addresses, and any implementation-specific reviewer context; do **not** duplicate the full proposal rationale or alternatives from the issue/research docs
    - `## Implementation Plan` — checkbox checklist tracking vertical slices
-4. **Check off items as you complete them.** Update the PR body after each slice or logical group — not at the end. The checkbox list is a live progress tracker; it should reflect current state throughout development so reviewers and collaborators always know where things stand. Keep the `## Summary` and `## Why` sections current too if the shipped scope or reviewer context changes during implementation. Use the GitHub UI or `mcp_github_update_pull_request` to keep the PR body current.
-5. Implement in vertical slices. Suggested order for cross-cutting changes:
+4. **Build a detailed implementation plan before coding.** The plan lives in the PR body's `## Implementation Plan` section. See the [Implementation Plan Quality Bar](#implementation-plan-quality-bar) below for requirements.
+5. **Check off items as you complete them.** Update the PR body after each slice or logical group — not at the end. The checkbox list is a live progress tracker; it should reflect current state throughout development so reviewers and collaborators always know where things stand. Keep the `## Summary` and `## Why` sections current too if the shipped scope or reviewer context changes during implementation. Use the GitHub UI or `mcp_github_update_pull_request` to keep the PR body current.
+6. Implement in vertical slices. Suggested order for cross-cutting changes:
    - Parser + model + diagnostics
    - Type checker
    - Runtime engine
@@ -98,6 +99,39 @@ The table above covers which files to touch during implementation. This table is
 | Dependencies / related issues | Tracked in the issues themselves — no migration needed |
 
 The most commonly dropped items are **deliberate exclusions** (they disappear when the issue closes) and **resolved open questions** (the resolution often stays only in an issue comment). Both are durable decisions that belong in permanent homes.
+
+#### Implementation Plan Quality Bar
+
+The `## Implementation Plan` in the PR body is the execution blueprint. A plan that says "implement narrowing" is useless; a plan that says "create `TryApplyNumericComparisonNarrowing` in `PreceptTypeChecker.cs` (~30 lines), wire into `ApplyNarrowing` after the null-comparison branch at line 2152" is actionable. Every plan must meet this bar before coding begins.
+
+**Required elements per slice:**
+
+| Element | Why |
+|---------|-----|
+| **Create vs. Modify** | Distinguish new methods/classes from changes to existing ones. Name each method, the file it lives in, and approximate size. |
+| **Exact file paths** | Every slice lists the files it touches. No ambiguity about where changes land. |
+| **Method-level specificity** | Name the methods to create or modify. Reference line numbers or structural landmarks (e.g., "after the null-comparison branch in `ApplyNarrowing`") when modifying existing code. |
+| **Tests per slice** | Each slice specifies its test methods — names, assertion style (`[Fact]` vs `[Theory]` with row counts), and what each test verifies. Tests are part of the slice, not a separate phase. |
+| **Regression anchors** | For slices that replace or refactor existing behavior, list the exact existing test method names that must pass unchanged. |
+| **Dependency ordering** | State which slices must precede others and why. A reviewer should be able to read the ordering constraints and understand the critical path. |
+
+**Required plan-level elements:**
+
+| Element | Why |
+|---------|-----|
+| **File inventory table** | A single table mapping every file to the slices that touch it. Reviewers use this to scope their review. |
+| **Tooling/MCP sync assessment** | Explicit statement per category (syntax highlighting, completions, semantic tokens, MCP) — either "changes needed" with specifics or "no changes needed" with reasoning. |
+
+**How to build a plan (process):**
+
+1. **Read the full issue body AND all comments.** Implementation notes, scope additions, test requirements, and ordering constraints often appear in comments — not the body. Missing a comment means missing scope.
+2. **Explore the codebase** before planning. Locate the exact files, methods, and line numbers involved. A plan built on assumptions about code structure will be wrong.
+3. **Organize as vertical slices** — each slice is independently testable and delivers a coherent unit of behavior. Slices are not "parser, then type checker, then tests" — they are "feature X end-to-end including its tests."
+4. **Include the dependency graph.** If Slice 2 depends on Slice 1's infrastructure, say so explicitly. If slices can be parallelized, note that too.
+
+**Quality bar exemplar:** PR #108 (`feat: compile-time divisor safety via unified narrowing`) demonstrates the expected depth — 9 vertical slices with method-level specificity, exact file paths, ~56 edge-case tests mapped to slices, 16 named regression anchors, dependency ordering, and a file inventory table.
+
+**A plan that fails this bar is incomplete.** Send it back for detail before coding begins — just as a proposal without rationale is sent back for rationale.
 
 #### 5. Merge and Close
 


### PR DESCRIPTION
## Summary

Codifies the implementation plan quality standard demonstrated by PR #108 into three enforcement layers: process docs, squad skill, and agent charter/routing.

- **CONTRIBUTING.md** — new "Implementation Plan Quality Bar" section defining required per-slice elements (create vs modify, exact file paths, method-level specificity, tests, regression anchors, dependency ordering) and plan-level elements (file inventory, tooling/MCP sync assessment). Includes a 4-step planning process and cites PR #108 as the quality bar exemplar.
- **`.squad/skills/implementation-planning/SKILL.md`** — new squad skill covering the full planning workflow in 4 phases: issue research (read all comments), codebase exploration (locate exact methods/lines), vertical slice decomposition (slice anatomy template), and plan-level elements. Includes common mistakes table.
- **Frank's charter** — new "Implementation Plan Gate" section making plan authorship Frank's explicit responsibility before coding begins.
- **Squad coordinator** — updated Implementation Gate to require Frank to build the plan (step 5) before routing implementation work to agents.

## Why

PR #108 produced a plan with 9 vertical slices, method-level specificity, ~56 edge-case tests mapped to slices, 16 named regression anchors, and a dependency graph. This level of detail should be the norm, not the exception. Without explicit process enforcement, future plans will regress to vague checklists like "implement narrowing" that don't help implementers or reviewers.

The three layers ensure coverage:
- **CONTRIBUTING.md** defines what "good enough" means (any contributor can reference it)
- **Squad skill** teaches agents HOW to build plans (reusable workflow knowledge)
- **Frank charter + squad routing** enforces WHEN plans are required (gate before coding)