### PR TITLE
infra: component alignment enforcement — Roslyn analyzer, drift tests, registry-driven derivation (#132)

### DIFF
--- a/docs/ArchitecturalCoherenceDesign.md
+++ b/docs/ArchitecturalCoherenceDesign.md
@@ -1,0 +1,385 @@
+# Architectural Coherence Design
+
+Date: 2026-04-19
+
+Status: **Draft** — Phase 1 skeleton. Section headings and thesis established. Body content pending design review.
+
+> **Research grounding:** [ComponentAlignmentInventory.md](ComponentAlignmentInventory.md) (50-edge alignment map, 22 components, 12 enforcement mechanisms). Architecture context: [ArchitectureDesign.md](ArchitectureDesign.md) (two-phase architecture, 8 principles). Product philosophy: [philosophy.md](philosophy.md).
+
+> **Supersedes:** [CatalogInfrastructureDesign.md](CatalogInfrastructureDesign.md) (3-tier catalog infrastructure). The catalog design is absorbed into this document's broader architectural coherence framework. The original file is retained for reference but is no longer the governing design.
+
+> **Dependency:** Issue [#115](https://github.com/sfalik/Precept/issues/115) (evaluator semantic fidelity rewrite) is blocked on this design. The evaluator is the highest-drift component in the codebase — its function dispatch, operator dispatch, and member accessor tables are all hand-coded parallel copies with no structural link to their authoritative registries. The coherence framework established here defines the enforcement architecture that #115's rewrite must satisfy.
+
+> **Related issues:** [#111](https://github.com/sfalik/Precept/issues/111) (compile-time enforcement C94–C99) adds new diagnostic codes and constraint kinds that must propagate coherently through the type checker, evaluator, language server, and MCP surfaces. [#107](https://github.com/sfalik/Precept/issues/107) (temporal type system — 8 NodaTime-backed types) is the largest upcoming language surface expansion; every new type, operator, accessor, and postfix unit must satisfy the coherence boundaries defined here. [#95](https://github.com/sfalik/Precept/issues/95) (currency, money, quantity, unit-of-measure investigation) would extend the same postfix grammar and type-family dispatch, further stressing the alignment edges this document governs.
+
+---
+
+## Overview
+
+Precept's philosophy promises that invalid configurations are structurally impossible. That guarantee begins in the language definition itself — the registries, enums, and catalogs that authoritatively define what the DSL contains — and must propagate faithfully through every component that processes, enforces, or presents the language: parser, type checker, proof engine, evaluator, engine, language server, MCP server, TextMate grammar. A soundness gap at any boundary (a function the type checker accepts but the evaluator doesn't implement, a keyword the parser recognizes but completions don't offer, a constraint the engine enforces but MCP doesn't surface) silently weakens the guarantee that reaches the user.
+
+```mermaid
+flowchart LR
+    PHIL(["Philosophy"]) ==> DEF["Language\nDefinition"]
+    DEF --> COMPILE["Compile-Time"]
+    DEF --> SURFACE["Consumer\nSurfaces"]
+    COMPILE --> RUNTIME["Runtime"]
+    RUNTIME --> USER(["User / AI\nConsumer"])
+    SURFACE --> USER
+```
+
+This document defines the language's authoritative structure, traces how that structure must flow through the component pipeline, and establishes the enforcement mechanisms that prevent coherence failures. The enforcement mechanisms — Roslyn analyzers, drift tests, registry-driven derivation — are not the thesis; they serve it. The thesis is architectural coherence: the language definition is the single source of truth, and every component that participates in delivering the philosophy's promise must derive from that truth completely, consistently, and verifiably. The product's own core principle — prevention, not detection — applies recursively to the codebase itself.
+
+---
+
+## Architecture
+
+*The three-tier model of language knowledge — authoritative registries, pipeline stages, and consumer surfaces — and the coherence relationships between them. This is the structural foundation the rest of the document operates on.*
+
+```mermaid
+flowchart TD
+    PHIL["Philosophy\nInvalid configurations are\nstructurally impossible"]
+
+    subgraph REG["Language Definition — Source of Truth"]
+        TOK["PreceptToken + attributes"]
+        FUNC["FunctionRegistry"]
+        DIAG["DiagnosticCatalog"]
+        CONST["ConstructCatalog"]
+        SVK["StaticValueKind"]
+        MODEL["PreceptModel types"]
+        VIOL["ConstraintViolation types"]
+    end
+
+    subgraph COMPILE["Compile-Time — Processes"]
+        TKNZ["Tokenizer"] --> PARSE["Parser"]
+        PARSE --> TC["Type Checker"]
+        TC --> PE["Proof Engine"]
+        PE --> TC
+        TC --> COMP["Compiler"]
+    end
+
+    subgraph RUNTIME["Runtime — Enforces"]
+        ENG["Engine"] --> EVAL["Evaluator"]
+    end
+
+    subgraph SURFACE["Consumer Surfaces — Presents"]
+        GRAM["TextMate Grammar"]
+        LS["Language Server"]
+        MCP["MCP Server"]
+    end
+
+    USER(["User / AI Consumer"])
+
+    PHIL ==> REG
+
+    REG --> COMPILE
+    COMP -- "PreceptEngine" --> ENG
+    FUNC -. "parallel copy" .-> EVAL
+
+    REG --> SURFACE
+    FUNC -. "parallel copy" .-> GRAM
+    FUNC -. "parallel copy" .-> LS
+
+    RUNTIME --> USER
+    SURFACE --> USER
+```
+
+> **Diagram note:** Solid lines = derived (structural coherence). Dotted lines = parallel copies (drift risk — the alignment edges this document's enforcement architecture targets).
+
+The language exists in three categories of artifacts:
+
+**Authoritative registries** are the single-source-of-truth artifacts that define what the language contains. Nothing else in the codebase *decides* what the language is — these do:
+
+- `PreceptToken` enum + attributes — the complete vocabulary: every keyword, operator, punctuation symbol, and literal kind, annotated with `[TokenCategory]`, `[TokenDescription]`, and `[TokenSymbol]`
+- `FunctionRegistry` — the function library: names, overloads, parameter types, return types, argument constraints
+- `DiagnosticCatalog` — the constraint surface: every compile-time and runtime diagnostic (C1–C99), with phase, severity, and message template
+- `ConstructCatalog` — the grammar documentation: every parseable construct with form, context, description, and example
+- `StaticValueKind` enum — the type system's internal representation of value kinds
+- `PreceptModel` types — the structural model: `PreceptDefinition`, `PreceptField`, `PreceptState`, `PreceptEvent`, `PreceptExpression` hierarchy, `FieldConstraint` hierarchy, outcome types
+- `ConstraintViolation` types — the failure model: `ConstraintTarget` and `ConstraintSource` hierarchies
+
+**Pipeline stages** are the components that process language knowledge into validated engines. Each stage consumes authoritative definitions and must handle the full surface they define:
+
+- Tokenizer → Parser → Type Checker ↔ Proof Engine → Compiler → Engine → Evaluator
+
+**Consumer surfaces** are the components that present language knowledge to users and tooling. Each surface carries its own representation of language knowledge:
+
+- TextMate grammar (syntax highlighting)
+- Language server (completions, hover, diagnostics, semantic tokens)
+- MCP server (tool DTOs, serialization)
+- VS Code extension (preview, commands)
+
+The coherence problem is the gap between these categories. Every pipeline stage and consumer surface carries its own representation of language knowledge. When those representations are *derived* from the authoritative registries, coherence is structural — a new keyword in the token enum automatically appears in the tokenizer, in semantic tokens, in MCP vocabulary. When they are *hand-coded parallel copies*, coherence depends on discipline — and discipline fails. The evaluator's function switch, the grammar's keyword alternation, the language server's hover content dictionary are all parallel copies today. This document's enforcement architecture exists to close those gaps.
+
+---
+
+## Philosophy-Rooted Design Principles
+
+The following principles govern every decision in this document. They operate on the three-tier architecture above — authoritative registries, pipeline stages, consumer surfaces — and extend Precept's core philosophy (prevention, one-file completeness, inspectability, determinism) from the DSL runtime to the codebase that delivers it.
+
+1. **The registries are the origin of the guarantee.** The philosophy promises prevention. That promise is anchored in the authoritative registries that define what the language *is*. Every pipeline stage and consumer surface derives its understanding of the language from these sources. If a registry is incomplete, no amount of downstream correctness can restore the guarantee. If a pipeline stage or consumer surface diverges from a registry, the guarantee is broken at that boundary.
+
+2. **The guarantee is only as strong as the weakest boundary.** The guarantee flows from registries through pipeline stages to consumer surfaces. If any stage silently drops a construct — a function that `FunctionRegistry` defines and the type checker validates but the evaluator doesn't implement, a keyword that `PreceptToken` declares but the TextMate grammar doesn't highlight — the user encounters detection where they were promised prevention. Coherence across every registry → consumer edge is the mechanism that makes prevention real across the full surface.
+
+3. **Prevention applies inward.** The product prevents invalid entity configurations. The codebase must prevent invalid component configurations. A parallel copy in the evaluator that drifts from `FunctionRegistry` is a detection failure — caught only when a user hits the gap. A Roslyn analyzer that refuses to compile when the evaluator's switch and the registry disagree is prevention. The enforcement hierarchy must prefer structural prevention over after-the-fact detection at every tier.
+
+4. **Derive from registries, never duplicate them.** When a pipeline stage or consumer surface needs a fact that an authoritative registry already defines — a keyword list, a function name, a diagnostic code — it must derive that fact, not maintain a parallel copy. Derivation eliminates the class of drift where two independent copies fall out of sync. Where derivation is not yet feasible, the gap must be covered by the highest-tier enforcement mechanism available.
+
+5. **Coherence is auditable.** For every alignment edge between a registry and a consumer (pipeline stage or surface), it must be possible to answer: what is the authoritative source, what is the derivation or enforcement mechanism, and what is the current status? If an edge cannot be audited, it cannot be trusted.
+
+6. **Enforcement is tiered by cost of failure.** Not all alignment gaps carry the same risk. A missing keyword in the TextMate grammar degrades the authoring experience; a missing expression subtype in the evaluator produces a runtime crash. The enforcement tier must match the severity: compile-time Roslyn errors for soundness-critical pipeline boundaries, drift tests for consumer surface fidelity, registry derivation for vocabulary propagation.
+
+7. **Registries are uniform by convention.** The authoritative registries today are scattered across different files, use different structural patterns (attribute-decorated enums, static class registrations, parser-time side effects), and expose their data through different access patterns. This inconsistency makes derivation harder and enforcement mechanisms non-reusable. To whatever extent possible, registries should follow a consistent structural pattern — same location conventions, same attribute/metadata approach, same reflection surface — so that a single derivation mechanism or Roslyn rule can cover an entire class of alignment edges rather than requiring bespoke logic per registry.
+
+---
+
+## Guarantee Flow Model
+
+*How correctness propagates from the language definition through compile-time, runtime, and consumer surfaces. The architectural path the guarantee travels — starting from the authoritative registries — and the boundaries where coherence must hold.*
+
+### The Path
+
+The guarantee begins in the authoritative registries and must arrive, intact, at the user. Between origin and destination lie nine pipeline stages and four consumer surfaces, each of which carries language knowledge in a different representation. The guarantee is not a single fact that flows through a single pipe — it is a set of overlapping knowledge claims (vocabulary, types, functions, constraints, proof facts, outcome semantics) that must be independently represented at every stage while remaining mutually consistent. This section traces those claims through the system, names the form each takes at each boundary crossing, and identifies where the path branches into parallel representations that can drift.
+
+```mermaid
+flowchart TD
+    subgraph REG["Authoritative Registries"]
+        TOK["PreceptToken"]
+        FUNC["FunctionRegistry"]
+        DIAG["DiagnosticCatalog"]
+        CONST["ConstructCatalog"]
+        SVK["StaticValueKind"]
+        MODEL["PreceptModel"]
+    end
+
+    subgraph PIPE["Compile-Time Pipeline"]
+        TKNZ[Tokenizer] -->|"TokenList"| PAR[Parser]
+        PAR -->|"PreceptDefinition"| TC["Type Checker"]
+        TC <-->|"IntervalOf · narrowings"| PE["Proof Engine"]
+        TC -->|"TypeCheckResult"| COMP["Validate"]
+    end
+
+    subgraph RT["Runtime"]
+        ENG[Engine] -->|"eval contexts"| EVAL[Evaluator]
+    end
+
+    TOK -->|"keyword dict"| TKNZ
+    TOK -.->|"operator patterns"| TKNZ
+    FUNC -->|"IsFunction"| PAR
+    PAR -.->|".Register"| CONST
+    FUNC -->|"overloads"| TC
+    DIAG -->|"constraints"| TC
+    SVK -->|"type kinds"| TC
+    DIAG -->|"C29–C31 · C55"| COMP
+    COMP -->|"PreceptEngine"| ENG
+    MODEL -->|"fields · transitions"| ENG
+    FUNC -.->|"function dispatch"| EVAL
+    SVK -.->|"type dispatch"| EVAL
+    MODEL -.->|"expression subtypes"| EVAL
+```
+
+> **Diagram key.** Solid lines (→): the consumer derives from the registry by structural reference, reflection, or API call — coherence is built in. Dotted lines (⇢): the consumer carries a parallel copy that was authored independently of the registry — coherence depends on discipline, and discipline fails.
+
+### Stage-by-Stage Knowledge Flow
+
+**Registries → Tokenizer.** The tokenizer is the first consumer. It needs two things from `PreceptToken`: keyword text-to-token mappings (which keywords exist and what token each produces) and operator/punctuation recognition patterns (which character sequences are operators). The keyword mapping is **derived** — `PreceptTokenMeta.BuildKeywordDictionary()` reads `[TokenSymbol]` attributes at startup and produces the keyword dictionary by reflection. A new keyword token with a `[TokenSymbol]` attribute is recognized by the tokenizer automatically. The operator/punctuation mapping is **hardcoded** — each operator token requires an explicit `builder.Match()` call with `Span.EqualTo()` or `Character.EqualTo()`. This is the first boundary where knowledge can be lost: a new operator token in the enum with no matching tokenizer pattern will never be produced.
+
+**Tokenizer → Parser.** The tokenizer emits a `TokenList<PreceptToken>` — a sequence of typed token values with source positions. The parser consumes these via Superpower combinators that reference `PreceptToken` enum members directly (`Token.EqualTo(PreceptToken.Field)`). The parser also consults `FunctionRegistry.IsFunction()` to recognize function names during parsing — a direct structural reference, not a parallel copy. The knowledge crossing this boundary is the token stream itself plus function-name recognition. The parser also populates `ConstructCatalog` via `.Register()` extension methods on parser combinators — this is the reverse direction, where the parser writes back into a registry. A parser combinator that omits `.Register()` produces an undocumented construct.
+
+**Parser → Type Checker.** The parser emits a `PreceptDefinition` — the complete structural model of the `.precept` file: fields, states, events, transition rows, rules, ensures, edit blocks, computed fields, collection fields, and the `PreceptExpression` AST for every expression position. This is the richest single boundary crossing in the pipeline. The type checker consumes it alongside two registries directly: `FunctionRegistry` (for overload resolution and argument constraint validation) and `DiagnosticCatalog` (for diagnostic generation). It also consumes `StaticValueKind` as the currency of type inference.
+
+**Type Checker ↔ Proof Engine.** This is the only bidirectional boundary in the pipeline, and the information flow has direction. The type checker orchestrates: it walks the definition model, writes narrowing facts into `ProofContext` as it processes guards and assignments, and queries the proof engine via `IntervalOf(expr)` at six defined integration points (C94 assignment validation, C92/C93 divisor safety, C76 sqrt operand, C97/C98 guard analysis, C95/C96 rule analysis, compound RHS inference). The proof engine responds with `ProofResult` — a `NumericInterval` and a `ProofAttribution` naming the source constraints. The knowledge crossing this boundary is numeric: intervals, relational orderings, sign facts. The type checker translates these into diagnostics; the proof engine never generates diagnostics directly.
+
+**Type Checker → Compiler → Engine.** The type checker produces a `TypeCheckResult`: diagnostics, `PreceptTypeContext` (resolved type per expression position), `ComputedFieldOrder` (topological evaluation sequence for computed fields), and `GlobalProofContext`. The compilation stage — `PreceptRuntime.Validate()`, labeled "Validate" in the pipeline diagram (there is no standalone `PreceptCompiler` class) — orchestrates three validation passes: (1) `PreceptTypeChecker.Check()` for type and expression semantics, (2) `CollectCompileTimeDiagnostics()` for structural enforcement — C29 rule-at-defaults validation, C30 initial-state ensures at defaults, C31 event ensures at defaults, C55 root edit block validation, and structural duplicate-ensure detection — and (3) `PreceptAnalysis.Analyze()` for dead-state analysis. The validation stage is a thin orchestrator for type and expression semantics, but it **owns** structural enforcement checks that neither the type checker nor the parser performs. The `PreceptEngine` is gated on the full validation output across all three passes, not just the type checker result. If any pass produces errors, engine construction does not proceed. The `PreceptEngine` is the **phase boundary** — the single object that separates compile-time from runtime. It carries the field map, transition table, computed field order, edit permissions, and state action map. It does not carry the type context, the proof context, or the diagnostic surface. Those are compile-time artifacts that do not cross into runtime.
+
+**Engine → Evaluator.** The engine never evaluates expressions directly. For every guard, assignment, rule, ensure, and computed field recomputation, it builds an evaluation context and delegates to `PreceptExpressionRuntimeEvaluator.Evaluate()`. Three context builders serve different pipeline stages: `BuildEvaluationData` produces a static snapshot of current field values and event arguments for standard expression evaluation; `BuildEvaluationDataWithCollections` produces a read-your-writes snapshot including uncommitted collection mutations for rule and assignment evaluation within a transition; `BuildDirectEvaluationData` produces an event-args-only context — no instance data — for Stage 1 event ensure evaluation, where the engine must validate argument constraints before the instance is consulted. The evaluator receives the `PreceptExpression` AST and the evaluation data dictionary; it returns an `EvaluationResult` (success/failure + value).
+
+The *architectural* boundary is engine → evaluator (where expression evaluation is delegated via evaluation contexts). But the *knowledge agreement* boundary is type checker ↔ evaluator: the knowledge the evaluator needs to do its job — which functions exist, what operators are legal for which type families, which member accessors are valid — is **not passed to it by the engine and not read from any registry.** It is independently coded in the evaluator's own switch statements. This is the parallel-copy problem at its most acute: the evaluator carries its own copy of function dispatch (18 functions, each hand-coded), operator dispatch (every operator × type-family combination, independently implemented), and member accessor dispatch (`count`, `min`, `max`, `peek`, `length` — hardcoded strings). The type checker and the evaluator must agree on what is legal, but there is no structural mechanism ensuring they do.
+
+### The Fan-Out
+
+```mermaid
+flowchart TD
+    subgraph REG["Authoritative Registries"]
+        TOK["PreceptToken"]
+        FUNC["FunctionRegistry"]
+        DIAG["DiagnosticCatalog"]
+        CONST["ConstructCatalog"]
+        SVK["StaticValueKind"]
+        MODEL["PreceptModel"]
+        VIOL["ConstraintViolation"]
+    end
+
+    subgraph GRAM["TextMate Grammar"]
+        direction LR
+        G_ALL["all parallel copies"]
+    end
+
+    subgraph LS["Language Server"]
+        direction LR
+        LS_D["derived paths"]
+        LS_P["parallel copies"]
+    end
+
+    subgraph MCP_S["MCP Server"]
+        direction LR
+        MCP_D["catalog-driven"]
+        MCP_P["projections"]
+    end
+
+    TOK -.->|"all vocabulary"| G_ALL
+    FUNC -.->|"function names"| G_ALL
+
+    TOK -->|"semantic tokens · completions"| LS_D
+    TOK -.->|"type-name regexes"| LS_P
+    FUNC -.->|"hover · completions"| LS_P
+    DIAG -->|"diagnostic codes"| LS_D
+    CONST -->|"construct hover"| LS_D
+
+    TOK -->|"vocabulary"| MCP_D
+    FUNC -->|"AllFunctions"| MCP_D
+    DIAG -->|"Constraints"| MCP_D
+    CONST -->|"Constructs"| MCP_D
+    MODEL -.->|"DTOs"| MCP_P
+    VIOL -.->|"ViolationDto"| MCP_P
+```
+
+> The pipeline diagram (above) shows `StaticValueKind` feeding the type checker and evaluator. In the fan-out, type vocabulary reaches consumer surfaces through `PreceptToken` — type keywords are token enum members with `[TokenCategory(Type)]` — so `SVK` is included here for completeness but has no direct consumer-surface edges.
+
+The compile-time pipeline is a serial chain: tokenizer → parser → type checker → compiler → engine → evaluator. Knowledge flows forward, and each stage can structurally derive from the one before it (with the evaluator as the critical exception). But the same registries that feed the pipeline must also feed three consumer surfaces that branch off independently:
+
+**TextMate Grammar.** The grammar needs the complete vocabulary — every keyword, type name, constraint name, function name, operator, and accessor — as regex alternation patterns in a JSON file. It cannot call .NET reflection. It cannot read `[TokenSymbol]` attributes. Every vocabulary fact must be independently transcribed into regex strings. This makes the grammar a **total parallel copy** of every vocabulary-bearing registry. Seven vocabulary categories must be independently transcribed (keywords, types, constraints, operators, function names, collection accessors, string accessors), all enforced by convention only — zero structural enforcement. The fan-out diagram consolidates these into two registry edges (`PreceptToken` → Grammar and `FunctionRegistry` → Grammar) because accessors and type names originate from the same registries, but each category is an independent maintenance surface. The grammar is the highest-maintenance consumer in the system.
+
+**Language Server.** The language server is a hybrid. Its **semantic tokens** derive from `PreceptTokenMeta.GetCategory()` via a startup-built `SemanticTypeMap` — zero drift by construction. Its **keyword completions** derive from the same attribute-driven pattern: `BuildKeywordItems()` iterates `Enum.GetValues<PreceptToken>()`, reads `PreceptTokenMeta.GetCategory()` and `GetSymbol()`, and builds the completion list by reflection — zero drift by construction. Its **diagnostics** derive from `TypeCheckResult` diagnostics mapped to LSP codes via `DiagnosticCatalog.ToDiagnosticCode()` — zero drift. Its **construct hover content** reads `ConstructCatalog.Constructs` directly — zero drift. The parallel-copy risks in the language server are concentrated in three areas: **function hover content** (`FunctionHoverContent` — 18 hand-maintained entries that must track `FunctionRegistry`), **type-name regexes** hardcoded in context-detection logic (parallel copies of `PreceptToken` type vocabulary, shown as a dotted edge in the fan-out diagram), and **function completion lists** that are independently maintained rather than registry-driven. The language server occupies the uncomfortable middle: its four derived paths (semantic tokens, keyword completions, diagnostics, construct hover) are structurally sound, while its parallel-copy paths (function hover, type-name regexes, function completions) are conventional maintenance surfaces where drift accumulates silently.
+
+**MCP Server.** The MCP server is the best-aligned consumer surface. Its vocabulary output reflects `PreceptToken` attributes directly. Its constraint output reads `DiagnosticCatalog.Constraints`. Its construct output reads `ConstructCatalog.Constructs`. Its function output reads `FunctionRegistry.AllFunctions`. These are catalog-driven derivations — zero drift by construction. The residual risk is in projection: `CompileTool` DTOs mirror `PreceptModel` types via manual property mapping; `ViolationDtoMapper` switches on `ConstraintTarget` and `ConstraintSource` subtypes; `FirePipeline`, `ExpressionScopes`, and `OutcomeKinds` are hardcoded arrays. The catalog-driven core is solid; the projection periphery is a conventional maintenance surface.
+
+### The Three Guarantee Surfaces
+
+The knowledge flow through pipeline and fan-out creates three distinct guarantee surfaces, each with its own failure mode and cost of failure:
+
+**Compile-time soundness.** The guarantee that the compile-time gate is trustworthy — that every expression the type checker accepts is well-typed, every constraint the proof engine proves is sound, every structural invariant the compiler enforces is correctly checked, and every definition the compiler accepts will not produce a runtime type error. This surface lives in the serial pipeline: registries → tokenizer → parser → type checker ↔ proof engine → compiler. The boundaries are registry-to-pipeline (does the type checker handle every `StaticValueKind` flag? every `PreceptExpression` subtype? every `FunctionRegistry` overload?) and pipeline-internal (does the type checker correctly consult the proof engine at every integration point? does the compiler's structural enforcement catch every C29, C55, and duplicate-ensure violation?). A gap here means "it compiles but it shouldn't have" — a silent violation of the prevention guarantee.
+
+**Runtime fidelity.** The guarantee that what compiles also runs correctly — that the evaluator faithfully implements every operation the type checker approves. This surface lives at the engine → evaluator boundary, and it is where coherence is weakest. The evaluator must independently implement every function, every operator × type-family combination, and every member accessor that the type checker blesses. There is no structural link. The type checker says "this division is safe because the divisor is provably nonzero"; the evaluator must actually perform the division correctly for every numeric type family. The type checker says "`floor(x)` returns an integer"; the evaluator must actually return a `long`. A gap here means "it compiles, the type checker says it's valid, but the evaluator produces the wrong result or crashes." This is the highest-cost boundary in the system — and the one with the least enforcement.
+
+**Consumer surface completeness.** The guarantee that the user and AI consumer see the full language — every keyword highlighted, every function in completions, every diagnostic surfaced, every construct documented. This surface lives in the fan-out to grammar, language server, and MCP server. A gap here does not break correctness — a missing keyword in the grammar does not cause a runtime error. But it breaks the philosophy's inspectability promise: if the tooling surface is incomplete, the author's understanding of the language is incomplete, and the AI agent's understanding is incomplete. The cost is not failure; it is degraded trust. And degraded trust compounds — an author who learns they cannot rely on completions stops using completions, and the tooling surface becomes irrelevant.
+
+### Why These Boundaries
+
+Each guarantee surface groups a set of boundaries that share a failure mode and a cost tier. Compile-time soundness boundaries protect the prevention guarantee — their failure is a type-system hole. Runtime fidelity boundaries protect the execution contract — their failure is a crash or wrong result. Consumer surface completeness boundaries protect the inspectability promise — their failure is a tooling gap.
+
+This tiering is not arbitrary. It follows directly from Principle 6 (enforcement is tiered by cost of failure) and Principle 2 (the guarantee is only as strong as the weakest boundary). The highest-cost boundaries — type checker ↔ evaluator knowledge agreement for runtime fidelity, `PreceptExpression` switch exhaustiveness for compile-time soundness — require the strongest enforcement. The lowest-cost boundaries — `FirePipeline` array freshness in MCP for consumer completeness — can tolerate weaker enforcement without endangering the core guarantee.
+
+The Coherence Boundaries section that follows takes each guarantee surface and inventories the specific boundaries within it: what registry knowledge must cross, what form it takes on each side, and what happens when the two sides disagree.
+
+---
+
+## Coherence Boundaries
+
+*The specific component boundaries where the guarantee must be preserved as language knowledge flows from authoritative registries through pipeline stages and into consumer surfaces. Organized by guarantee surface — not by enforcement mechanism.*
+
+### Compile-Time Soundness
+
+*Boundaries where authoritative registries meet the compile-time pipeline: token enum → tokenizer, function registry → type checker, type checker ↔ proof engine, expression subtypes → type checker switch dispatch. What must hold for the compile-time gate to be trustworthy.*
+
+*(Phase 3 — content forthcoming.)*
+
+### Runtime Fidelity
+
+*Boundaries where compile-time validation hands off to runtime execution: function registry → evaluator, operator type inference → operator dispatch, expression subtypes → evaluator switch dispatch, member accessor names → evaluator accessor dispatch. What must hold for "if it compiles, it runs correctly."*
+
+*(Phase 3 — content forthcoming.)*
+
+### Consumer Surface Completeness
+
+*Boundaries where authoritative registries meet tooling consumers: token enum → TextMate grammar, function registry → completions/hover, diagnostic catalog → language server, model types → MCP DTOs. What must hold for the user and AI consumer to see the full language.*
+
+*(Phase 3 — content forthcoming.)*
+
+---
+
+## Enforcement Architecture
+
+*The mechanisms that prevent coherence failures, organized by enforcement tier. Each mechanism is justified by which guarantee surface it protects.*
+
+### Tier 1: Structural Derivation
+
+*Registry-driven code paths that eliminate drift by construction — zero manual sync required.*
+
+*(Phase 4 — content forthcoming.)*
+
+### Tier 2: Compile-Time Enforcement (Roslyn Analyzers)
+
+*Roslyn diagnostic rules that refuse to compile when a registry and its consumer disagree. PREC002–PREC011 specifications.*
+
+*(Phase 4 — content forthcoming.)*
+
+### Tier 3: Automated Drift Detection (Tests)
+
+*Drift tests that verify alignment relationships hold. Catalog drift tests, grammar drift tests, construct-example round-trip tests.*
+
+*(Phase 4 — content forthcoming.)*
+
+### Tier 4: Structural Markers (SYNC Comments)
+
+*Convention-backed traceability markers validated by reflection tests and (once shipped) Roslyn rules.*
+
+*(Phase 4 — content forthcoming.)*
+
+### Tier 5: Human Review
+
+*Alignment relationships that cannot yet be mechanically enforced. The residual — minimized by promoting edges to higher tiers.*
+
+*(Phase 4 — content forthcoming.)*
+
+---
+
+## Design Decisions
+
+*Rationale for key architectural choices. Each entry: decision, rationale, alternatives considered, tradeoff accepted.*
+
+### DD1: Top-down guarantee framing, not bottom-up inventory
+
+**Decision:** Organize the document by guarantee surface (compile-time soundness, runtime fidelity, consumer surface completeness) rather than by component pair or enforcement mechanism.
+
+**Rationale:** The research artifact ([ComponentAlignmentInventory.md](ComponentAlignmentInventory.md)) inventories 22 components, 50 alignment edges, and 12 enforcement mechanisms bottom-up. That framing treats coherence as a maintenance hygiene problem — keeping things in sync. The top-down framing starts from the philosophy's guarantee and asks how the component architecture must be structured to deliver it. Enforcement mechanisms serve that thesis; they are not the thesis.
+
+**Alternative considered:** Organize by enforcement mechanism (Roslyn rules, drift tests, registry derivation). Rejected because it centers the tooling rather than the architectural argument, and makes it harder to reason about whether the guarantee is complete at each surface.
+
+**Tradeoff accepted:** The bottom-up edge inventory is still needed as a reference — it lives in the appendix rather than driving the document structure. Readers who want the per-edge detail must look there.
+
+### DD2: Registry uniformity is foundational, not aspirational
+
+**Decision:** Principle 7 (registries are uniform by convention) is a non-negotiable design principle, not a future improvement.
+
+**Rationale:** Principles 1 and 4 require that every pipeline stage and consumer surface derive from authoritative registries. Derivation at scale requires that registries follow consistent structural patterns — same attribute conventions, same reflection surface, same metadata access patterns. Without uniformity, every Roslyn rule and every drift test requires bespoke logic per registry, and systematic enforcement is not achievable. Registry uniformity is the prerequisite that makes the enforcement architecture work generically across an entire class of alignment edges.
+
+**Alternative considered:** Treat uniformity as a north-star aspiration and handle each registry individually in the meantime. Rejected because it perpetuates the exact problem the document exists to solve — bespoke enforcement that doesn't scale as the language surface grows.
+
+**Tradeoff accepted:** Achieving full uniformity may require refactoring existing registries (e.g., `FunctionRegistry` uses a different pattern than `PreceptToken` attributes). That refactoring cost is accepted as necessary infrastructure.
+
+<!-- Additional design decisions populated as sections are written -->
+
+---
+
+## Test Obligations
+
+*What must be tested to verify architectural coherence holds. Organized by enforcement tier.*
+
+<!-- Populated during Phase 4 -->
+
+---
+
+## Future Considerations
+
+*Planned improvements: registry-driven evaluator (DD24/DD25), expression subtype exhaustiveness via discriminated unions, promotion of Tier 3–5 edges to higher tiers.*
+
+<!-- Populated as sections are written -->
+
+---
+
+## Appendix: Component Alignment Edge Map
+
+*The full 50-edge alignment map from the research inventory, annotated with enforcement tier, current status, and owning design decision. Summary in body; detailed table here.*
+
+<!-- Phase 5 content -->

--- a/docs/ComponentAlignmentInventory.md
+++ b/docs/ComponentAlignmentInventory.md
@@ -1,0 +1,690 @@
+# Component Alignment Inventory
+
+**Date:** 2026-04-19
+**Author:** Frank (Lead/Architect)
+**Purpose:** Structured inventory of every component that defines or consumes language knowledge, every alignment relationship, every enforcement mechanism, and every gap — input for the unified drift prevention design doc that supersedes `docs/CatalogInfrastructureDesign.md`.
+
+---
+
+## Part 1: Component Registry
+
+### Core Definitions
+
+#### 1.1 PreceptToken Enum + Attributes
+
+**File:** `src/Precept/Dsl/PreceptToken.cs` (lines 1–540, includes `PreceptTokenMeta` at line 510+)
+
+**What it defines:**
+- Every token kind in the DSL (68 members: 14 Declaration, 6 Control, 2 Grammar, 8 Action, 3 Outcome, 10 Constraint, 9 Type, 3 Literal, 14 Operator, 6 Punctuation, 2 Structure, 3 Value)
+- `TokenCategory` enum (12 categories: Control, Declaration, Action, Outcome, Grammar, Constraint, Type, Literal, Operator, Punctuation, Structure, Value)
+- Three attribute types: `[TokenCategory]`, `[TokenDescription]`, `[TokenSymbol]`
+- `PreceptTokenMeta` reflection helpers: `GetCategory()`, `GetCategories()`, `GetDescription()`, `GetSymbol()`, `GetByCategory()`, `BuildKeywordDictionary()`
+
+**What it consumes:** Nothing — pure source of truth.
+
+**Alignment risk:** Every consumer of vocabulary knowledge depends on this file. A missing attribute silently breaks downstream derivation.
+
+---
+
+#### 1.2 PreceptExpression AST
+
+**File:** `src/Precept/Dsl/PreceptModel.cs` (lines 130–190)
+
+**What it defines:**
+- `PreceptExpression` abstract record base class
+- 7 concrete subtypes: `PreceptLiteralExpression`, `PreceptIdentifierExpression`, `PreceptUnaryExpression`, `PreceptBinaryExpression`, `PreceptParenthesizedExpression`, `PreceptFunctionCallExpression`, `PreceptConditionalExpression`
+- `SourceSpan` for position tracking
+
+**What it consumes:** Nothing — pure type definitions.
+
+**Alignment risk:** Every `switch` over `PreceptExpression` subtypes (in type checker, evaluator, and analysis code) must handle all 7 subtypes. Adding an 8th subtype without updating all switch sites produces runtime `default` fallthrough. Currently convention-only; planned for Roslyn PREC002 enforcement.
+
+---
+
+#### 1.3 StaticValueKind Enum
+
+**File:** `src/Precept/Dsl/PreceptTypeChecker.cs` (lines 8–18)
+
+**What it defines:**
+- `[Flags]` enum with 8 members: None, String, Number, Boolean, Null, Integer, Decimal, OrderedChoice, UnorderedChoice
+- The type system's internal representation of value kinds for static analysis
+
+**What it consumes:** Nothing — pure type definition.
+
+**Alignment risk:** The type checker, evaluator, function registry, operator dispatch, and MCP LanguageTool all switch on or combine `StaticValueKind` flags. Missing a flag in any consumer creates a silent type-system gap. Planned for Roslyn PREC008 enforcement.
+
+---
+
+#### 1.4 FunctionRegistry
+
+**File:** `src/Precept/Dsl/FunctionRegistry.cs`
+
+**What it defines:**
+- `FunctionDefinition` records (name, description, overloads)
+- `FunctionOverload` records (parameters, return type, min arity)
+- `FunctionParameter` records (name, accepted types, constraint)
+- `FunctionArgConstraint` enum (None, MustBeIntegerLiteral, RequiresNonNegativeProof)
+- 18 built-in functions: abs, floor, ceil, round, truncate, min, max, clamp, pow, sqrt, toLower, toUpper, trim, startsWith, endsWith, left, right, mid
+
+**What it consumes:** `StaticValueKind` for parameter/return types.
+
+**How it consumes:** Direct reference to `StaticValueKind` flags.
+
+**Alignment risk:**
+- The **type checker** reads the registry for overload resolution and argument validation.
+- The **evaluator** has a **parallel hand-coded switch** that independently implements every function body — the archetype drift problem. Adding a function to the registry without updating the evaluator creates a type-checks-but-fails-at-runtime gap.
+- The **TextMate grammar** has a hardcoded function name alternation pattern (`abs|floor|ceil|...`) — must be updated manually.
+- The **MCP LanguageTool** reflects the registry via `FunctionRegistry.AllFunctions` — automatic.
+- The **LS completions** have hardcoded function names in completion lists.
+- The **LS hover** has hardcoded function documentation in `PreceptDocumentIntellisense.FunctionHoverContent`.
+
+---
+
+#### 1.5 DiagnosticCatalog
+
+**File:** `src/Precept/Dsl/DiagnosticCatalog.cs`
+
+**What it defines:**
+- `LanguageConstraint` records (Id, Phase, Rule, MessageTemplate, Severity)
+- `ConstraintSeverity` enum (Error, Warning, Hint)
+- `ConstraintViolationException` for parse-time enforcement
+- 79 constraints: C1–C25 (parse), C26–C32 (compile structural), C33–C37 (runtime), C38–C98 (compile type/proof)
+- `ToDiagnosticCode()` → PRECEPT{NNN} mapping
+
+**What it consumes:** Nothing — pure source of truth.
+
+**Alignment risk:**
+- Every enforcement point in parser, type checker, and runtime must reference a catalog entry via `// SYNC:CONSTRAINT:Cnn` comments.
+- MCP LanguageTool serializes constraints automatically via `DiagnosticCatalog.Constraints`.
+- Language server diagnostics derive codes via `ToDiagnosticCode()`.
+- Missing SYNC comment = invisible to drift tests. Orphaned SYNC comment = references a non-existent constraint.
+
+---
+
+#### 1.6 ConstructCatalog
+
+**File:** `src/Precept/Dsl/ConstructCatalog.cs`
+
+**What it defines:**
+- `ConstructInfo` records (Name, Form, Context, Description, Example)
+- Registration via parser combinator extension method `.Register()`
+
+**What it consumes:** Populated by `PreceptParser` static initializers (parser combinators register constructs at class-load time).
+
+**How it consumes:** Extension method on `TokenListParser<PreceptToken, T>`.
+
+**Alignment risk:** Construct examples must parse successfully (enforced by drift test). Adding a parser combinator without calling `.Register()` creates an undocumented construct.
+
+---
+
+#### 1.7 PreceptModel Types
+
+**File:** `src/Precept/Dsl/PreceptModel.cs`
+
+**What it defines:**
+- `PreceptDefinition`, `PreceptState`, `PreceptEvent`, `PreceptEventArg`, `PreceptField`, `PreceptCollectionField`
+- `PreceptScalarType` enum (String, Number, Boolean, Null, Integer, Decimal, Choice)
+- `PreceptCollectionKind` enum (Set, Queue, Stack)
+- `FieldConstraint` hierarchy (9 subtypes: Nonnegative, Positive, Min, Max, Notempty, Minlength, Maxlength, Mincount, Maxcount, Maxplaces)
+- `PreceptCollectionMutationVerb` enum
+- Outcome types: `StateTransition`, `Rejection`, `NoTransition`
+- `EnsureAnchor` enum (In, To, From)
+
+**What it consumes:** `PreceptExpression` types for expression fields.
+
+**Alignment risk:** MCP CompileTool DTOs mirror model types — if model types gain/lose properties, MCP DTOs may drift. Language server hover/completions extract data from model types — new model properties need LS rendering.
+
+---
+
+#### 1.8 ConstraintViolation Types
+
+**File:** `src/Precept/Dsl/ConstraintViolation.cs`
+
+**What it defines:**
+- `ConstraintTarget` hierarchy (Field, EventArg, Event, State, Definition)
+- `ConstraintSource` hierarchy (Rule, StateEnsure, EventEnsure, TransitionRejection)
+
+**What it consumes:** `EnsureAnchor` from PreceptModel.
+
+**Alignment risk:** MCP ViolationDto mirrors this hierarchy — drift if new target/source kinds are added.
+
+---
+
+### Pipeline Stages
+
+#### 1.9 PreceptTokenizer
+
+**File:** `src/Precept/Dsl/PreceptTokenizer.cs`
+
+**What it defines:** The Superpower tokenizer builder that converts source text into `TokenList<PreceptToken>`.
+
+**What it consumes:**
+- `PreceptTokenMeta.BuildKeywordDictionary()` — **attribute-driven derivation**, zero drift for keywords
+- Hardcoded operator/punctuation patterns (multi-char `==`, `!=`, `>=`, `<=`, `->` before single-char `>`, `<`, `=`, etc.)
+- Hardcoded string literal regex and number literal regex
+
+**How it consumes:** Reflection-derived keyword dictionary at startup; hardcoded `Span.EqualTo()` / `Character.EqualTo()` for operators/punctuation.
+
+**Alignment risk:** Operator/punctuation tokens are hardcoded — adding a new operator token to `PreceptToken` without adding a `builder.Match()` line creates a token that exists in the enum but is never produced. Keywords are zero-drift by construction.
+
+---
+
+#### 1.10 PreceptParser
+
+**File:** `src/Precept/Dsl/PreceptParser.cs` (large — combinators + assembly)
+
+**What it defines:** Grammar rules, AST production, `ConstructCatalog` registration.
+
+**What it consumes:**
+- `PreceptToken` enum members directly (combinator patterns like `Token.EqualTo(PreceptToken.Field)`)
+- `DiagnosticCatalog` constraints for error messages (`C1`–`C25`, `C54`, `C70`, `C80`–`C82`)
+- `ConstructCatalog.Register()` for construct documentation
+
+**How it consumes:** Direct reference to `PreceptToken` members and `DiagnosticCatalog` static fields.
+
+**Alignment risk:** Adding a new token kind without parser support means the token is recognized but never consumed. Adding a new grammar form without `ConstructCatalog.Register()` means the construct exists but is undocumented.
+
+---
+
+#### 1.11 PreceptTypeChecker (+ partials)
+
+**Files:**
+- `src/Precept/Dsl/PreceptTypeChecker.cs` — main: scope building, expression type inference dispatch
+- `src/Precept/Dsl/PreceptTypeChecker.Helpers.cs` — copy helpers, utility methods
+- `src/Precept/Dsl/PreceptTypeChecker.FieldConstraints.cs` — field constraint validation
+- `src/Precept/Dsl/PreceptTypeChecker.Narrowing.cs` — null narrowing, proof narrowing
+- `src/Precept/Dsl/PreceptTypeChecker.ProofChecks.cs` — proof engine: interval analysis, contradiction/tautology detection
+- `src/Precept/Dsl/PreceptTypeChecker.TypeInference.cs` — (likely in main, expression type inference)
+
+**What it defines:**
+- `StaticValueKind` enum (see 1.3)
+- `PreceptValidationDiagnostic` records
+- `PreceptTypeContext` / `PreceptTypeScopeInfo` / `PreceptTypeExpressionInfo`
+- `GlobalProofContext` for proof engine state
+
+**What it consumes:**
+- `FunctionRegistry` for function overload resolution and argument constraint checking
+- `DiagnosticCatalog` constraints (C38–C98) for type error messages
+- `PreceptExpression` subtypes in switch dispatch
+- `StaticValueKind` flags throughout
+- `FunctionArgConstraint` enum for proof obligations
+
+**How it consumes:** Direct reference to all. Switch over `PreceptExpression` subtypes, switch over `StaticValueKind` combinations, direct `FunctionRegistry.TryGetFunction()` calls.
+
+**Alignment risk:** New expression subtypes require new switch arms. New `StaticValueKind` flags require new inference paths. New functions in `FunctionRegistry` are automatically picked up for type checking but may need specific argument-constraint handling. New diagnostic codes need `// SYNC:CONSTRAINT:Cnn` comments.
+
+---
+
+#### 1.12 PreceptExpressionEvaluator
+
+**File:** `src/Precept/Dsl/PreceptExpressionEvaluator.cs`
+
+**What it defines:**
+- `EvaluationResult` record (Success, Value, Error)
+- Runtime expression evaluation logic
+
+**What it consumes:**
+- `PreceptExpression` subtypes in switch dispatch
+- Hardcoded function names in `EvaluateFunction` switch
+- Hardcoded operator dispatch in `EvaluateBinary` / `EvaluateUnary`
+- Hardcoded member accessor names (`count`, `min`, `max`, `peek`, `length`)
+- `CollectionValue` for collection operations
+- `PreceptCollectionKind` for collection-kind-specific accessor validation
+
+**How it consumes:** Direct pattern matching (`is long`, `is decimal`, `is string`); string-based function name switch; hardcoded operator dispatch.
+
+**Alignment risk:** **This is the highest-drift component.** Every language addition must be mirrored here independently. There is no structural link between the evaluator's function switch and `FunctionRegistry`, between the evaluator's operator dispatch and the type checker's `TryInferBinaryKind`, or between the evaluator's accessor names and any registry. The planned DD24 (registry-driven functions) and DD25 (operator registry) address this.
+
+---
+
+#### 1.13 PreceptRuntime (Engine + Compiler)
+
+**File:** `src/Precept/Dsl/PreceptRuntime.cs`
+
+**What it defines:**
+- `PreceptEngine` — runtime event processing, fire pipeline, validation, Update API
+- `PreceptCompiler` — `Validate()`, `Compile()`, `CompileFromText()` pipeline
+- `PreceptInstance` — runtime state holder
+- Fire pipeline stages (event ensures → row selection → exit actions → row mutations → entry actions → derived recomputation → validation)
+
+**What it consumes:**
+- `DiagnosticCatalog` constraints (C26–C37) for compile/runtime errors
+- `PreceptExpressionRuntimeEvaluator.Evaluate()` for guard/rule/ensure evaluation
+- `PreceptTypeChecker.Check()` for compile-time validation
+- `PreceptAnalysis.Analyze()` for reachability/dead-state analysis
+- `PreceptModel` types throughout
+
+**How it consumes:** Direct calls to evaluator, type checker, analysis. Direct reference to `DiagnosticCatalog` constraint fields.
+
+**Alignment risk:** Fire pipeline stage changes require MCP LanguageTool `FirePipeline` array update. New violation categories require MCP ViolationDto/mapper updates.
+
+---
+
+### Tooling Consumers
+
+#### 1.14 Language Server — PreceptAnalyzer (Completions)
+
+**File:** `tools/Precept.LanguageServer/PreceptAnalyzer.cs`
+
+**What it consumes:**
+- `PreceptParser.ParseWithDiagnostics()` for diagnostics
+- `PreceptCompiler.Validate()` for semantic diagnostics
+- `DiagnosticCatalog.ToDiagnosticCode()` for diagnostic codes
+- Hardcoded keyword completion items (must match `PreceptToken` vocabulary)
+- Hardcoded regex patterns for context detection (field declarations, collection fields, event args, transition rows)
+- `PreceptDocumentIntellisense.Analyze()` for document-level analysis
+
+**How it consumes:** Mix of direct API calls and hardcoded string/regex patterns.
+
+**Alignment risk:** Keyword completions are **hardcoded lists** — adding a new keyword to `PreceptToken` does NOT automatically add it to completions. Context-detection regexes must be updated when grammar forms change. Type keyword lists (`string|number|boolean|integer|decimal|choice`) are hardcoded in regexes.
+
+---
+
+#### 1.15 Language Server — PreceptDocumentIntellisense (Hover + Completions Support)
+
+**File:** `tools/Precept.LanguageServer/PreceptDocumentIntellisense.cs`
+
+**What it consumes:**
+- `PreceptParser.ParseWithDiagnostics()` for model extraction
+- `PreceptTypeChecker.Check()` for proof context
+- Hardcoded regex patterns for fallback document analysis (when parser fails)
+- Hardcoded `FunctionHoverContent` dictionary — **18 function entries maintained independently of `FunctionRegistry`**
+- Type names hardcoded in regexes (`string|number|boolean|integer|decimal|choice`)
+- Collection kinds hardcoded in regexes (`set|queue|stack`)
+
+**How it consumes:** Direct API calls for model/type data; hardcoded strings and regexes for fallback paths and hover content.
+
+**Alignment risk:** `FunctionHoverContent` is a **manually maintained parallel copy** of function documentation. Adding a function to `FunctionRegistry` without updating this dictionary means no hover for the new function. Type name and collection kind regexes are hardcoded copies.
+
+---
+
+#### 1.16 Language Server — PreceptSemanticTokensHandler
+
+**File:** `tools/Precept.LanguageServer/PreceptSemanticTokensHandler.cs`
+
+**What it consumes:**
+- `PreceptTokenMeta.GetCategory()` via `BuildSemanticTypeMap()` — **attribute-driven derivation**, zero drift for token → semantic type mapping
+- `PreceptTokenizerBuilder.Instance` for token stream
+- Hardcoded context token sets (`StateContextTokens`, `EventContextTokens`, `FieldContextTokens`) — must match `PreceptToken` members that introduce state/event/field names
+- `PreceptParser.ParseWithDiagnostics()` for constraint-set extraction
+
+**How it consumes:** Reflection-driven `SemanticTypeMap` built at startup from `[TokenCategory]` attributes; hardcoded `HashSet<PreceptToken>` for identifier classification context.
+
+**Alignment risk:** `SemanticTypeMap` is zero-drift by construction. Context token sets (`StateContextTokens` etc.) are hardcoded — adding a new token that introduces a state/event/field name requires manual update.
+
+---
+
+#### 1.17 Language Server — PreceptHoverHandler
+
+**File:** `tools/Precept.LanguageServer/PreceptHoverHandler.cs`
+
+**What it consumes:** `PreceptDocumentIntellisense.Analyze()` and `PreceptDocumentIntellisense.CreateHover()`.
+
+**How it consumes:** Thin delegation — all intelligence is in `PreceptDocumentIntellisense`.
+
+**Alignment risk:** Same as 1.15 — inherited from `PreceptDocumentIntellisense`.
+
+---
+
+#### 1.18 TextMate Grammar
+
+**File:** `tools/Precept.VsCode/syntaxes/precept.tmLanguage.json`
+
+**What it consumes (via hardcoded regex patterns):**
+- Declaration keywords: `precept|state|event|field|edit|from|on|in|to|as|nullable|default|because|initial|with|any|all|of|into`
+- Control keywords: `when|if|then|else`
+- Grammar keywords: `rule|ensure`
+- Action keywords: `set|add|remove|enqueue|dequeue|push|pop|clear`
+- Outcome keywords: `transition|reject` + `no transition` compound pattern
+- Type keywords: `string|number|boolean|integer|decimal|choice|set|queue|stack`
+- Constraint keywords: `nonnegative|positive|notempty|min|max|minlength|maxlength|mincount|maxcount|maxplaces|ordered`
+- Operators: `and|or|not|contains`, `==|!=|>=|<=`, `[+\-*/%]`, `>|<`, `=`
+- Function names: `abs|floor|ceil|round|truncate|min|max|pow|sqrt|clamp|toLower|toUpper|startsWith|endsWith|trim|left|right|mid`
+- Collection member accessors: `count|min|max|peek`
+- String member accessors: `length`
+- Literals: `true|false|null`
+
+**How it consumes:** Entirely hardcoded regex alternations in JSON. No programmatic derivation. No build-time validation.
+
+**Alignment risk:** **Every** keyword, operator, function, type, constraint, and accessor must be manually duplicated into regex patterns. This is the highest-maintenance consumer and the most likely to drift. No enforcement mechanism exists today except the copilot-instructions sync checklist and manual review.
+
+---
+
+#### 1.19 MCP LanguageTool
+
+**File:** `tools/Precept.Mcp/Tools/LanguageTool.cs`
+
+**What it consumes:**
+- `PreceptTokenMeta` (all three attribute readers) — **attribute-driven derivation** for vocabulary
+- `ConstructCatalog.Constructs` — **catalog-driven** for constructs
+- `DiagnosticCatalog.Constraints` — **catalog-driven** for constraints
+- `FunctionRegistry.AllFunctions` — **registry-driven** for function catalog
+- Hardcoded `GetOperatorInfo()` switch — operator precedence/arity (must match evaluator dispatch)
+- Hardcoded `ExpressionScopes` array — expression scope descriptions
+- Hardcoded `FirePipeline` array — pipeline stage descriptions (must match runtime behavior)
+- Hardcoded `OutcomeKinds` array — outcome kind descriptions
+- Hardcoded `GetAssessmentModel()`, `GetRemediation()`, `GetProofDependency()` — proof enrichment for specific constraint IDs
+
+**How it consumes:** Mix of attribute/catalog reflection (automatic) and hardcoded data (manual).
+
+**Alignment risk:** Vocabulary, constructs, constraints, and functions are zero-drift by construction. `FirePipeline` stages must be updated when the runtime fire pipeline changes. `ExpressionScopes` must be updated when new expression contexts are added. `OutcomeKinds` must be updated when new outcome types are added. `GetOperatorInfo()` must match the evaluator's precedence table. Proof enrichment helpers must be updated when new proof-dependent constraints are added.
+
+---
+
+#### 1.20 MCP CompileTool
+
+**File:** `tools/Precept.Mcp/Tools/CompileTool.cs`
+
+**What it consumes:**
+- `PreceptCompiler.CompileFromText()` — direct API call
+- `PreceptModel` types → DTO projection (fields, states, events, transitions, rules, ensures, edit blocks)
+- `FieldConstraint` subtypes in `FormatConstraint()` switch
+- `PreceptClauseOutcome` subtypes in `MapBranch()` switch
+- `PreceptCollectionMutationVerb` in verb formatting
+
+**How it consumes:** Direct API calls with DTO projection.
+
+**Alignment risk:** New model properties require new DTO properties. New `FieldConstraint` subtypes require new `FormatConstraint()` arms. New outcome types require new `MapBranch()` arms.
+
+---
+
+#### 1.21 MCP Fire/Inspect/Update Tools
+
+**Files:** `tools/Precept.Mcp/Tools/FireTool.cs`, `InspectTool.cs`, `UpdateTool.cs`
+
+**What they consume:**
+- `PreceptCompiler.CompileFromText()` for compilation
+- `PreceptEngine` API (`Fire`, `Inspect`, `Update`, `CreateInstance`)
+- `JsonConvert.ToNativeDict()` for JSON → native type coercion
+- `ViolationDtoMapper.Map()` for violation serialization
+
+**How they consume:** Thin wrappers over core APIs.
+
+**Alignment risk:** New API surface on `PreceptEngine` may need MCP exposure. New violation types need `ViolationDtoMapper` updates. `JsonConvert` type coercion must handle all `PreceptScalarType` values.
+
+---
+
+#### 1.22 MCP Shared DTOs
+
+**Files:** `tools/Precept.Mcp/Tools/ViolationDto.cs`, `JsonConvert.cs`
+
+**What they define:**
+- `ViolationDto` record, `ViolationDtoMapper.Map()` — mirrors `ConstraintViolation` hierarchy
+- `JsonConvert.ToNativeDict()` — JSON element → CLR type coercion (handles long/decimal/double/string/bool)
+
+**Alignment risk:** `ViolationDtoMapper` switches on `ConstraintTarget` and `ConstraintSource` subtypes — new subtypes require new arms. `JsonConvert` must handle every `PreceptScalarType` lane.
+
+---
+
+## Part 2: Alignment Edge Map
+
+| # | Source | Consumer | What Must Agree | Current Enforcement | Planned Enforcement | Risk if Drifted |
+|---|--------|----------|----------------|--------------------|--------------------|----------------|
+| E1 | `PreceptToken` `[TokenSymbol]` | Tokenizer keyword dict | Keyword text → token kind mapping | **Attribute-driven derivation** (zero drift) | — | N/A — eliminated by construction |
+| E2 | `PreceptToken` `[TokenCategory]` | Semantic tokens `SemanticTypeMap` | Token → semantic type mapping | **Attribute-driven derivation** (zero drift) | — | N/A — eliminated by construction |
+| E3 | `PreceptToken` `[TokenCategory]` | MCP LanguageTool vocabulary grouping | Keywords grouped by category | **Attribute-driven derivation** (zero drift) | — | N/A — eliminated by construction |
+| E4 | `PreceptToken` `[TokenDescription]` | MCP LanguageTool vocabulary descriptions | Description text per keyword | **Attribute-driven derivation** (zero drift) | — | N/A — eliminated by construction |
+| E5 | `PreceptToken` members | Token attribute completeness | Every member has `[TokenCategory]` + `[TokenDescription]` | Reflection test `AllTokens_HaveCategoryAndDescription` | Roslyn PREC003 (replaces test) | Missing attributes → broken derivation chain |
+| E6 | `PreceptToken` keyword members | `[TokenSymbol]` presence | All keyword/operator tokens have `[TokenSymbol]` | Reflection test `KeywordAndOperatorTokens_HaveSymbol` | Roslyn PREC004 (replaces test) | Missing symbol → keyword not recognized by tokenizer |
+| E7 | `PreceptToken` operators/punct | Tokenizer `builder.Match()` | Operator/punct tokens have tokenizer patterns | **None** — manual convention | — | Token exists in enum but never produced |
+| E8 | `PreceptToken` vocabulary | TextMate grammar keyword alternations | All keywords appear in grammar regex patterns | **None** — copilot-instructions checklist | — | Missing keyword → no syntax highlighting |
+| E9 | `PreceptToken` types | TextMate grammar `typeKeywords` | All type keywords in grammar | **None** — copilot-instructions checklist | — | New type → no highlighting |
+| E10 | `PreceptToken` constraints | TextMate grammar `constraintKeywords` | All constraint keywords in grammar | **None** — copilot-instructions checklist | — | New constraint → no highlighting |
+| E11 | `PreceptToken` operators | TextMate grammar `operators` | All operators in grammar | **None** — copilot-instructions checklist | — | New operator → no highlighting |
+| E12 | `PreceptToken` vocabulary | LS completions keyword lists | All keywords offered as completions | **None** — manual convention | — | Missing keyword → no completion offered |
+| E13 | `FunctionRegistry` function names | TextMate grammar `functionCall` pattern | All function names in grammar alternation | **None** — copilot-instructions checklist | Planned drift test `FunctionRegistry_GrammarSync` | New function → no syntax highlighting |
+| E14 | `FunctionRegistry` function names | LS completions function list | All functions offered in expression context | **None** — manual convention | — | Missing function → no completion |
+| E15 | `FunctionRegistry` function docs | LS hover `FunctionHoverContent` | Hover text matches registry descriptions | **None** — manual maintenance | — | Missing/stale hover for functions |
+| E16 | `FunctionRegistry` signatures | Evaluator `EvaluateFunction` switch | Every registered function has eval implementation | **None** — manual convention | DD24: registry-driven evaluation | Type-checks but fails at runtime |
+| E17 | `FunctionRegistry` signatures | Type checker overload resolution | Type checker reads registry directly | **Structural** (direct reference) | — | N/A — same data structure |
+| E18 | Type checker operator rules | Evaluator operator dispatch | Legal operator × type combinations agree | **None** — independent implementations | DD25: operator registry | Type checker allows what evaluator rejects (or vice versa) |
+| E19 | `DiagnosticCatalog` constraints | Parser `// SYNC:CONSTRAINT:Cnn` | Every parse constraint has SYNC comment | Reflection test `SyncComments_MatchDiagnosticCatalog` | Roslyn PREC010 (replaces test) | Orphaned/missing SYNC comments |
+| E20 | `DiagnosticCatalog` constraints | Type checker `// SYNC:CONSTRAINT:Cnn` | Every compile constraint has SYNC comment | Reflection test `SyncComments_MatchDiagnosticCatalog` | Roslyn PREC010 (replaces test) | Orphaned/missing SYNC comments |
+| E21 | `DiagnosticCatalog` constraints | Runtime `// SYNC:CONSTRAINT:Cnn` | Every runtime constraint has SYNC comment | Reflection test `SyncComments_MatchDiagnosticCatalog` | Roslyn PREC010 (replaces test) | Orphaned/missing SYNC comments |
+| E22 | `DiagnosticCatalog` constraints | MCP LanguageTool constraints | Constraints serialized for AI consumers | **Catalog-driven** (zero drift) | — | N/A — eliminated by construction |
+| E23 | `DiagnosticCatalog` constraint IDs | LS diagnostic codes | `C{nn}` → `PRECEPT{NNN}` mapping | **Structural** (`ToDiagnosticCode()` call) | — | N/A — single function |
+| E24 | `ConstructCatalog` constructs | MCP LanguageTool constructs | Constructs serialized for AI consumers | **Catalog-driven** (zero drift) | — | N/A — eliminated by construction |
+| E25 | `ConstructCatalog` examples | Parser correctness | Every example parses successfully | Drift test `AllConstructExamples_ParseSuccessfully` | — | Stale example → misleading docs |
+| E26 | `ConstructCatalog` constructs | Sample files | At least one sample uses each construct | Drift test `SampleFiles_CoverAllConstructs` | — | Uncovered construct → no real-world validation |
+| E27 | `PreceptExpression` subtypes | Type checker switch | All 7 subtypes handled | **None** — `default` arm fallthrough | Roslyn PREC002 | New subtype → silent type-check skip |
+| E28 | `PreceptExpression` subtypes | Evaluator switch | All 7 subtypes handled | **None** — `default` arm returns Fail("unsupported") | Roslyn PREC002 | New subtype → runtime "unsupported" error |
+| E29 | `StaticValueKind` flags | Type checker inference | All flag values handled in switch sites | **None** — convention | Roslyn PREC008 | New type kind → not type-checked |
+| E30 | `StaticValueKind` flags | Evaluator dispatch | All type families handled in operator/function dispatch | **None** — convention | Roslyn PREC008 + DD24/DD25 | New type kind → runtime failure |
+| E31 | `FunctionArgConstraint` members | Type checker constraint handling | All constraint kinds enforced | **None** — convention | Roslyn PREC007 | New constraint kind → not enforced |
+| E32 | `PreceptModel` types | MCP CompileTool DTOs | DTO properties mirror model properties | **None** — manual maintenance | — | New model property → missing from MCP output |
+| E33 | `FieldConstraint` subtypes | MCP CompileTool `FormatConstraint()` | All constraint types serialized | **None** — switch with potential gap | — | New constraint type → not shown in MCP |
+| E34 | `PreceptClauseOutcome` subtypes | MCP CompileTool `MapBranch()` | All outcome types serialized | **None** — switch with potential gap | — | New outcome type → not shown in MCP |
+| E35 | `ConstraintViolation` types | MCP `ViolationDtoMapper` | All violation types mapped | **None** — switch with potential gap | — | New violation type → not mapped in MCP |
+| E36 | `PreceptScalarType` values | MCP `JsonConvert.ToNativeDict()` | All scalar types coerced correctly from JSON | **None** — manual maintenance | — | New scalar type → JSON coercion failure |
+| E37 | Runtime fire pipeline stages | MCP LanguageTool `FirePipeline` | Stage descriptions match runtime behavior | **None** — hardcoded array | — | Pipeline change → stale MCP docs |
+| E38 | Runtime outcome kinds | MCP LanguageTool `OutcomeKinds` | Outcome descriptions match runtime | **None** — hardcoded array | — | New outcome → missing from MCP |
+| E39 | Evaluator `Fail()` sites | `EvalFailCode` classification | Every Fail call has enum identity | **None** — bare string calls today | DD23 + Roslyn PREC001 | Unclassified failure → invisible to conformance tests |
+| E40 | `EvalFailCode` `[StaticallyPreventable]` | `DiagnosticCatalog` entries | Every statically preventable failure has a compiler rule | **None** — planned | DD23 + Roslyn PREC009 | Evaluator catches what compiler should prevent |
+| E41 | Model record types | `SourceLine` property | All declaration records carry source position | **None** — convention | Roslyn PREC011 | Missing source line → no diagnostic squiggle position |
+| E42 | `PreceptToken` `[TokenSymbol]` | No duplicate symbols | Each symbol text maps to exactly one token | **None** — manual review | Roslyn PREC005 | Ambiguous tokenization |
+| E43 | Collection member accessors | TextMate grammar `collectionMemberAccess` | `count|min|max|peek` in grammar | **None** — manual maintenance | — | New accessor → no highlighting |
+| E44 | String member accessors | TextMate grammar `stringMemberAccess` | `length` in grammar | **None** — manual maintenance | — | New accessor → no highlighting |
+| E45 | Semantic tokens context sets | `PreceptToken` members | `StateContextTokens`, `EventContextTokens`, `FieldContextTokens` match token semantics | **None** — hardcoded `HashSet<PreceptToken>` | — | New context-setting token → wrong identifier coloring |
+| E46 | LS completions type names | `PreceptScalarType` + collection kinds | Type names in regex patterns match type system | **None** — hardcoded regex patterns | — | New type → not offered in completions |
+| E47 | Proof enrichment helpers | `DiagnosticCatalog` constraint IDs | `GetAssessmentModel()`, `GetRemediation()`, `GetProofDependency()` cover proof constraints | **None** — hardcoded switch | — | New proof constraint → missing enrichment |
+| E48 | Expression scope descriptions | Type checker scope rules | `ExpressionScopes` array matches actual scoping | **None** — hardcoded array | — | Scope change → stale MCP docs |
+| E49 | `DiagnosticCatalog` constraints | Constraint trigger tests | Every constraint can be triggered | Reflection test `EveryConstraint_CanBeTriggered` | — | Untriggerable constraint → dead code or wrong ID |
+| E50 | Sample `.precept` files | Parser + compiler correctness | All samples parse and compile | Drift test `SampleFile_ParsesWithoutErrors` / `CompilesWithoutErrors` | — | Broken sample → misleading reference |
+
+---
+
+## Part 3: Enforcement Mechanism Inventory
+
+### 3.1 Attribute-Driven Derivation
+
+**Type:** Structural — eliminated by construction
+**Feedback timing:** Runtime initialization (startup)
+**What it covers:** E1 (tokenizer keywords), E2 (semantic token types), E3 (MCP vocabulary grouping), E4 (MCP vocabulary descriptions)
+**What it misses:** Cannot enforce that the attribute values are correct — only that they exist and are consumed.
+**Status:** Existing, operational
+
+### 3.2 Catalog-Driven Serialization
+
+**Type:** Structural — eliminated by construction
+**Feedback timing:** Runtime API call
+**What it covers:** E22 (MCP constraints), E24 (MCP constructs), E17 (type checker reads FunctionRegistry)
+**What it misses:** Cannot enforce that the catalog entries are complete or that the serialized format matches consumer expectations.
+**Status:** Existing, operational
+
+### 3.3 Reflection Drift Tests (CatalogDriftTests)
+
+**Type:** Reflection test
+**Feedback timing:** Test-time (CI)
+**What it covers:**
+- E5 (`AllTokens_HaveCategoryAndDescription`)
+- E6 (`KeywordAndOperatorTokens_HaveSymbol`)
+- E19/E20/E21 (`SyncComments_MatchDiagnosticCatalog`)
+- E25 (`AllConstructExamples_ParseSuccessfully`)
+- E26 (`SampleFiles_CoverAllConstructs`)
+- E49 (`EveryConstraint_CanBeTriggered`)
+- Dual-role token test (`CollectionTypeTokens_HaveTypeCategoryAmongCategories`)
+- Diagnostic code format test (`DiagnosticCodes_FollowPreceptNNNFormat`)
+
+**What it misses:** Test-time only — no IDE feedback. Cannot detect gaps in consumers (TextMate grammar, completions, hover). Does not verify that enforcement code actually references the correct constraint.
+**Status:** Existing, 4 tests planned for retirement (replaced by Roslyn PREC003, PREC004, PREC010, PREC011)
+
+### 3.4 Diagnostic Sample Drift Tests (DiagnosticSampleDriftTests)
+
+**Type:** Integration test
+**Feedback timing:** Test-time (CI)
+**What it covers:** E50 (sample correctness), plus strict `# EXPECT:` contract validation for diagnostic samples
+**What it misses:** Only covers samples that exist — cannot detect missing samples for new constructs.
+**Status:** Existing, operational
+
+### 3.5 Copilot Instructions Sync Checklists
+
+**Type:** Convention / review-time
+**Feedback timing:** Review-time (Copilot reads `.github/copilot-instructions.md`)
+**What it covers:** E8–E11 (TextMate grammar), E12 (completions), E13 (function grammar), E14 (function completions), E15 (function hover). The "Non-Negotiable" sections list explicit checklists.
+**What it misses:** Copilot may not follow checklists consistently. No CI enforcement. No IDE feedback. Human reviewer must verify compliance.
+**Status:** Existing, operational but unreliable
+
+### 3.6 Language Surface Sync Instructions
+
+**Type:** Convention / review-time
+**Feedback timing:** Review-time (Copilot reads `.github/instructions/language-surface-sync.instructions.md`)
+**What it covers:** Three-category impact analysis (Runtime, Tooling, MCP) for every language surface change.
+**What it misses:** Same as 3.5 — convention-only, no CI enforcement.
+**Status:** Existing, operational but unreliable
+
+### 3.7 SYNC Comments
+
+**Type:** Source-code marker
+**Feedback timing:** Review-time (visible in diffs) + test-time (validated by `SyncComments_MatchDiagnosticCatalog`)
+**What it covers:** E19/E20/E21 — bidirectional link between enforcement code and DiagnosticCatalog.
+**What it misses:** Does not verify that the enforcement code at the SYNC comment actually implements the constraint correctly. Does not cover non-constraint alignment edges.
+**Status:** Existing, planned for Roslyn PREC010 upgrade (edit-time enforcement)
+
+### 3.8 Roslyn Analyzer (Planned — DD26, Issue #115)
+
+**Type:** Roslyn analyzer — build-time / edit-time
+**Feedback timing:** Edit-time (IDE squiggles) + build-time (`dotnet build`)
+**What it covers:**
+- E5 → PREC003 (token category + description)
+- E6 → PREC004 (token symbol)
+- E19/E20/E21 → PREC010 (SYNC comment validation)
+- E27/E28 → PREC002 (exhaustive PreceptExpression switch)
+- E29/E30 → PREC008 (exhaustive StaticValueKind switch)
+- E31 → PREC007 (exhaustive FunctionArgConstraint switch)
+- E39 → PREC001 (EvalFailCode on Fail calls)
+- E40 → PREC009 (StaticallyPreventable ↔ DiagnosticCatalog)
+- E41 → PREC011 (SourceLine on model records)
+- E42 → PREC005 (no duplicate TokenSymbol)
+- PREC006 (exhaustive EvalFailCode switch)
+
+**What it misses:** Cannot reach cross-boundary edges (C# ↔ JSON grammar). Cannot validate TextMate grammar regex patterns. Cannot validate MCP DTO completeness. Cannot validate hardcoded string arrays (FirePipeline, ExpressionScopes, OutcomeKinds).
+**Status:** Planned for issue #115
+
+### 3.9 Registry-Driven Function Evaluation (Planned — DD24, Issue #115)
+
+**Type:** Structural — eliminated by construction
+**Feedback timing:** Runtime initialization
+**What it covers:** E16 (FunctionRegistry ↔ evaluator function dispatch)
+**What it misses:** Cannot verify evaluation correctness — only that a delegate exists.
+**Status:** Planned for issue #115
+
+### 3.10 Operator Registry (Planned — DD25, Issue #115)
+
+**Type:** Structural — eliminated by construction
+**Feedback timing:** Runtime initialization
+**What it covers:** E18 (type checker operator rules ↔ evaluator operator dispatch)
+**What it misses:** Cannot verify evaluation correctness — only that an entry exists.
+**Status:** Planned for issue #115
+
+### 3.11 EvalFailCode Enum (Planned — DD23, Issue #115)
+
+**Type:** Enum-based classification
+**Feedback timing:** Build-time (via Roslyn PREC001) + test-time (sentinel tests)
+**What it covers:** E39 (Fail site identity), E40 (StaticallyPreventable ↔ DiagnosticCatalog)
+**What it misses:** Cannot verify that the EvalFailCode classification is semantically correct — only structurally complete.
+**Status:** Planned for issue #115
+
+### 3.12 FunctionRegistry ↔ Grammar Sync Test (Planned)
+
+**Type:** Reflection test (cross-boundary)
+**Feedback timing:** Test-time (CI)
+**What it covers:** E13 (function names in TextMate grammar)
+**What it misses:** Cannot run at edit-time. Roslyn cannot reach JSON files.
+**Status:** Planned for issue #115
+
+---
+
+## Part 4: Gap Analysis
+
+### Undefended Edges (No Enforcement)
+
+| Edge | Source → Consumer | Current State | Severity |
+|------|------------------|---------------|----------|
+| **E7** | Token operators/punct → Tokenizer patterns | Manual convention | **High** — new operator token silently not produced |
+| **E8** | Token vocabulary → TextMate grammar keywords | Copilot checklist only | **High** — no syntax highlighting for new keywords |
+| **E9** | Token types → TextMate grammar typeKeywords | Copilot checklist only | **High** — no highlighting for new types |
+| **E10** | Token constraints → TextMate grammar constraintKeywords | Copilot checklist only | **Medium** — no highlighting for new constraints |
+| **E11** | Token operators → TextMate grammar operators | Copilot checklist only | **High** — no highlighting for new operators |
+| **E12** | Token vocabulary → LS completions | Manual convention | **Medium** — no completion for new keywords |
+| **E14** | FunctionRegistry → LS completions | Manual convention | **Medium** — no completion for new functions |
+| **E15** | FunctionRegistry → LS hover content | Manual maintenance | **Medium** — stale/missing hover for functions |
+| **E32** | PreceptModel → MCP CompileTool DTOs | Manual maintenance | **Low** — new property missing from MCP |
+| **E33** | FieldConstraint subtypes → MCP `FormatConstraint()` | Switch with gap potential | **Low** — new constraint type not serialized |
+| **E34** | PreceptClauseOutcome → MCP `MapBranch()` | Switch with gap potential | **Low** — new outcome type not serialized |
+| **E35** | ConstraintViolation → MCP ViolationDtoMapper | Switch with gap potential | **Low** — new violation type not mapped |
+| **E36** | PreceptScalarType → MCP JsonConvert | Manual maintenance | **Low** — new type → coercion failure |
+| **E37** | Runtime fire pipeline → MCP FirePipeline | Hardcoded array | **Low** — stale pipeline docs |
+| **E38** | Runtime outcomes → MCP OutcomeKinds | Hardcoded array | **Low** — missing outcome description |
+| **E43** | Collection accessors → TextMate grammar | Manual maintenance | **Medium** — no highlighting for new accessors |
+| **E44** | String accessors → TextMate grammar | Manual maintenance | **Low** — no highlighting for new accessors |
+| **E45** | Semantic token context sets → PreceptToken | Hardcoded HashSet | **Medium** — wrong identifier coloring |
+| **E46** | LS completions type names → PreceptScalarType | Hardcoded regex | **Medium** — new type not in completions |
+| **E47** | Proof enrichment → DiagnosticCatalog | Hardcoded switch | **Low** — missing enrichment |
+| **E48** | Expression scopes → Type checker | Hardcoded array | **Low** — stale scope descriptions |
+
+### Edges With Only Convention/Review Enforcement
+
+All TextMate grammar edges (E8–E11, E13, E43, E44) rely solely on copilot-instructions checklists. All LS completions/hover edges (E12, E14, E15, E45, E46) rely solely on manual convention. All MCP hardcoded-array edges (E37, E38, E47, E48) rely solely on manual convention.
+
+### Edges Addressed by Planned Mechanisms (#115)
+
+| Edge | Mechanism | Status |
+|------|-----------|--------|
+| E16 | DD24: Registry-driven function evaluation | Planned |
+| E18 | DD25: Operator registry | Planned |
+| E27, E28 | Roslyn PREC002: Exhaustive expression switch | Planned |
+| E29, E30 | Roslyn PREC008: Exhaustive StaticValueKind switch | Planned |
+| E31 | Roslyn PREC007: Exhaustive FunctionArgConstraint switch | Planned |
+| E39 | DD23 + Roslyn PREC001: EvalFailCode | Planned |
+| E40 | DD23 + Roslyn PREC009: StaticallyPreventable ↔ DiagnosticCatalog | Planned |
+| E13 | FunctionRegistry ↔ Grammar sync test | Planned |
+
+---
+
+## Part 5: Design Doc Scope Recommendation
+
+### Recommended Enforcement Hierarchy
+
+1. **Eliminated by construction** (attribute/catalog/registry-driven derivation) — the gold standard. No enforcement needed because the alignment is structural.
+2. **Roslyn analyzer** — build-time + edit-time enforcement. Red squiggles in IDE, build failures in CI.
+3. **Reflection drift test** — test-time enforcement in CI. For cross-boundary edges Roslyn cannot reach (C# ↔ JSON, C# ↔ markdown).
+4. **SYNC comments** — review-time markers validated by Roslyn/tests. Not standalone enforcement.
+5. **Convention / copilot-instructions** — behavioral guidance. Necessary for TextMate grammar and other non-code artifacts, but not sufficient alone.
+
+### What the New Design Doc Should Cover
+
+#### Edges to Eliminate by Construction (Registry Pattern)
+
+- **E16** — Already designed (DD24): function evaluation via registry delegates.
+- **E18** — Already designed (DD25): operator dispatch via registry.
+- **E15** — Function hover content should derive from `FunctionRegistry.AllFunctions` descriptions instead of maintaining a parallel `FunctionHoverContent` dictionary. The registry already has `Description` fields.
+- **E12, E14** — LS completions keyword/function lists should derive from `PreceptTokenMeta.GetByCategory()` and `FunctionRegistry.FunctionNames` instead of hardcoded lists.
+
+#### Edges to Enforce with Roslyn (Already Designed in Appendix F)
+
+PREC001–PREC011 cover E5, E6, E19–E21, E27–E31, E39–E42. These are already specified.
+
+#### Edges to Enforce with New Drift Tests (Cross-Boundary)
+
+- **E13** (FunctionRegistry ↔ TextMate grammar) — already planned: `FunctionRegistry_GrammarSync` test.
+- **E8–E11** (Token vocabulary ↔ TextMate grammar) — **new**: reflection test that reads `precept.tmLanguage.json`, extracts keyword alternation patterns, and asserts they match `PreceptTokenMeta.GetByCategory()` results. This replaces copilot-instructions-only enforcement with CI enforcement.
+- **E43, E44** (Collection/string accessors ↔ TextMate grammar) — **new**: reflection test that asserts accessor names in grammar match evaluator-supported accessors.
+- **E33, E34, E35** (Model subtypes ↔ MCP switch arms) — consider Roslyn exhaustive-switch enforcement if feasible, otherwise reflection tests.
+- **E45** (Semantic token context sets ↔ PreceptToken members) — **new**: reflection test that asserts context sets are complete relative to token category.
+
+#### Edges to Remain Convention-Only
+
+- **E7** (Tokenizer operator patterns) — Low change frequency. Document the obligation.
+- **E32, E36–E38, E46–E48** (MCP DTOs, hardcoded arrays, regex patterns) — Low change frequency, low risk. Document as convention obligations.
+
+#### Document Structure Recommendation
+
+The new design doc should:
+
+1. **Supersede** `docs/CatalogInfrastructureDesign.md` — incorporate its three-tier catalog content as a section, not as a separate document.
+2. **Incorporate** the Appendix F content from `docs/EvaluatorDesign.md` by reference — the Roslyn analyzer and registry designs live there.
+3. **Add** the full alignment edge map (Part 2 of this inventory) as a living reference.
+4. **Specify** new drift tests for cross-boundary edges (TextMate grammar sync, accessor sync, MCP switch completeness).
+5. **Specify** LS completions/hover derivation from catalogs/registries (eliminating hardcoded lists).
+6. **Define** the enforcement hierarchy and classify every edge by its enforcement tier.
+7. **Track** per-edge status (implemented, planned, convention-only) as a maintenance table.


### PR DESCRIPTION
## Summary

Establishes the structural enforcement infrastructure for keeping all Precept components aligned — Roslyn analyzers, cross-boundary drift tests, and registry-driven derivation.

## Linked Issue

Closes #132

## Why

Precept has 50 alignment edges across 22 components. ~20 of those edges have zero enforcement today — they rely on copilot-instructions checklists or manual convention. This PR introduces systematic, CI-enforced alignment checking so that adding a new keyword, function, operator, or type cannot silently break downstream consumers.

This infrastructure must land before #115 (evaluator redesign), which introduces new types that the Roslyn analyzer will enforce.

## Implementation Plan

Pending design review.