### PR TITLE
fix: step numbering in CONTRIBUTING.md + quality bar ref in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,7 @@ For issue-based implementation work:
 - Open or reuse the linked **draft PR** immediately and treat it as the execution hub for the issue.
 - Use the exact PR-body structure required by `CONTRIBUTING.md` and the repository PR template: `## Summary`, `## Linked Issue` (with `Closes #N`), `## Why`, and `## Implementation Plan`.
 - Keep the `## Summary` and `## Why` sections current so reviewers can see what changed and why without reconstructing it from the diff.
+- **Build a detailed implementation plan before coding.** The plan lives in the PR body's `## Implementation Plan` section and must meet the quality bar defined in `CONTRIBUTING.md` § Implementation Plan Quality Bar: vertical slices with method-level specificity, exact file paths, tests per slice, regression anchors, dependency ordering, file inventory, and tooling/MCP sync assessment.
 - Work in vertical slices. After each completed slice, commit, push, and update the PR-body summary/checklist before continuing.
 - Do **not** create a separate implementation-plan markdown file; the PR body is the ephemeral plan artifact for this repo.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ When ready to implement:
    - Tests (throughout, not at the end)
    - Sample files
    - Documentation updates
-6. Mark the PR as ready for review when all acceptance criteria are met.
+7. Mark the PR as ready for review when all acceptance criteria are met.
 
 #### 4. Documentation Sync (Same PR — Non-Negotiable)
 


### PR DESCRIPTION
## Summary\n\nTwo small fixes from the process-change review:\n\n1. **CONTRIBUTING.md** — duplicate step `6.` → renumber final step to `7.`\n2. **copilot-instructions.md** — add quality bar reference to the Issue Implementation Workflow section so non-Squad agents (default Copilot mode) also see the planning requirement\n\n## Why\n\nPR #109 introduced the Implementation Plan Quality Bar into CONTRIBUTING.md, Frank's charter, the squad skill, and the squad agent. But it missed two things:\n- A step-numbering bug (two step 6's) introduced when inserting the new step 4\n- The `copilot-instructions.md` Issue Implementation Workflow section didn't reference the quality bar, meaning agents outside Squad mode wouldn't know about it