### PR TITLE
fix: correct state-scoped edit highlighting

### DIFF
--- a/test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs
+++ b/test/Precept.LanguageServer.Tests/PreceptSemanticTokensClassificationTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using Precept.LanguageServer;
 using Xunit;
@@ -244,6 +245,25 @@ public class PreceptSemanticTokensClassificationTests
         tokens.Should().Contain(t =>
             t.Text == "ensure" &&
             t.Type == "preceptKeywordSemantic");
+    }
+
+    [Fact]
+    public void GetClassifiedTokens_StateEditFields_ArePreceptFieldNames_IncludingCommaTail()
+    {
+        const string dsl = """
+            precept M
+            field ScheduledDay as number default 0
+            field ScheduledMinute as number default 0
+            state Scheduled initial
+            in Scheduled edit ScheduledDay, ScheduledMinute
+            event Save
+            from Scheduled on Save -> no transition
+            """;
+
+        var tokens = PreceptSemanticTokensHandler.GetClassifiedTokens(dsl);
+
+        tokens.Count(t => t.Text == "ScheduledDay" && t.Type == "preceptFieldName").Should().Be(2);
+        tokens.Count(t => t.Text == "ScheduledMinute" && t.Type == "preceptFieldName").Should().Be(2);
     }
 
     [Fact]

--- a/tools/Precept.LanguageServer/PreceptSemanticTokensHandler.cs
+++ b/tools/Precept.LanguageServer/PreceptSemanticTokensHandler.cs
@@ -199,10 +199,21 @@ internal sealed class PreceptSemanticTokensHandler : SemanticTokensHandlerBase
         var (constrainedStates, constrainedEvents, guardedFields) = BuildConstraintSets(text);
 
         PreceptToken? previousKind = null;
+        var previousLine = -1;
         var declContext = DeclContext.None;
 
         foreach (var token in tokens)
         {
+            var currentLine = token.Span.Position.Line;
+            if (currentLine != previousLine)
+            {
+                // The tokenizer strips whitespace, including newlines, so declaration context must
+                // be reset from token positions rather than waiting for a NewLine token.
+                previousKind = null;
+                declContext = DeclContext.None;
+                previousLine = currentLine;
+            }
+
             if (token.Kind == PreceptToken.State)
                 declContext = DeclContext.State;
             else if (token.Kind == PreceptToken.Event)

--- a/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
+++ b/tools/Precept.VsCode/syntaxes/precept.tmLanguage.json
@@ -13,6 +13,7 @@
     { "include": "#fieldCollectionDeclaration" },
     { "include": "#fieldScalarDeclaration" },
     { "include": "#ruleStatement" },
+    { "include": "#stateEditDeclaration" },
     { "include": "#ensureStatement" },
     { "include": "#fromOnHeader" },
     { "include": "#transitionTarget" },
@@ -141,6 +142,70 @@
                   "name": "punctuation.separator.comma.precept",
                   "match": ","
                 }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "stateEditDeclaration": {
+      "comment": "in <StateTarget> [when <Guard>] edit all | edit Field1, Field2",
+      "patterns": [
+        {
+          "name": "meta.declaration.edit.state.precept",
+          "match": "^(\\s*)(in)(\\s+)(any|(?:[A-Za-z_][A-Za-z0-9_]*(?:\\s*,\\s*[A-Za-z_][A-Za-z0-9_]*)*))(.*)$",
+          "captures": {
+            "2": { "name": "keyword.other.precept" },
+            "4": {
+              "patterns": [
+                {
+                  "name": "keyword.other.precept",
+                  "match": "\\bany\\b"
+                },
+                {
+                  "name": "entity.name.type.state.precept",
+                  "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b"
+                },
+                {
+                  "name": "punctuation.separator.comma.precept",
+                  "match": ","
+                }
+              ]
+            },
+            "5": {
+              "patterns": [
+                { "include": "#controlKeywords" },
+                {
+                  "name": "meta.declaration.edit.target.precept",
+                  "match": "\\b(edit)(\\s+)(all|(?:[A-Za-z_][A-Za-z0-9_]*(?:\\s*,\\s*[A-Za-z_][A-Za-z0-9_]*)*))",
+                  "captures": {
+                    "1": { "name": "keyword.other.precept" },
+                    "3": {
+                      "patterns": [
+                        {
+                          "name": "keyword.other.precept",
+                          "match": "\\ball\\b"
+                        },
+                        {
+                          "name": "variable.other.field.precept",
+                          "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b"
+                        },
+                        {
+                          "name": "punctuation.separator.comma.precept",
+                          "match": ","
+                        }
+                      ]
+                    }
+                  }
+                },
+                { "include": "#functionCall" },
+                { "include": "#collectionMemberAccess" },
+                { "include": "#stringMemberAccess" },
+                { "include": "#operators" },
+                { "include": "#booleanNull" },
+                { "include": "#numbers" },
+                { "include": "#strings" },
+                { "include": "#identifierReference" }
               ]
             }
           }


### PR DESCRIPTION
## Summary
- fix semantic-token declaration context resets for state-scoped edit lines
- add a regression test covering `in Scheduled edit ScheduledDay, ScheduledMinute`
- add TextMate fallback support for `in <State> edit <Fields>` declarations

## Why
The editor was briefly coloring state-scoped edit fields correctly on reload, then flipping `ScheduledMinute` to the wrong color once semantic tokens arrived. This PR fixes the semantic-token classification bug and hardens the fallback grammar so the line is colored correctly in both paths.

## Validation
- `dotnet build tools/Precept.LanguageServer/Precept.LanguageServer.csproj --artifacts-path temp/dev-language-server`
- targeted semantic token classification tests passed