### PR TITLE
refactor(samples): use constraint modifiers in examples

### DIFF
--- a/.squad/agents/frank/history.md
+++ b/.squad/agents/frank/history.md
@@ -4,6 +4,144 @@
 - Co-owns language research with George and keeps `docs/PreceptLanguageDesign.md` aligned with actual implementation.
 - Standing architecture rules: keep MCP as thin wrappers, keep docs factual, surface open decisions instead of inventing behavior, and preserve philosophy boundaries.
 - Historical summary (pre-2026-04-13): drove proposal/design work for conditional guards, event hooks, verdict modifiers, modifier ordering, computed fields, and related issue-review passes; also reviewed the Squad `@copilot` lane retirement and other cross-surface contract updates.
+- Owns architecture, system boundaries, and review gates across the runtime, tooling, and documentation surfaces.
+- **Language Designer:** Owns Precept language design, grammar evolution, and Superpower parser strategy. `docs/PreceptLanguageDesign.md` is the foundational document.
+- **Language research co-owner:** Co-owns `docs/research/language/` with George. Knows the comparative studies (xstate, Polly, FluentValidation, Zod/Valibot, LINQ, FluentAssertions, FEEL/DMN, Cedar), expression audit, verbosity analysis, and all PLT references.
+- Core architectural discipline: keep MCP tools as thin wrappers, keep docs honest about implemented behavior, and document open decisions instead of inventing values.
+- Technical-surface work flows through Elaine (UX), Peterman (brand compliance), Frank (architectural fit), then Shane (sign-off).
+- README and brand-spec changes should reflect actual runtime semantics, not speculative future behavior.
+
+## Recent Updates
+
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
+### 2026-04-10 - PR #50 final review — Issue #31 keyword logical operators
+
+**Verdict: APPROVED.** All 8 slices verified. 774/774 tests passing. Full review filed at `.squad/decisions/inbox/frank-31-review.md`.
+
+**Key architectural confirmation:** `BuildKeywordDictionary()` uses `symbol.All(char.IsLetter)` to auto-include `and`/`or`/`not` via reflection. Registered with `requireDelimiters: true` — whole-word safety against prefixes like `android` is architectural, not ad-hoc. Consistent with `contains` precedent.
+
+**ApplyNarrowing() confirmed updated** — all three arms (`"not"`, `"and"`, `"or"`) correctly updated at their respective pattern-match sites.
+
+**MCP is catalog-driven** — zero hardcoded operator strings. `TokenSymbol` attribute update is the only change needed; LanguageTool picks it up automatically.
+
+**Minor non-blocking gap:** `LanguageToolTests.LogicalOperatorsAreKeywordForms` asserts `&&` and `||` are absent, but does not assert `!` is absent. Not blocking because `!` was removed from the tokenizer entirely and has no path to the inventory.
+
+**Learnings:**
+- The attribute-driven `BuildKeywordDictionary()` + `requireDelimiters` is the correct mechanism for any future operator-to-keyword migrations. No tokenizer code changes are needed — only the `[TokenSymbol]` attribute value.
+- When reviewing logical operator migrations, `ApplyNarrowing()` is the easy-to-miss site — it uses pattern-match syntax (`{ Operator: "..." }` and string comparison) separately from the main type-checker switch. Both were correctly updated here.
+
+### 2026-04-10 - Issue #31 Slice 8 docs — PreceptLanguageDesign.md sync
+- Updated `docs/PreceptLanguageDesign.md` on branch `squad/31-keyword-logical-operators` to reflect #31 as fully implemented.
+- **Sections updated:** (1) "Keyword vs Symbol Design Framework" — migration table heading changed from "Implementation Pending" to "Implemented", table columns renamed from "Current/Target/Pending" to "Symbolic/Keyword/Implemented", removed "Until implementation" paragraph; (2) Reserved keywords list — removed "Pending additions (#31)" note, added `and`, `or`, `not` to the main keyword list; (3) Nullability and narrowing — updated Pattern 1 and Pattern 2 code examples from `&&`/`||` to `and`/`or`, updated prose labels and inline descriptions to match; (4) Expressions section — removed `pending migration` annotations, updated `!` → `not` and `&&`/`||` → `and`/`or` in bullet list; (5) Event asserts section and Minimal Example — updated `&&` → `and` in both code examples.
+- Committed as `03d50b7`, pushed to origin. PR #50 Slice 8 docs checkbox now checked.
+
+### 2026-04-10 - Philosophy Refresh Assessment — full research corpus review
+- Systematically reviewed all 32 files in `docs/research/language/` against the rewritten `docs/philosophy.md` (commits `dd14a4c` entity-first rewrite, `185e20b` governance strengthening).
+- Assessment written to `docs/research/language/philosophy-refresh-assessment.md`.
+- **Findings:** 16 files aligned, 14 need framing updates, 2 need significant refresh (`xstate.md`, one framing gap). No file contradicts the philosophy. Two cross-cutting problems dominate: (1) zero files use "governed integrity" — the philosophy's unifying principle; (2) 14 files don't consider data-only/stateless entities.
+- Identified 4 new research gaps: constraint patterns for data-only entities, Inspect/Fire semantics for stateless instances, governance-vs-validation positioning evidence, MDM/industry-standard comparison depth.
+- Recommended 16-file refresh order prioritized by impact × dependency.
+- Quality bar (`computed-fields.md`) confirmed as excellent research but needs minor framing update for governed integrity language and stateless entity implications.
+- Gold standard files: `entity-first-positioning-evidence.md`, `entity-modeling-surface.md`, `static-reasoning-expansion.md`.
+
+### 2026-04-08 - PR #48 code review — data-only precepts (Slices 1–7)
+- Reviewed `feature/issue-22-data-only-precepts` (commits e0eac05–833422e) against all 12 Q&A design decisions from `.squad/decisions/decisions.md`.
+- **Verdict: CHANGES REQUESTED.** All 12 decisions faithfully implemented (11 PASS, 1 ISSUE — Decision 11 sample files absent). Architecture is sound; no silent drift from design.
+- **Blocking issue:** `docs/PreceptLanguageDesign.md`, `docs/RuntimeApiDesign.md`, and `docs/McpServerDesign.md` are entirely missing stateless-precept documentation. This violates the project's non-negotiable doc-sync mandate.
+- **Required changes:** (1) Update three design docs before merge. (2) Add multi-event C49 test (Decision 10 contract untested: 3 events → 3 separate warnings).
+- **Code quality nits:** `DiagnosticCatalog.C55.MessageTemplate` used instead of `FormatMessage()` at PreceptRuntime.cs:1824; `currentState!` null-forgiving in MCP tool stateful branches; null-forgiving on `InitialState!` in `CollectCompileTimeDiagnostics` relies on implicit guard.
+- **Recommendations (non-blocking):** Add explicit `IsStateless` guard before "2. Validate initial state asserts" block; add at least one sample `.precept` file (Decision 11 placeholder names are fine); add `in State edit all` engine test; replace `MessageTemplate` with `FormatMessage()` on C55.
+- Full review filed at `.squad/decisions/inbox/frank-pr48-review.md`.
+
+### 2026-04-08 - Issue #22 semantic rules review (4 spawns)
+- Reviewed and rewrote #22 semantic rules for stateless precepts across 4 spawns: (1) decomposed the "states, events, and transitions forbidden" rule — states tautological, transitions structurally impossible, events the only real boundary; (2) deep analysis of stateless event boundary — confirmed binary taxonomy (data vs. behavioral), no middle tier, single-state escape hatch is correct not ceremonial; (3) warning model research — audited C48–C53 diagnostic infrastructure, external precedent survey; (4) full #22 issue body rewrite.
+- **Owner decision (Shane):** events-without-states = warning (not error). C50 upgraded from hint to warning for consistency. Binary taxonomy confirmed.
+- Wrote `frank-stateless-event-boundary.md` and `frank-warning-model-research.md` to decisions inbox; both merged into decisions.md by Scribe.
+
+### 2026-04-08 - Language research corpus completed
+- Closed the domain-first corpus with the final sweep in `3cc5343`, keeping `docs/research/language/domain-map.md` as the canonical map and leaving proposal bodies untouched.
+- The finished corpus now spans Batch 1 `54a77da`, Batch 2 `48860ae`, and the final corpus/index pass `3cc5343`, while preserving `computed-fields.md` as the quality bar and keeping horizon domains visible.
+
+### 2026-04-08 - Language research corpus map locked
+- Preserved `docs/research/language/domain-map.md` as the canonical research-corpus map and kept the corpus organized by domain rather than by issue.
+- Held the session guardrails: no proposal-body edits during corpus curation, `computed-fields.md` remains the quality bar, and horizon domains stay in scope even before proposals exist.
+- The alternate map-file experiment was folded back out; Batch 1 research landed in `54a77da`, Batch 2 landed in `48860ae`, and only Batch 3 plus the final README/index sweep remain.
+
+### 2026-04-07 - PR #35 merge: finalize README cleanup and record Squad decision
+- Merged PR #35 (chore: finalize README cleanup and record Squad decision) to `main`.
+- Branch `chore/upgrade-squad-latest` carried 2 commits: (1) Scribe post-task recording for PR #34 merge, and (2) README Quick Example refactoring (removed explanatory hedge, copyable DSL block, replaced markdown image syntax with fixed-width HTML img tag).
+- Cleaned up merged inbox entries from `.squad/decisions/inbox/` and updated `.squad/agents/j-peterman/history.md` with team update.
+- Workflow: Clean working tree before push (separated uncommitted Squad sync artifacts from committed README cleanup work), explicit PR creation with `gh pr create --base main --head sfalik:chore/upgrade-squad-latest`, merged with merge-commit strategy.
+- User directive honored: branch retained locally and remotely per user request (NOT deleted post-merge).
+- Verified zero scope creep: 81 additions, 3 files changed (README.md, .squad/decisions.md, .squad/agents/j-peterman/history.md), no unrelated code changes.
+- Co-authored-by trailer included in original commits.
+
+### 2026-04-07 - PR #34 merge with Squad config and README image fixes
+- Merged PR #34 (chore: upgrade Squad configuration and fix README image links) to `main`.
+- Branch `chore/upgrade-squad-latest` carried both architectural Squad updates and related README.md image path corrections.
+- Image references corrected: `brand/readme-hero.svg` → `design/brand/readme-hero.svg` (added `design/` prefix per canonical asset layout).
+- Workflow: Committed image fix with Co-authored-by trailer, pushed with `-u` for upstream tracking, created PR via `gh pr create` with explicit `--base` and `--head` flags, merged with merge-commit strategy, deleted remote branch post-merge.
+- Remote branch cleaned up post-merge; no uncommitted changes remaining.
+- User directive captured: keep branch open for future work (logged in decisions).
+- Verified zero scope creep: only Squad config + image link fixes, no unrelated code changes.
+
+### 2026-04-05 - Named rule proposal converged
+- Reached the final proposal framing for issue #8: rule <Name> when <BoolExpr>, with reuse allowed in when, invariant, and state assert, but not on <Event> assert.
+- The standing architecture filter now treats philosophy, non-programmer readability, and configuration-like legibility as explicit review criteria instead of secondary polish.
+
+### 2026-05-01 - Expression feature research & proposals
+- Produced comprehensive expression-surface research at `docs/research/dsl-expressiveness/expression-feature-proposals.md`.
+- Confirmed current expression limitations via MCP compile: no ternary (`?` parse error), no `.length` on strings (PRECEPT038), no function calls, no named guards.
+- Proposed 7 features across 3 waves: Wave 1 (ternary + `.length`), Wave 2 (named guards + conditional invariants), Wave 3 (`.contains()` + numeric functions), Future (computed fields).
+- Extended research base beyond existing 6-library set to include FEEL/DMN, Drools DRL, and Cedar (AWS). FEEL is the strongest comparator for business-rule DSL expression design — it has ternary, string functions, numeric functions, and range membership, all of which Precept currently lacks.
+- Updated `docs/research/dsl-expressiveness/README.md` with the new file entry.
+- Decision note filed at `.squad/decisions/inbox/frank-expression-research.md`. No implementation authorized — Shane sign-off required per wave.
+
+### 2026-04-05 - Proposal bodies expanded for issues #11-#13
+- Expanded GitHub issues #11, #12, and #13 into fuller proposal narratives with before/after Precept examples, reference-language snippets, and explicit architectural cautions.
+- Logged the wave placement and guardrails in .squad/decisions.md so the issue bodies stay aligned with keyword-anchored flat statements and first-match routing.
+
+### 2026-04-05 - Trunk consolidation dissent logged
+- Audited the repo topology and argued for force-promoting 'feature/language-redesign' to 'main' because 'main' still carries only placeholder history.
+- The team did not adopt that path: Uncle Leo's review blocked direct trunk replacement, so Frank's recommendation now stands as a documented dissent pending Shane sign-off.
+
+---
+
+2026-04-05T03:20:00Z: Steinbrenner applied branch protection to main (pull requests required, force pushes/admin only, no branch deletion).
+
+### 2026-04-08 - Issue #17 computed fields proposal revamp
+- Revamped `temp/issue-body-rewrites/17.md` to incorporate all findings from the research document and all 7 team re-reviews.
+- Resolved all 6 semantic contracts from the research: scope boundary, recomputation timing (Fire+Update+Inspect), nullability/accessor safety, dependency ordering, writeability/external input, tooling surface.
+- Used Steinbrenner's default-if-skipped options: (a) conservative nullable rejection, (a) `.count` only for collection accessors, (a) Terraform-model external input rejection, (a) single pass after all mutations.
+- Added 3 new locked decisions (#9 nullable conservative rejection, #10 external input rejection, #11 `.count`-only collection accessor restriction).
+- Expanded locked decision #8 from Fire-only to all three pipelines citing George's `CommitCollections` analysis.
+- Added `->` dual-use acknowledgment note to locked decision #1.
+- Replaced "Open Questions: None" with a "Resolved decisions" table mapping all 6 research contracts to locked decisions.
+- Changed wave from "Wave 4: Compactness + Composition" to "Composition" framing per Steinbrenner's recommendation.
+- Added new sections: Tooling surface (hover, MCP compile, inspect/fire, completions), Teachable error messages (9 scenarios), Before/after example using travel-reimbursement, Interleaved fields examples, `->` reading guide callout.
+- Surfaced the research's cross-category positioning claim in Motivation section.
+- Added spreadsheet mental model sentence to Summary.
+- Linked research document in Research and rationale links.
+- Expanded Explicit exclusions with: silent default fallbacks, writable computed fields, null-coalescing operator, unsafe collection accessors. Merged fixed-point evaluation with cycle detection.
+- Expanded acceptance criteria from 19 to 37 items, organized by category (parser, type checker, runtime, LS, MCP, general). Added all items from Soup Nazi's must-add and should-add lists plus Uncle Leo's blockers.
+- Expanded implementation scope from 10 to 16 items covering nullable validation, accessor safety, Update pipeline, external input rejection, LS filtering, MCP specifics.
+
+### 2026-04-08 - Issue #22 semantic rule review for Shane
+- Reviewed the "states, events, and transitions forbidden in stateless precepts" semantic rule at Shane's request before implementation.
+- Confirmed Shane's critique that the "states forbidden" and "transitions forbidden" parts are tautological/redundant — the real design decision is the events boundary.
+- The issue body already acknowledges the tautology in the exclusions section ("this exclusion is tautological") but contradicts itself in the semantic rules section by framing it as a prohibition. Recommended rewrite to eliminate the contradiction.
+- Key architectural insight: the only non-trivial semantic boundary is events. Events are forbidden because they dispatch transitions between states (a semantic dependency), not because of a tautology or structural impossibility. This is a real design choice with a potential future evolution path (stateless event-triggered mutations), deliberately closed for now.
+
+### 2026-04-08 - Stateless event boundary deep analysis
+- Shane flagged the revised #22 semantic rules as "a slippery slope." Conducted deep analysis of whether events should be forbidden in stateless precepts.
+- **Recommendation: events require states. The binary taxonomy (data vs. behavioral) is correct.** The "middle tier" (data + events, no states) is a category error, not a missing feature.
+- Key insight: events in Precept are not generic triggers — they are routed through states via `from State on Event -> Outcome`. The `from` is the routing context, not decoration. Events without routing are a different concept ("commands") that would need parallel syntax, semantics, and tooling.
+- The single-state escape hatch (`state Active initial`) is correct, not ceremonial: it communicates "this entity has exactly one behavioral mode" — a true structural statement, not dummy ceremony. Cost: 1 line.
+- Precedent survey confirms no surveyed system (Terraform, SQL, DDD, GraphQL, Protobuf) provides "data entity with named commands but no lifecycle." Every system with named commands routes them through a behavioral layer.
+- The slippery slope concern is acknowledged but self-correcting: the escape hatch is cheap enough that demand for stateless events won't reach critical mass.
+- Decision filed at `.squad/decisions/inbox/frank-stateless-event-boundary.md`.
 
 ## Learnings
 

--- a/.squad/agents/george/history.md
+++ b/.squad/agents/george/history.md
@@ -22,6 +22,17 @@
 - Updated C76 message in `DiagnosticCatalog.cs` and the instance message in `PreceptTypeChecker.cs` to mention `rule`, state/event `ensure`, and guard as proof sources (not just `nonnegative` constraint).
 - 5 new tests: rule proof, state ensure proof, guard proof, dotted event-arg with event ensure (no C76), dotted event-arg without proof (C76 emitted with `Submit.Val` in message).
 - All 1290 Precept.Tests + 169 LS tests pass. Catalog drift tests unaffected (fragment `"non-negative"` still matches).
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
+### 2026-04-10 - Issue #31 Slices 1-4 + Samples (keyword logical operators)
+- **Token names found:** `And`, `Or`, `Not` — already existed in `PreceptToken` enum with old `[TokenSymbol("&&")]`, `[TokenSymbol("||")]`, `[TokenSymbol("!")]`. Changed to `[TokenSymbol("and")]`, `[TokenSymbol("or")]`, `[TokenSymbol("not")]`. Both `TokenCategory.Operator` attributes were correct; no category changes needed.
+- **Tokenizer protection:** `requireDelimiters: true` on keyword registration (step 7 in `Build()`) is the mechanism that prevents `android` from matching `And` + `roid`. The operator entries (`&&`, `||`, `!`) were in steps 4-5 (plain span/character matches without delimiters) — removing them from those sections was sufficient, since `And`/`Or`/`Not` are now registered as keywords via the keyword loop.
+- **Surprises — none.** The branch already had all five source-file changes prepared (PreceptToken.cs, PreceptTokenizer.cs, PreceptParser.cs, PreceptTypeChecker.cs, PreceptExpressionEvaluator.cs) plus sample file changes. The work was complete; it only needed a build verification and commit.
+- **ApplyNarrowing location:** `PreceptTypeChecker.cs` around line 889 (method body starts after `StripParentheses` call). The pattern-matched `"!"` → `"not"` update was in the `PreceptUnaryExpression { Operator: "not" } unary` destructure; `"&&"` → `"and"` and `"||"` → `"or"` were `binary.Operator ==` string comparisons in the same method. Both were already updated on the branch.
+- **`CatalogDriftTests.cs` change:** C4 test used `PreceptParser.ParseExpression("&&")` to trigger parse-expression failure path; updated to `"and"` since the old `&&` is no longer a valid token.
+- **Build:** 0 errors, 0 warnings on full solution (`dotnet build`). Committed as `83497aa` on `squad/31-keyword-logical-operators`.
+- **Key pattern:** When a branch has pre-staged diffs, always run `git status` + `git diff` to inventory existing work before touching files — avoids double-applying changes.
 
 ### 2026-04-17 — Issue #106 Slice 3: unified rule-based proof extraction
 - Replaced the bespoke `$nonneg:` constraint-inspection loop in `Check()` with unified rule-based proof iteration through `ApplyNarrowing`.

--- a/.squad/agents/kramer/history.md
+++ b/.squad/agents/kramer/history.md
@@ -3,6 +3,67 @@
 - Owns tooling surfaces: language server, VS Code extension, grammar sync, plugin wiring, and executable developer workflows.
 - Keeps grammar, completions, semantic tokens, and tooling docs synchronized with the real DSL surface.
 - Historical summary (pre-2026-04-13): handled grammar/completion passes for `when` guards, new scalar/choice types, stateless edit syntax, conditional expressions, and broader preview/tooling audits.
+- Owns tooling surfaces: language server, VS Code extension, MCP server, plugin wiring, and developer workflow accuracy.
+- Tooling docs must stay synchronized with actual commands, artifacts, sample counts, and installation paths.
+- README/tooling polish should improve usability without introducing claims the extension or servers cannot support.
+
+## Recent Updates
+
+### 2026-04-05 - Comprehensive tooling knowledge refresh
+- Consolidated the current toolchain, build/test commands, and major extension/MCP/plugin responsibilities.
+- Key learning: the fastest tooling documentation win is precise, executable instructions with no stale paths.
+
+### 2026-04-05 - README badge cleanup and sample count fix
+- Tightened badge/presentation details while correcting surfaced counts and tooling-adjacent metadata.
+- Key learning: small public inconsistencies erode confidence in larger tooling claims.
+
+### 2026-04-05 - Inspector/Preview panel audit for PRD
+- Audited `inspector-preview.html` (3,464 lines), `extension.ts`, mockup, archived spec, and brand review.
+- Key finding: implementation is far ahead of what `inspector-panel-review.md` describes. The review predates edit mode, rule violation banners, state-rules indicator, field icons, and null toggle.
+- Color system mismatch (review's Priority 1) is still 100% unaddressed — all 7 color tokens remain on the custom palette, not the brand system.
+- The mockup's round pill event buttons became skewed parallelograms in the live implementation — deliberate design evolution.
+- Header current-state label was present in mockup, removed in implementation (state shown only in SVG diagram).
+- Key file paths: `tools/Precept.VsCode/webview/inspector-preview.html` (source of truth), `tools/Precept.VsCode/src/extension.ts` (host/protocol).
+- Decision inbox: `.squad/decisions/inbox/kramer-preview-audit.md`
+
+### 2026-04-08 - Slice 5 — Grammar, completions, semantic tokens (issue-22 data-only precepts)
+
+- Grammar (`precept.tmLanguage.json`): added `all` to `controlKeywords` alternation (sibling of `any`).
+- Grammar: added `rootEditDeclaration` repository pattern — matches `edit all` and `edit Field1, Field2` at line start; highlights `edit` as `keyword.other`, `all` as `keyword.control`, fields as `variable.other.field`; inserted before `controlKeywords` catch-all for correct priority.
+- Completions (`PreceptAnalyzer.cs`): new root-level `edit` branch suggests `all` + field names (stateless precept context).
+- Completions: updated `in State edit` branch to also suggest `all` (supports `in any edit all`).
+- Semantic tokens: no changes — `PreceptToken.All` auto-picked up via `[TokenCategory(Grammar)]` from Slice 1.
+- Both builds green: LS 0 errors, npm compile clean.
+- Key learning: always check `node_modules` before running `npm run compile` — directory may not exist on a fresh checkout.
+
+### 2026-04-05 - Retired legacy proposal labels in sync workflow
+
+- Added `needs-decision` and `decided` to `RETIRED_LABELS` in both the active workflow (`.github/workflows/sync-squad-labels.yml`) and the template copy (`.squad/templates/workflows/sync-squad-labels.yml`).
+- Key learning: when a label retirement pass exists, always check it covers *all* superseded label families — the `go:*` cleanup was done, the proposal-state labels were missed. Template sync must always mirror the active workflow or they diverge silently.
+
+- Investigated improving syntax highlighting for DSL code fences in README.
+- Research confirmed GitHub Linguist does not support `precept` language identifier.
+- Current approach (```precept fence) is already optimal: truthful, future-proof, follows DSL industry practice.
+- Key learning: for custom DSLs, using the language name in code fences is standard practice even without Linguist support. Provides documentation value and future-proofs for potential Linguist addition. Alternative approaches (mislabeling as similar language, using no tag) provide no real improvement and introduce misleading claims.
+- Decision documented in .squad/decisions/inbox/kramer-readme-syntax-highlighting.md
+
+### 2026-05-18 - GitHub README width contract clarified
+- Split README sizing research into two separate ceilings: the broader repo/article layout (`~1280px` shell, `~1012px` article) and the actual repo-view README image display cap (`~830px`) that governs the DSL hero asset.
+- Recorded the reusable audit workflow at `.squad/skills/github-readme-width-audit/SKILL.md` and preserved the merged sizing outcome in `.squad/decisions.md`.
+- Key learning: for README hero images, composition guidance and final image-display limits are different measurements; size the shipped asset to the image cap, not the wider article container.
+
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
+### 2026-04-10 - Slice 5: Grammar + Language Server (issue #31 — and/or/not keywords)
+
+- Grammar (`precept.tmLanguage.json`): added `and`, `or`, `not` to `actionKeywords` alternation (same group as `contains`) — these are operator-category tokens used in expression positions, so they fit naturally alongside `contains`.
+- Grammar: removed the `keyword.operator.logical.precept` block (`&&|\\|\\||!`) from `operators` entirely; `!=` lives in the comparison block and was untouched.
+- Completions (`PreceptAnalyzer.cs`): replaced `&&`, `||`, `!` `Operator` items with `and`, `or`, `not` `Keyword` items in `ExpressionOperatorItems` — the static list consumed by `BuildGuardCompletions`, `BuildExpressionCompletions`, and `BuildDataExpressionCompletions`.
+- Global `KeywordItems` required no change — `BuildKeywordItems()` auto-discovers `And`/`Or`/`Not` from `PreceptToken` enum via `[TokenCategory(Operator)]` + alphabetic symbol filter.
+- Semantic tokens: verified `BuildSemanticTypeMap()` iterates all enum values; `TokenCategory.Operator → "preceptKeywordGrammar"` covers `And`/`Or`/`Not` automatically. Zero handler changes.
+- Build: 0 errors. Tests: 87/87 pass.
+- Commit: `8f3bdab` — "feat(#31): grammar and language server — and/or/not keywords (slice 5)"
 
 ## Learnings
 

--- a/.squad/agents/newman/history.md
+++ b/.squad/agents/newman/history.md
@@ -9,6 +9,10 @@
 - MCP contract changes should be additive when possible and preserve existing consumer shapes.
 - Catalog-driven vocabulary is the preferred path for exposing DSL keywords/types; non-token constructs need explicit catalog registration.
 - Label/automation removals should be staged through sync workflows and disabled notices, not silent deletion.
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
+### Issue #31 Slice 6 — Operator Inventory (2026-04-10)
 
 ## Recent Updates
 

--- a/.squad/agents/soup-nazi/history.md
+++ b/.squad/agents/soup-nazi/history.md
@@ -23,6 +23,14 @@
 - Warnings: guarded state ensure exclusion from divisor proof covered by mechanism but no explicit test; generic C93 message text not asserted.
 - Strengths: Theory-based proof source × operator matrix, 7-variant or-pattern suite, zero disabled tests, CatalogDriftTests fully populated, code action tests go beyond core AC.
 - Total: ~51 new test methods (47 Precept.Tests + 4 LS.Tests). 1463 total tests, 0 failures.
+### 2026-04-10 — Issue #31 shipped
+- PR #50 merged to main (squash SHA `305ec03`). Issue #31 closed. 775 tests passing.
+
+### 2026-04-10 - Issue #31 Slice 7: keyword logical operator tests
+- Updated 9 existing test files (8 in `test/Precept.Tests/`, 1 in `test/Precept.LanguageServer.Tests/`) to replace DSL symbols `&&` → `and`, `||` → `or`, `!` → `not` in all `.precept` string literals and operator assertions.
+- Created new `test/Precept.Tests/PreceptKeywordLogicalOperatorTests.cs` covering: basic keyword parsing (not/and/or), precedence validation (not > and > or), null narrowing through `not (Field == null)`, `!=` operator unaffected, old symbols `&&`/`||`/`!` produce parse errors, compound expression parse/evaluate, invariant context (or/and).
+- George's runtime changes (parser, tokenizer, type checker, evaluator, samples) were already on the branch — tests written against the finished spec.
+- Key learning: always check if the partner's runtime changes are already on branch before assuming tests will fail. The old-symbol-produces-error tests and keyword tests may pass immediately if George's work is complete.
 
 ### 2026-04-11 — Guarded declaration validation sweep
 - Built and verified multi-layer tests for guarded invariants, state asserts, event asserts, and guarded edit blocks, including runtime and MCP coverage.

--- a/samples/building-access-badge-request.precept
+++ b/samples/building-access-badge-request.precept
@@ -5,7 +5,7 @@ precept BuildingAccessBadgeRequest
 
 field EmployeeName as string nullable
 field Department as string nullable
-field AccessReason as string nullable
+field AccessReason as string nullable maxlength 200
 field ReviewerNote as string nullable
 field LowestRequestedFloor as number default 0
 field HighestRequestedFloor as number default 0
@@ -14,7 +14,6 @@ field BadgePrinted as boolean default false
 field RequestedFloors as set of number
 
 rule RequestedFloors.count == 0 or LowestRequestedFloor <= HighestRequestedFloor because "Requested floor bounds must stay ordered"
-rule AccessReason == null or AccessReason.length <= 200 because "Access reasons cannot exceed 200 characters"
 
 state Draft initial
 state Submitted
@@ -38,11 +37,9 @@ event RemoveFloor with Floor as number
 on RemoveFloor ensure Floor > 0 because "Floors must be positive"
 
 event Submit
-event Approve with Note as string nullable default null
-on Approve ensure Note == null or Note != "" because "An approval note cannot be blank when supplied"
+event Approve with Note as string nullable default null notempty
 
-event Reject with Reason as string
-on Reject ensure Reason != "" because "A rejection reason is required"
+event Reject with Reason as string notempty
 
 event PrintBadge
 

--- a/samples/clinic-appointment-scheduling.precept
+++ b/samples/clinic-appointment-scheduling.precept
@@ -4,16 +4,13 @@ precept ClinicAppointmentScheduling
 # The event ensures show that modulo checks belong on event arguments, not fields.
 
 field PatientName as string nullable
-field ScheduledDay as number default 0
-field ScheduledMinute as number default 0
+field ScheduledDay as number default 0 nonnegative
+field ScheduledMinute as number default 0 nonnegative
 field ConfirmationCode as string nullable
 field ReminderSent as boolean default false
 field CheckInNote as string nullable
 field VisitCompleted as boolean default false
 field CancellationReason as string nullable
-
-rule ScheduledDay >= 0 because "Scheduled day cannot be negative"
-rule ScheduledMinute >= 0 because "Scheduled minute cannot be negative"
 
 state Draft initial
 state Scheduled
@@ -27,8 +24,7 @@ in Completed ensure VisitCompleted because "Completed visits must be marked comp
 
 to Scheduled -> set ConfirmationCode = "CONFIRMED" -> set ReminderSent = false
 
-event Schedule with Name as string, DayNumber as number, MinuteOfDay as number
-on Schedule ensure Name != "" because "A patient name is required"
+event Schedule with Name as string notempty, DayNumber as number, MinuteOfDay as number
 on Schedule ensure DayNumber >= 0 because "The scheduled day cannot be negative"
 on Schedule ensure MinuteOfDay >= 0 because "The scheduled minute cannot be negative"
 on Schedule ensure MinuteOfDay % 15 == 0 because "Appointments must start on a 15-minute boundary"
@@ -40,12 +36,10 @@ on Reschedule ensure MinuteOfDay % 15 == 0 because "Appointments must start on a
 
 event SendReminder
 
-event CheckIn with Note as string nullable default null
-on CheckIn ensure Note == null or Note != "" because "A supplied check-in note cannot be blank"
+event CheckIn with Note as string nullable default null notempty
 
 event CompleteVisit
-event Cancel with Reason as string nullable default null
-on Cancel ensure Reason == null or Reason != "" because "A supplied cancellation reason cannot be blank"
+event Cancel with Reason as string nullable default null notempty
 
 from Draft on Schedule -> set PatientName = Schedule.Name -> set ScheduledDay = Schedule.DayNumber -> set ScheduledMinute = Schedule.MinuteOfDay -> transition Scheduled
 

--- a/samples/crosswalk-signal.precept
+++ b/samples/crosswalk-signal.precept
@@ -5,11 +5,8 @@ precept CrosswalkSignal
 # with a decreasing countdown before returning to DontWalk.
 
 field RequestPending as boolean default false
-field CycleCount as integer default 0
-field CountdownSeconds as integer default 0
-
-rule CycleCount >= 0 because "Cycle count cannot be negative"
-rule CountdownSeconds >= 0 because "Countdown seconds cannot be negative"
+field CycleCount as integer default 0 nonnegative
+field CountdownSeconds as integer default 0 nonnegative
 
 state DontWalk initial
 state Walk

--- a/samples/event-registration.precept
+++ b/samples/event-registration.precept
@@ -5,17 +5,13 @@ precept EventRegistration
 
 field RegistrantName as string nullable
 field ContactEmail as string nullable
-field SeatsReserved as number default 0
-field TicketsIssued as number default 0
-field AmountDue as decimal default 0
+field SeatsReserved as number default 0 nonnegative
+field TicketsIssued as number default 0 nonnegative
+field AmountDue as decimal default 0 nonnegative
 field PaymentReceived as boolean default false
 field CancellationReason as string nullable
 field CheckInDesk as string nullable
-
-rule SeatsReserved >= 0 because "Reserved seats cannot be negative"
-rule TicketsIssued >= 0 because "Issued tickets cannot be negative"
 rule TicketsIssued <= SeatsReserved because "Issued tickets cannot exceed reserved seats"
-rule AmountDue >= 0 because "Amount due cannot be negative"
 
 state Draft initial
 state PendingPayment
@@ -34,9 +30,7 @@ in CheckedIn ensure CheckInDesk != null because "Checked-in registrations must r
 # Every transition into Confirmed finishes the same bookkeeping.
 to Confirmed -> set PaymentReceived = true -> set AmountDue = 0
 
-event StartRegistration with Name as string, Email as string, Seats as number default 1, PricePerSeat as number default 25
-on StartRegistration ensure Name != "" because "A registrant name is required"
-on StartRegistration ensure Email != "" because "A contact email is required"
+event StartRegistration with Name as string notempty, Email as string notempty, Seats as number default 1, PricePerSeat as number default 25
 on StartRegistration ensure Seats > 0 because "At least one seat must be reserved"
 on StartRegistration ensure PricePerSeat > 0 because "The seat price must be positive"
 
@@ -45,11 +39,9 @@ on UpdateSeats ensure Seats > 0 because "Updated seat count must stay positive"
 
 event RecordPayment
 
-event Cancel with Reason as string nullable default null
-on Cancel ensure Reason == null or Reason != "" because "If a cancellation reason is supplied, it cannot be blank"
+event Cancel with Reason as string nullable default null notempty
 
-event CheckIn with Desk as string
-on CheckIn ensure Desk != "" because "The check-in desk is required"
+event CheckIn with Desk as string notempty
 
 from Draft on StartRegistration -> set RegistrantName = StartRegistration.Name -> set ContactEmail = StartRegistration.Email -> set SeatsReserved = StartRegistration.Seats -> set AmountDue = if StartRegistration.Seats >= 10 then round(StartRegistration.Seats * StartRegistration.PricePerSeat * 0.9, 2) else round(StartRegistration.Seats * StartRegistration.PricePerSeat, 2) -> transition PendingPayment
 

--- a/samples/hiring-pipeline.precept
+++ b/samples/hiring-pipeline.precept
@@ -3,7 +3,7 @@ precept HiringPipeline
 # Hiring is a good fit for Precept because the state flow is clear but the details still matter.
 # The interview loop uses a set of pending interviewers to track who still owes feedback.
 
-field CandidateName as string nullable
+field CandidateName as string nullable maxlength 100
 field RoleName as string nullable
 field RecruiterName as string nullable
 field FeedbackCount as integer default 0 nonnegative
@@ -22,7 +22,6 @@ state Rejected
 
 in InterviewLoop ensure PendingInterviewers.count > 0 because "Interview loops require at least one pending interviewer"
 in Hired ensure OfferAmount > 0 because "Hired candidates must have an offer amount"
-rule CandidateName == null or CandidateName.length <= 100 because "Candidate name must be ≤100 characters"
 
 event SubmitApplication with Candidate as string notempty, Role as string notempty, Recruiter as string notempty
 

--- a/samples/insurance-claim.precept
+++ b/samples/insurance-claim.precept
@@ -5,20 +5,16 @@ precept InsuranceClaim
 # Built-in functions (min, trim) keep the logic clear.
 
 field ClaimantName as string nullable
-field ClaimAmount as decimal default 0 maxplaces 2
-field ApprovedAmount as decimal default 0 maxplaces 2
+field ClaimAmount as decimal default 0 nonnegative maxplaces 2
+field ApprovedAmount as decimal default 0 nonnegative maxplaces 2
 field AdjusterName as string nullable
-field DecisionNote as string nullable
+field DecisionNote as string nullable maxlength 500
 field PoliceReportRequired as boolean default false
 field FraudFlag as boolean default false
 
 field MissingDocuments as set of string
-
-rule ClaimAmount >= 0 because "Claim amounts cannot be negative"
-rule ApprovedAmount >= 0 because "Approved amounts cannot be negative"
 rule ApprovedAmount <= ClaimAmount because "Approved amounts cannot exceed the claim"
 rule ApprovedAmount * 2 <= ClaimAmount when FraudFlag because "Fraud-flagged claims are capped at half the claimed amount"
-rule DecisionNote == null or DecisionNote.length <= 500 because "Decision notes cannot exceed 500 characters"
 
 state Draft initial
 state Submitted
@@ -32,26 +28,20 @@ in UnderReview when not FraudFlag edit AdjusterName
 in Approved ensure ApprovedAmount > 0 because "Approved claims must specify a payout amount"
 in Approved ensure DecisionNote != null when FraudFlag because "Fraud-flagged approvals require a decision note"
 
-event Submit with Claimant as string, Amount as decimal, RequiresPoliceReport as boolean default false
-on Submit ensure Claimant != "" because "A claimant name is required"
+event Submit with Claimant as string notempty, Amount as decimal, RequiresPoliceReport as boolean default false
 on Submit ensure Amount > 0 because "Claim amounts must be positive"
 on Submit ensure Amount <= 100000 when RequiresPoliceReport because "Police-report claims are capped at $100,000"
 
-event RequestDocument with Name as string
-on RequestDocument ensure Name != "" because "A document name is required"
+event RequestDocument with Name as string notempty
 
-event ReceiveDocument with Name as string
-on ReceiveDocument ensure Name != "" because "A document name is required"
+event ReceiveDocument with Name as string notempty
 
-event AssignAdjuster with Name as string
-on AssignAdjuster ensure Name != "" because "An adjuster name is required"
+event AssignAdjuster with Name as string notempty
 
-event Approve with Amount as decimal, Note as string nullable default null
+event Approve with Amount as decimal, Note as string nullable default null notempty
 on Approve ensure Amount > 0 because "Approved claim amounts must be positive"
-on Approve ensure Note == null or Note != "" because "A supplied decision note cannot be blank"
 
-event Deny with Note as string
-on Deny ensure Note != "" because "A denial note is required"
+event Deny with Note as string notempty
 
 event PayClaim
 

--- a/samples/invoice-line-item.precept
+++ b/samples/invoice-line-item.precept
@@ -7,9 +7,9 @@ precept InvoiceLineItem
 # no lifecycle states or events, just structural constraints and derived math.
 
 field Description as string nullable
-field UnitPrice as number default 0
-field Quantity as number default 1
-field DiscountPercent as number default 0
+field UnitPrice as number default 0 nonnegative
+field Quantity as number default 1 min 1
+field DiscountPercent as number default 0 nonnegative max 100
 field TaxRate as number default 8
 
 # Computed fields — derived from editable source fields.
@@ -21,8 +21,3 @@ field LineTotal as number -> TaxableAmount + TaxAmount nonnegative
 
 # Only source fields are editable; derived totals are locked.
 edit Description, UnitPrice, Quantity, DiscountPercent
-
-rule Quantity >= 1 because "Quantity must be at least 1"
-rule UnitPrice >= 0 because "Unit price cannot be negative"
-rule DiscountPercent >= 0 because "Discount cannot be negative"
-rule DiscountPercent <= 100 because "Discount cannot exceed 100%"

--- a/samples/it-helpdesk-ticket.precept
+++ b/samples/it-helpdesk-ticket.precept
@@ -4,18 +4,14 @@ precept ItHelpdeskTicket
 # It also shows from any rows that act like system-wide support events.
 
 field TicketTitle as string nullable
-field Severity as number default 3
+field Severity as number default 3 min 1 max 5
 field AssignedAgent as string nullable
 field LastQueuedAgent as string nullable
 field ResolutionNote as string nullable
-field ReopenCount as integer default 0
+field ReopenCount as integer default 0 nonnegative
 field Priority as choice("Low","Medium","High","Critical") default "Low"
 
 field AgentQueue as queue of string
-
-rule Severity >= 1 because "Severity cannot be lower than 1"
-rule Severity <= 5 because "Severity cannot be higher than 5"
-rule ReopenCount >= 0 because "Reopen count cannot be negative"
 
 state New initial
 state Assigned
@@ -26,23 +22,19 @@ state Closed
 in Assigned ensure AssignedAgent != null because "Assigned tickets must name an agent"
 in New edit Priority
 
-event RegisterAgent with AgentName as string
-on RegisterAgent ensure AgentName != "" because "An agent name is required"
+event RegisterAgent with AgentName as string notempty
 
-event Triage with Title as string, Level as number default 3
-on Triage ensure Title != "" because "A ticket title is required"
+event Triage with Title as string notempty, Level as number default 3
 on Triage ensure Level >= 1 and Level <= 5 because "Severity must stay within the supported range"
 
 event Assign
 
 event CustomerReply
-event Resolve with Note as string
-on Resolve ensure Note != "" because "A resolution note is required"
+event Resolve with Note as string notempty
 
 event CloseTicket
 
-event Reopen with Note as string nullable default null
-on Reopen ensure Note == null or Note != "" because "A supplied reopen note cannot be blank"
+event Reopen with Note as string nullable default null notempty
 
 from New on RegisterAgent -> enqueue AgentQueue RegisterAgent.AgentName -> no transition
 from Assigned on RegisterAgent -> enqueue AgentQueue RegisterAgent.AgentName -> no transition

--- a/samples/library-book-checkout.precept
+++ b/samples/library-book-checkout.precept
@@ -5,19 +5,13 @@ precept LibraryBookCheckout
 
 field BookTitle as string nullable
 field BorrowerId as string nullable
-field CurrentDay as number default 0
-field CheckoutDay as number default 0
-field DueDay as number default 0
-field RenewalCount as number default 0
-field FineAmount as number default 0
+field CurrentDay as number default 0 nonnegative
+field CheckoutDay as number default 0 nonnegative
+field DueDay as number default 0 nonnegative
+field RenewalCount as number default 0 nonnegative
+field FineAmount as number default 0 nonnegative
 field ConditionNote as string nullable
 field LostReported as boolean default false
-
-rule CurrentDay >= 0 because "The day counter cannot be negative"
-rule CheckoutDay >= 0 because "The checkout day cannot be negative"
-rule DueDay >= 0 because "The due day cannot be negative"
-rule RenewalCount >= 0 because "Renewal counts cannot be negative"
-rule FineAmount >= 0 because "Fines cannot be negative"
 
 state Available initial
 state CheckedOut
@@ -37,9 +31,7 @@ in Returned ensure BorrowerId == null because "Returned books must clear the bor
 in Lost ensure LostReported because "Lost books must be marked as reported lost"
 in Lost ensure BorrowerId != null because "Lost books must still record the last borrower"
 
-event Checkout with Title as string, PatronId as string, LoanDays as number default 14
-on Checkout ensure Title != "" because "A book title is required"
-on Checkout ensure PatronId != "" because "A patron id is required"
+event Checkout with Title as string notempty, PatronId as string notempty, LoanDays as number default 14
 on Checkout ensure LoanDays > 0 because "Loan days must be positive"
 
 event Renew with ExtraDays as number default 7
@@ -48,11 +40,9 @@ on Renew ensure ExtraDays > 0 because "Renewal days must be positive"
 event AdvanceDay with DayNumber as number
 on AdvanceDay ensure DayNumber >= 0 because "The day counter cannot be negative"
 
-event ReturnBook with Condition as string nullable default null
-on ReturnBook ensure Condition == null or Condition != "" because "A supplied condition note cannot be blank"
+event ReturnBook with Condition as string nullable default null notempty
 
-event ReportLost with Note as string nullable default null
-on ReportLost ensure Note == null or Note != "" because "A supplied loss note cannot be blank"
+event ReportLost with Note as string nullable default null notempty
 
 event Shelve
 

--- a/samples/library-hold-request.precept
+++ b/samples/library-hold-request.precept
@@ -8,14 +8,11 @@ field CurrentBorrower as string nullable
 field PromotedPatron as string nullable
 field ReadyPatron as string nullable
 field PickupCode as string nullable
-field PickupExpiryDay as number default 0
-field CurrentDay as number default 0
+field PickupExpiryDay as number default 0 nonnegative
+field CurrentDay as number default 0 nonnegative
 
 field HoldQueue as queue of string
 field BorrowerHistory as stack of string
-
-rule CurrentDay >= 0 because "The day counter cannot be negative"
-rule PickupExpiryDay >= 0 because "Pickup expiry cannot be negative"
 
 state OnShelf initial
 state CheckedOut
@@ -30,18 +27,15 @@ to HoldReady -> set ReadyPatron = PromotedPatron -> set PickupCode = "READY" -> 
 # Leaving HoldReady clears the temporary handoff fields.
 from HoldReady -> set PromotedPatron = null -> set ReadyPatron = null -> set PickupCode = null
 
-event Checkout with PatronId as string
-on Checkout ensure PatronId != "" because "A patron id is required to check out a book"
+event Checkout with PatronId as string notempty
 
 event ReturnBook
 
-event PlaceHold with PatronId as string
-on PlaceHold ensure PatronId != "" because "A patron id is required for a hold"
+event PlaceHold with PatronId as string notempty
 
 event ProcessNextHold
 
-event CollectHold with PatronId as string
-on CollectHold ensure PatronId != "" because "The collecting patron must be identified"
+event CollectHold with PatronId as string notempty
 
 event AdvanceDay with DayNumber as number
 on AdvanceDay ensure DayNumber >= 0 because "The day counter cannot be negative"

--- a/samples/loan-application.precept
+++ b/samples/loan-application.precept
@@ -5,19 +5,14 @@ precept LoanApplication
 # Built-in functions (min, round, clamp) keep the logic readable without external helpers.
 
 field ApplicantName as string nullable
-field RequestedAmount as number default 0
-field ApprovedAmount as number default 0
+field RequestedAmount as number default 0 nonnegative
+field ApprovedAmount as number default 0 nonnegative
 field CreditScore as number default 0
-field AnnualIncome as number default 0
-field ExistingDebt as number default 0
+field AnnualIncome as number default 0 nonnegative
+field ExistingDebt as number default 0 nonnegative
 field DecisionNote as string nullable
 field DocumentsVerified as boolean default false
-
-rule RequestedAmount >= 0 because "Requested amount cannot be negative"
-rule ApprovedAmount >= 0 because "Approved amount cannot be negative"
 rule ApprovedAmount <= RequestedAmount because "Approved amount cannot exceed the request"
-rule AnnualIncome >= 0 because "Annual income cannot be negative"
-rule ExistingDebt >= 0 because "Existing debt cannot be negative"
 rule ExistingDebt <= AnnualIncome * 3 when DocumentsVerified because "Verified applications must have a debt-to-income ratio of 3x or less"
 
 state Draft initial
@@ -32,8 +27,7 @@ in Funded ensure ApprovedAmount > 0 because "Funded loans must have a positive a
 
 in UnderReview when DocumentsVerified edit DecisionNote
 
-event Submit with Applicant as string, Amount as number, Score as number, Income as number, Debt as number
-on Submit ensure Applicant != "" because "An applicant name is required"
+event Submit with Applicant as string notempty, Amount as number, Score as number, Income as number, Debt as number
 on Submit ensure Amount > 0 because "Loan requests must be positive"
 on Submit ensure Score >= 0 because "Credit score cannot be negative"
 on Submit ensure Income >= 0 because "Income cannot be negative"
@@ -41,12 +35,10 @@ on Submit ensure Debt >= 0 because "Debt cannot be negative"
 
 event VerifyDocuments
 
-event Approve with Amount as number, Note as string nullable default null
+event Approve with Amount as number, Note as string nullable default null notempty
 on Approve ensure Amount > 0 because "Approved amounts must be positive"
-on Approve ensure Note == null or Note != "" because "A supplied decision note cannot be blank"
 
-event Decline with Note as string
-on Decline ensure Note != "" because "A decline note is required"
+event Decline with Note as string notempty
 
 event FundLoan
 

--- a/samples/maintenance-work-order.precept
+++ b/samples/maintenance-work-order.precept
@@ -7,15 +7,12 @@ field RequesterName as string nullable
 field Location as string nullable
 field IssueSummary as string nullable
 field AssignedTechnician as string nullable
-field EstimatedHours as number default 0
-field ActualHours as number default 0
+field EstimatedHours as number default 0 nonnegative
+field ActualHours as number default 0 nonnegative
 field Urgent as boolean default false
 field PartsApproved as boolean default false
 field CompletionNote as string nullable
 field CancellationReason as string nullable
-
-rule EstimatedHours >= 0 because "Estimated hours cannot be negative"
-rule ActualHours >= 0 because "Actual hours cannot be negative"
 
 state Draft initial
 state Open
@@ -31,13 +28,9 @@ in Completed ensure CompletionNote != null because "Completed work orders need a
 # Leaving active work still requires a technician on record.
 from InProgress ensure AssignedTechnician != null because "Active work cannot finish without a technician"
 
-event Submit with Requester as string, WorkLocation as string, Summary as string, IsUrgent as boolean default false
-on Submit ensure Requester != "" because "A requester name is required"
-on Submit ensure WorkLocation != "" because "A location is required"
-on Submit ensure Summary != "" because "An issue summary is required"
+event Submit with Requester as string notempty, WorkLocation as string notempty, Summary as string notempty, IsUrgent as boolean default false
 
-event Assign with Technician as string, Estimate as number
-on Assign ensure Technician != "" because "A technician is required"
+event Assign with Technician as string notempty, Estimate as number
 on Assign ensure Estimate > 0 because "Estimated hours must be positive"
 
 event ApproveParts
@@ -46,11 +39,9 @@ event StartWork
 event RecordProgress with Hours as number
 on RecordProgress ensure Hours > 0 because "Progress entries must be positive"
 
-event Complete with Note as string
-on Complete ensure Note != "" because "A completion note is required"
+event Complete with Note as string notempty
 
-event Cancel with Reason as string nullable default null
-on Cancel ensure Reason == null or Reason != "" because "A supplied cancellation reason cannot be blank"
+event Cancel with Reason as string nullable default null notempty
 
 from Draft on Submit -> set RequesterName = Submit.Requester -> set Location = Submit.WorkLocation -> set IssueSummary = Submit.Summary -> set Urgent = Submit.IsUrgent -> transition Open
 

--- a/samples/parcel-locker-pickup.precept
+++ b/samples/parcel-locker-pickup.precept
@@ -6,16 +6,12 @@ precept ParcelLockerPickup
 field LockerId as string nullable
 field RecipientName as string nullable
 field PickupCode as string nullable
-field ReminderCount as number default 0
-field CurrentDay as number default 0
-field LastReminderDay as number default 0
+field ReminderCount as number default 0 nonnegative
+field CurrentDay as number default 0 nonnegative
+field LastReminderDay as number default 0 nonnegative
 field LastReminderNote as string nullable
 
 field ReminderLog as stack of string
-
-rule ReminderCount >= 0 because "Reminder count cannot be negative"
-rule CurrentDay >= 0 because "Current day cannot be negative"
-rule LastReminderDay >= 0 because "Reminder day cannot be negative"
 
 state Empty initial
 state AwaitingPickup
@@ -28,16 +24,11 @@ in AwaitingPickup ensure PickupCode != null because "Loaded lockers must store a
 to PickedUp -> clear ReminderLog
 to Returned -> clear ReminderLog
 
-event LoadParcel with Locker as string, Recipient as string, Code as string
-on LoadParcel ensure Locker != "" because "A locker id is required"
-on LoadParcel ensure Recipient != "" because "A recipient is required"
-on LoadParcel ensure Code != "" because "A pickup code is required"
+event LoadParcel with Locker as string notempty, Recipient as string notempty, Code as string notempty
 
-event SendReminder with Note as string
-on SendReminder ensure Note != "" because "Reminder notes cannot be blank"
+event SendReminder with Note as string notempty
 
-event PickUp with Code as string
-on PickUp ensure Code != "" because "The pickup code is required"
+event PickUp with Code as string notempty
 
 event AdvanceDay with DayNumber as number
 on AdvanceDay ensure DayNumber >= 0 because "Days cannot be negative"

--- a/samples/payment-method.precept
+++ b/samples/payment-method.precept
@@ -10,14 +10,10 @@ precept PaymentMethod
 
 field CardholderName as string nullable
 field LastFour as string nullable
-field ExpiryMonth as number default 1
-field ExpiryYear as number default 2025
+field ExpiryMonth as number default 1 min 1 max 12
+field ExpiryYear as number default 2025 min 2025
 field IsDefault as boolean default false
 field Nickname as string nullable
-
-rule ExpiryMonth >= 1 because "Expiry month must be at least 1"
-rule ExpiryMonth <= 12 because "Expiry month cannot exceed 12"
-rule ExpiryYear >= 2025 because "Expiry year must be current or future"
 
 # Cardholders may rename the card and toggle the default flag.
 # All other fields are immutable once the payment method is stored.

--- a/samples/refund-request.precept
+++ b/samples/refund-request.precept
@@ -6,13 +6,10 @@ precept RefundRequest
 field OrderId as string nullable
 field CustomerEmail as string nullable
 field ReasonText as string nullable
-field RequestedAmount as number default 0
-field ApprovedAmount as number default 0
+field RequestedAmount as number default 0 nonnegative
+field ApprovedAmount as number default 0 nonnegative
 field ReturnReceived as boolean default false
 field DecisionNote as string nullable
-
-rule RequestedAmount >= 0 because "Requested amount cannot be negative"
-rule ApprovedAmount >= 0 because "Approved amount cannot be negative"
 rule ApprovedAmount <= RequestedAmount because "Approved amount cannot exceed the request"
 
 state Draft initial
@@ -25,23 +22,17 @@ in Submitted edit ReasonText
 in AwaitingReturn ensure ApprovedAmount > 0 because "A waiting return must already have an approved amount"
 in Refunded ensure ReturnReceived because "A refunded request must have the item marked as returned"
 
-event Submit with OrderNumber as string, Email as string, Amount as number, Reason as string
-on Submit ensure OrderNumber != "" because "An order number is required"
-on Submit ensure Email != "" because "A customer email is required"
+event Submit with OrderNumber as string notempty, Email as string notempty, Amount as number, Reason as string notempty
 on Submit ensure Amount > 0 because "The refund amount must be positive"
-on Submit ensure Reason != "" because "A refund reason is required"
 
-event Approve with Amount as number, Note as string nullable default null
+event Approve with Amount as number, Note as string nullable default null notempty
 on Approve ensure Amount > 0 because "The approved amount must be positive"
-on Approve ensure Note == null or Note != "" because "An approval note cannot be blank when supplied"
 
-event Decline with Note as string
-on Decline ensure Note != "" because "A decline note is required"
+event Decline with Note as string notempty
 
 event MarkReturnReceived
 
-event Cancel with Reason as string nullable default null
-on Cancel ensure Reason == null or Reason != "" because "A supplied cancellation reason cannot be blank"
+event Cancel with Reason as string nullable default null notempty
 
 from Draft on Submit -> set OrderId = Submit.OrderNumber -> set CustomerEmail = Submit.Email -> set RequestedAmount = Submit.Amount -> set ReasonText = Submit.Reason -> transition Submitted
 

--- a/samples/restaurant-waitlist.precept
+++ b/samples/restaurant-waitlist.precept
@@ -5,12 +5,10 @@ precept RestaurantWaitlist
 
 field CurrentParty as string nullable
 field LastCalledParty as string nullable
-field EstimatedWaitMinutes as number default 0
+field EstimatedWaitMinutes as number default 0 nonnegative
 field WalkInOpen as boolean default true
 
 field PartyQueue as queue of string
-
-rule EstimatedWaitMinutes >= 0 because "Estimated wait time cannot be negative"
 
 state Accepting initial
 state Seating
@@ -18,8 +16,7 @@ state Closed
 
 in Seating ensure CurrentParty != null because "The seating state must know which party is being seated"
 
-event JoinWaitlist with PartyName as string
-on JoinWaitlist ensure PartyName != "" because "A party name is required"
+event JoinWaitlist with PartyName as string notempty
 
 event SeatNextParty
 event MarkSeated

--- a/samples/subscription-cancellation-retention.precept
+++ b/samples/subscription-cancellation-retention.precept
@@ -5,15 +5,11 @@ precept SubscriptionCancellationRetention
 
 field SubscriberName as string nullable
 field PlanName as string nullable
-field MonthlyPrice as number default 0
+field MonthlyPrice as number default 0 nonnegative
 field SaveOfferAccepted as boolean default false
-field RetentionDiscount as number default 0
+field RetentionDiscount as number default 0 nonnegative max 100
 field CancellationReason as string nullable
 field LastAgentNote as string nullable
-
-rule MonthlyPrice >= 0 because "Monthly price cannot be negative"
-rule RetentionDiscount >= 0 because "Retention discounts cannot be negative"
-rule RetentionDiscount <= 100 because "Retention discounts are percentages and must stay within 0-100"
 
 state Active initial
 state RetentionReview
@@ -21,11 +17,8 @@ state Cancelled
 
 in RetentionReview edit LastAgentNote
 
-event RequestCancellation with Name as string, Plan as string, Price as number, Reason as string
-on RequestCancellation ensure Name != "" because "The subscriber name is required"
-on RequestCancellation ensure Plan != "" because "The plan name is required"
+event RequestCancellation with Name as string notempty, Plan as string notempty, Price as number, Reason as string notempty
 on RequestCancellation ensure Price >= 0 because "The plan price cannot be negative"
-on RequestCancellation ensure Reason != "" because "A cancellation reason is required"
 
 event MakeSaveOffer with DiscountPercent as number default 10
 on MakeSaveOffer ensure DiscountPercent > 0 because "Save offers must include a positive discount"
@@ -33,8 +26,7 @@ on MakeSaveOffer ensure DiscountPercent <= 100 because "Save offers cannot excee
 
 event AcceptOffer
 
-event DeclineOffer with Note as string nullable default null
-on DeclineOffer ensure Note == null or Note != "" because "A supplied decline note cannot be blank"
+event DeclineOffer with Note as string nullable default null notempty
 
 from Active on RequestCancellation -> set SubscriberName = RequestCancellation.Name -> set PlanName = RequestCancellation.Plan -> set MonthlyPrice = RequestCancellation.Price -> set CancellationReason = RequestCancellation.Reason -> set SaveOfferAccepted = false -> transition RetentionReview
 

--- a/samples/trafficlight.precept
+++ b/samples/trafficlight.precept
@@ -4,13 +4,10 @@ precept TrafficLight
 # the light cycles through standard phases, and an authorized Emergency event
 # forces flashing red until explicitly cleared.
 
-field VehiclesWaiting as number default 0
-field CycleCount as number default 0
+field VehiclesWaiting as number default 0 nonnegative
+field CycleCount as number default 0 nonnegative
 field LeftTurnQueued as boolean default false
 field EmergencyReason as string nullable
-
-rule VehiclesWaiting >= 0 because "Vehicles waiting cannot be negative"
-rule CycleCount >= 0 because "Cycle count cannot be negative"
 
 state Red initial
 state FlashingGreen
@@ -22,9 +19,7 @@ in Red edit VehiclesWaiting, LeftTurnQueued
 
 event Advance
 
-event Emergency with AuthorizedBy as string, Reason as string
-on Emergency ensure AuthorizedBy != "" because "AuthorizedBy is required"
-on Emergency ensure Reason != "" because "Reason is required"
+event Emergency with AuthorizedBy as string notempty, Reason as string notempty
 
 event VehiclesArrive with Count as number default 5
 on VehiclesArrive ensure Count > 0 because "Vehicle count must be positive"

--- a/samples/travel-reimbursement.precept
+++ b/samples/travel-reimbursement.precept
@@ -6,18 +6,14 @@ precept TravelReimbursement
 # RequestedTotal is a computed field — always equal to the sum of its components.
 
 field EmployeeName as string nullable
-field TripDays as number default 1
+field TripDays as number default 1 positive
 field LodgingTotal as number default 0
 field MealsTotal as number default 0
 field MileageTotal as decimal default 0 maxplaces 2
 field MileageRate as number default 0.67
-field RequestedTotal as number -> LodgingTotal + MealsTotal + MileageTotal
-field ApprovedTotal as number default 0
+field RequestedTotal as number -> LodgingTotal + MealsTotal + MileageTotal nonnegative
+field ApprovedTotal as number default 0 nonnegative
 field FinanceNote as string nullable
-
-rule TripDays > 0 because "Trip days must be positive"
-rule RequestedTotal >= 0 because "Requested total cannot be negative"
-rule ApprovedTotal >= 0 because "Approved total cannot be negative"
 rule ApprovedTotal <= RequestedTotal because "Approved total cannot exceed the request"
 
 state Draft initial
@@ -28,20 +24,17 @@ state Rejected
 
 in Paid ensure ApprovedTotal > 0 because "Paid reimbursements must have an approved amount"
 
-event Submit with Employee as string, Days as number, Lodging as number, Meals as number, Miles as number, Rate as number default 0.67
-on Submit ensure Employee != "" because "An employee name is required"
+event Submit with Employee as string notempty, Days as number, Lodging as number, Meals as number, Miles as number, Rate as number default 0.67
 on Submit ensure Days > 0 because "Trip days must be positive"
 on Submit ensure Lodging >= 0 because "Lodging cannot be negative"
 on Submit ensure Meals >= 0 because "Meals cannot be negative"
 on Submit ensure Miles >= 0 because "Mileage cannot be negative"
 on Submit ensure Rate >= 0 because "Mileage rate cannot be negative"
 
-event Approve with Amount as number, Note as string nullable default null
+event Approve with Amount as number, Note as string nullable default null notempty
 on Approve ensure Amount > 0 because "Approved amounts must be positive"
-on Approve ensure Note == null or Note != "" because "A supplied finance note cannot be blank"
 
-event Reject with Note as string
-on Reject ensure Note != "" because "A rejection note is required"
+event Reject with Note as string notempty
 
 event Pay
 

--- a/samples/utility-outage-report.precept
+++ b/samples/utility-outage-report.precept
@@ -5,17 +5,14 @@ precept UtilityOutageReport
 
 field ReporterName as string nullable
 field RegionName as string nullable
-field EstimatedCustomers as number default 0
+field EstimatedCustomers as number default 0 nonnegative
 field Verified as boolean default false
 field AssignedCrew as string nullable
 field RestorationNote as string nullable
-field DispatchRound as number default 0
+field DispatchRound as number default 0 nonnegative
 
 field AffectedBlocks as set of string
 field CrewQueue as queue of string
-
-rule EstimatedCustomers >= 0 because "Estimated customers cannot be negative"
-rule DispatchRound >= 0 because "Dispatch rounds cannot be negative"
 
 state Reported initial
 state VerifiedState
@@ -26,25 +23,19 @@ state Closed
 in VerifiedState edit EstimatedCustomers
 in Dispatched ensure AssignedCrew != null because "Dispatched outages must name a crew"
 
-event FileReport with Reporter as string, Region as string, Customers as number
-on FileReport ensure Reporter != "" because "A reporter name is required"
-on FileReport ensure Region != "" because "A region name is required"
+event FileReport with Reporter as string notempty, Region as string notempty, Customers as number
 on FileReport ensure Customers >= 0 because "Estimated customers cannot be negative"
 
-event AddBlock with BlockName as string
-on AddBlock ensure BlockName != "" because "A block name is required"
+event AddBlock with BlockName as string notempty
 
-event RemoveBlock with BlockName as string
-on RemoveBlock ensure BlockName != "" because "A block name is required"
+event RemoveBlock with BlockName as string notempty
 
-event RegisterCrew with CrewName as string
-on RegisterCrew ensure CrewName != "" because "A crew name is required"
+event RegisterCrew with CrewName as string notempty
 
 event VerifyReport
 event DispatchCrew
 
-event MarkRestored with Note as string
-on MarkRestored ensure Note != "" because "A restoration note is required"
+event MarkRestored with Note as string notempty
 
 event CloseIncident
 

--- a/samples/vehicle-service-appointment.precept
+++ b/samples/vehicle-service-appointment.precept
@@ -6,14 +6,11 @@ precept VehicleServiceAppointment
 field CustomerName as string nullable
 field VehiclePlate as string nullable
 field AdvisorName as string nullable
-field ApprovedWorkCount as number default 0
-field InvoiceTotal as number default 0
+field ApprovedWorkCount as number default 0 nonnegative
+field InvoiceTotal as number default 0 nonnegative
 field PickupContacted as boolean default false
 
 field RecommendedServices as set of string
-
-rule ApprovedWorkCount >= 0 because "Approved work count cannot be negative"
-rule InvoiceTotal >= 0 because "Invoice totals cannot be negative"
 
 state Scheduled initial
 state CheckedIn
@@ -30,16 +27,11 @@ from AwaitingApproval ensure RecommendedServices.count > 0 because "Approval can
 
 to ReadyForPickup -> set PickupContacted = true
 
-event CheckIn with Customer as string, Plate as string, Advisor as string
-on CheckIn ensure Customer != "" because "A customer name is required"
-on CheckIn ensure Plate != "" because "A vehicle plate is required"
-on CheckIn ensure Advisor != "" because "An advisor name is required"
+event CheckIn with Customer as string notempty, Plate as string notempty, Advisor as string notempty
 
-event RecommendService with ServiceName as string
-on RecommendService ensure ServiceName != "" because "A recommended service must be named"
+event RecommendService with ServiceName as string notempty
 
-event RemoveServiceRecommendation with ServiceName as string
-on RemoveServiceRecommendation ensure ServiceName != "" because "A service name is required"
+event RemoveServiceRecommendation with ServiceName as string notempty
 
 event ApproveEstimate with ApprovedCount as number, EstimateTotal as number
 on ApproveEstimate ensure ApprovedCount > 0 because "At least one service must be approved"

--- a/samples/warranty-repair-request.precept
+++ b/samples/warranty-repair-request.precept
@@ -26,21 +26,15 @@ in Closed ensure ShippingLabelSent because "Closed cases must have a return labe
 
 to ReadyToReturn -> set ShippingLabelSent = true
 
-event Submit with Customer as string, Product as string, Serial as string
-on Submit ensure Customer != "" because "A customer name is required"
-on Submit ensure Product != "" because "A product name is required"
-on Submit ensure Serial != "" because "A serial number is required"
+event Submit with Customer as string notempty, Product as string notempty, Serial as string notempty
 
-event Approve with Note as string nullable default null
-on Approve ensure Note == null or Note != "" because "A supplied approval note cannot be blank"
+event Approve with Note as string nullable default null notempty
 
-event Deny with Note as string
-on Deny ensure Note != "" because "A denial note is required"
+event Deny with Note as string notempty
 
 event StartRepair
 
-event LogRepairStep with StepName as string
-on LogRepairStep ensure StepName != "" because "A repair step must have a description"
+event LogRepairStep with StepName as string notempty
 
 event UndoLastStep
 event FinishRepair


### PR DESCRIPTION
## Summary
- replace explicit sample rules with declaration-level numeric constraint modifiers where the semantics are equivalent
- replace simple string length and non-empty checks with field and event-argument constraint modifiers
- keep cross-field rules, state ensures, and other non-local logic explicit

## Why
- align the sample corpus with the current constraint modifier syntax
- make the examples smaller and more representative of the preferred authoring style
- verify that the MCP surface accepts the updated sample set end-to-end

## Validation
- built the language server with `dotnet build tools/Precept.LanguageServer/Precept.LanguageServer.csproj --artifacts-path temp/dev-language-server`
- compiled every sample through MCP `precept_compile`
- result: 25/25 samples valid, 0 failures, 0 diagnostics